### PR TITLE
Return values from WASM

### DIFF
--- a/third_party/wabt/include/wabt/interp/jit/jit.h
+++ b/third_party/wabt/include/wabt/interp/jit/jit.h
@@ -22,6 +22,11 @@
 namespace wabt {
 namespace interp {
 
+using ValueType = wabt::Type;
+using ValueTypes = std::vector<ValueType>;
+struct Value;
+using Values = std::vector<Value>;
+
 struct ExecutionContext {
   // Describes a function in the stack chain.
   struct CallFrame {
@@ -52,7 +57,10 @@ class JITFunction {
 
  public:
   bool isCompiled() const { return func_entry_ != nullptr; }
-  void call() const;
+  void call(const ValueTypes& param_types,
+            const Values& params,
+            const ValueTypes& result_types,
+            Values& results) const;
 
  private:
   void* func_entry_;

--- a/third_party/wabt/src/interp/interp.cc
+++ b/third_party/wabt/src/interp/interp.cc
@@ -420,7 +420,7 @@ Result DefinedFunc::DoCall(Thread& thread,
                            Trap::Ptr* out_trap) {
   assert(params.size() == type_.params.size());
   if (desc().jit_func.isCompiled()) {
-    desc().jit_func.call();
+    desc().jit_func.call(this->desc().type.params, params, this->desc().type.results, results);
     return Result::Ok;
   }
   thread.PushValues(type_.params, params);

--- a/third_party/wabt/src/interp/jit/jit-allocator.cc
+++ b/third_party/wabt/src/interp/jit/jit-allocator.cc
@@ -65,7 +65,7 @@ void StackAllocator::push(ValueInfo value_info) {
     case LocationInfo::kFourByteSize:
       mask = sizeof(uint32_t) - 1;
       break;
-    case LocationInfo::kSixteenByteSize:
+    case LocationInfo::kEightByteSize:
       mask = sizeof(uint64_t) - 1;
       break;
     default:


### PR DESCRIPTION
Copy the contents of the funcion's `data` memory to the `results` vector

Moved struct Value and its dependencies to value.h to use it in jit.cc, because including interp.h in jit.h would cause a circular import