### PR TITLE
Implement i32 - i64 conversion operations

### DIFF
--- a/third_party/wabt/src/interp/jit/binary-reader-jit.cc
+++ b/third_party/wabt/src/interp/jit/binary-reader-jit.cc
@@ -490,6 +490,13 @@ Result BinaryReaderJIT::OnConvertExpr(Opcode opcode) {
   if (opcode == Opcode::I32Eqz || opcode == Opcode::I64Eqz) {
     compiler_.append(Instruction::Compare, opcode, 1,
                      LocationInfo::kFourByteSize);
+  } else if (opcode == Opcode::I64ExtendI32S ||
+             opcode == Opcode::I64ExtendI32U) {
+    compiler_.append(Instruction::Unary, opcode, 1,
+                     LocationInfo::kEightByteSize);
+  } else if (opcode == Opcode::I32WrapI64) {
+    compiler_.append(Instruction::Unary, opcode, 1,
+                     LocationInfo::kFourByteSize);
   }
   return Result::Ok;
 }

--- a/third_party/wabt/src/interp/jit/jit-backend.cc
+++ b/third_party/wabt/src/interp/jit/jit-backend.cc
@@ -260,6 +260,30 @@ static void emitUnary(sljit_compiler* compiler, Instruction* instr) {
     case Opcode::I64Popcnt:
       // Not supported yet.
       return;
+    case Opcode::I32WrapI64:
+      sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, args[0].arg,
+                     args[0].argw);
+      if (args[1].arg & SLJIT_MEM) {
+        sljit_emit_op1(compiler, SLJIT_MOV32, args[1].arg, args[1].argw,
+                       SLJIT_R0, 0);
+      }
+      return;
+    case Opcode::I64ExtendI32S:
+      sljit_emit_op1(compiler, SLJIT_MOV_S32, SLJIT_R0, 0, args[0].arg,
+                     args[0].argw);
+      if (args[1].arg & SLJIT_MEM) {
+        sljit_emit_op1(compiler, SLJIT_MOV, args[1].arg, args[1].argw, SLJIT_R0,
+                       0);
+      }
+      return;
+    case Opcode::I64ExtendI32U:
+      sljit_emit_op1(compiler, SLJIT_MOV_U32, SLJIT_R0, 0, args[0].arg,
+                     args[0].argw);
+      if (args[1].arg & SLJIT_MEM) {
+        sljit_emit_op1(compiler, SLJIT_MOV, args[1].arg, args[1].argw, SLJIT_R0,
+                       0);
+      }
+      return;
     default:
       WABT_UNREACHABLE;
       break;


### PR DESCRIPTION
This implements:
- I32WrapI64 (i32.wrap_i64)
- I64ExtendI32S (i64.extend_i32_s)
- I64ExtendI32U (i64.extend_i32_u)

I also implemented unary operations, but @kulcsaradam has also did, and on first look he did it better, so that PR (https://github.com/Samsung/walrus/pull/39) should probably go first.