### PR TITLE
More local.get, set, tee can use direct access.

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -35,14 +35,18 @@ class FunctionType;
 
 class ByteCode {
 public:
-    OpcodeKind opcode() const { return m_opcode; }
-    void* opcodeInAddress() const { return m_opcodeInAddress; }
-#if !defined(NDEBUG)
-    OpcodeKind orgOpcode() const
+#if defined(WALRUS_ENABLE_COMPUTED_GOTO)
+    OpcodeKind opcode() const
     {
-        return m_orgOpcode;
+        return static_cast<OpcodeKind>(g_opcodeTable.m_addressToOpcodeTable[m_opcodeInAddress]);
+    }
+#else
+    OpcodeKind opcode() const
+    {
+        return m_opcode;
     }
 #endif
+
 
 #if !defined(NDEBUG)
     virtual ~ByteCode()
@@ -68,9 +72,6 @@ protected:
 #else
         : m_opcode(opcode)
 #endif
-#if !defined(NDEBUG)
-        , m_orgOpcode(opcode)
-#endif
     {
     }
 
@@ -80,9 +81,6 @@ protected:
 #else
         : m_opcode(OpcodeKind::InvalidOpcode)
 #endif
-#if !defined(NDEBUG)
-        , m_orgOpcode(OpcodeKind::InvalidOpcode)
-#endif
     {
     }
 
@@ -90,9 +88,6 @@ protected:
         OpcodeKind m_opcode;
         void* m_opcodeInAddress;
     };
-#if !defined(NDEBUG)
-    OpcodeKind m_orgOpcode;
-#endif
 };
 
 class Const32 : public ByteCode {
@@ -105,6 +100,7 @@ public:
     }
 
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+    void setDstOffset(ByteCodeStackOffset o) { m_dstOffset = o; }
     uint32_t value() const { return m_value; }
 
 #if !defined(NDEBUG)
@@ -136,6 +132,7 @@ public:
     }
 
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+    void setDstOffset(ByteCodeStackOffset o) { m_dstOffset = o; }
     uint64_t value() const { return m_value; }
 
 #if !defined(NDEBUG)
@@ -167,6 +164,7 @@ public:
 
     const ByteCodeStackOffset* srcOffset() const { return m_srcOffset; }
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+    void setDstOffset(ByteCodeStackOffset o) { m_dstOffset = o; }
 
 #if !defined(NDEBUG)
     virtual void dump(size_t pos)

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -198,6 +198,16 @@ R doConvert(ExecutionState& state, T val)
     return convert<R>(val);
 }
 
+#if defined(WALRUS_ENABLE_COMPUTED_GOTO)
+static void initAddressToOpcodeTable()
+{
+#define REGISTER_TABLE(rtype, type1, type2, type3, memSize, prefix, code, name, text, decomp) \
+    g_opcodeTable.m_addressToOpcodeTable[g_opcodeTable.m_addressTable[name##Opcode]] = name##Opcode;
+    FOR_EACH_USED_OPCODE(REGISTER_TABLE)
+#undef REGISTER_TABLE
+}
+#endif
+
 ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
                                             size_t programCounter,
                                             uint8_t* bp,
@@ -941,6 +951,7 @@ NextInstruction:
         FOR_EACH_USED_OPCODE(REGISTER_TABLE)
 #undef REGISTER_TABLE
 #endif
+        initAddressToOpcodeTable();
         return nullptr;
     }
 

--- a/src/interpreter/Opcode.h
+++ b/src/interpreter/Opcode.h
@@ -232,6 +232,7 @@ public:
     OpcodeTable();
 #if defined(WALRUS_ENABLE_COMPUTED_GOTO)
     void* m_addressTable[InvalidOpcode];
+    std::unordered_map<void*, int> m_addressToOpcodeTable;
 #endif
 };
 

--- a/src/runtime/Module.cpp
+++ b/src/runtime/Module.cpp
@@ -330,7 +330,7 @@ void ModuleFunction::dumpByteCode()
     while (idx < m_byteCode.size()) {
         ByteCode* code = reinterpret_cast<ByteCode*>(&m_byteCode[idx]);
         printf("%zu: ", idx);
-        printf("%s ", g_byteCodeInfo[code->orgOpcode()].m_name);
+        printf("%s ", g_byteCodeInfo[code->opcode()].m_name);
         code->dump(idx);
         printf("\n");
         idx += code->byteCodeSize();

--- a/src/runtime/Module.h
+++ b/src/runtime/Module.h
@@ -228,11 +228,6 @@ public:
         m_byteCode.resizeWithUninitializedValues(m_byteCode.size() + s);
     }
 
-    void shrinkByteCode(size_t s)
-    {
-        m_byteCode.resize(m_byteCode.size() - s);
-    }
-
     size_t currentByteCodeSize() const
     {
         return m_byteCode.size();

--- a/test/basic/ref_local_twice_and_modify.wast
+++ b/test/basic/ref_local_twice_and_modify.wast
@@ -36,3 +36,180 @@
 (assert_return (invoke "t1") (i32.const 0))
 (assert_return (invoke "t2" (i32.const 100)) (i32.const 0))
 (assert_return (invoke "t3") (i32.const 0))
+
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (param i32 i32 i32)))
+  (import "spectest" "print_i32" (func $print_i32 (param i32)))
+
+  (global $max i32 (i32.const 3))
+
+  (func $qs (type 1) (param i32 i32 i32)
+    (local i32 i32 i32 i32 i32 i32 i32 i32)
+    local.get 1
+    local.get 2
+    i32.lt_s
+    if  ;; label = @1
+      local.get 0
+      local.get 2
+      i32.const 2
+      i32.shl
+      i32.add
+      local.set 7
+      loop  ;; label = @2
+        i32.const 0
+        local.set 3
+        local.get 2
+        local.get 1
+        i32.sub
+        local.tee 8
+        i32.const 0
+        i32.gt_s
+        if  ;; label = @3
+          local.get 7
+          i32.load
+          local.set 6
+          i32.const 0
+          local.set 4
+          loop  ;; label = @4
+            block  ;; label = @5
+              local.get 6
+              local.get 0
+              local.get 1
+              local.get 3
+              i32.add
+              i32.const 2
+              i32.shl
+              i32.add
+              local.tee 5
+              i32.load
+              local.tee 9
+              i32.gt_s
+              if  ;; label = @6
+                local.get 3
+                i32.const 1
+                i32.add
+                local.set 3
+                br 1 (;@5;)
+              end
+              local.get 5
+              local.get 0
+              local.get 2
+              local.get 4
+              i32.sub
+              i32.const 2
+              i32.shl
+              i32.add
+              local.tee 5
+              i32.const 4
+              i32.sub
+              local.tee 10
+              i32.load
+              i32.store
+              local.get 5
+              local.get 9
+              i32.store
+              local.get 10
+              local.get 6
+              i32.store
+              local.get 4
+              i32.const 1
+              i32.add
+              local.set 4
+            end
+            local.get 3
+            local.get 4
+            i32.add
+            local.get 8
+            i32.lt_s
+            br_if 0 (;@4;)
+          end
+        end
+        local.get 0
+        local.get 1
+        local.get 1
+        local.get 3
+        i32.add
+        local.tee 1
+        i32.const 1
+        i32.sub
+        call $qs
+        local.get 1
+        i32.const 1
+        i32.add
+        local.tee 1
+        local.get 2
+        i32.lt_s
+        br_if 0 (;@2;)
+      end
+    end)
+
+
+
+  (func $print (type 0)
+      (local i32 i32)
+      global.get $max
+      local.set 1
+      (loop
+        local.get 0
+        i32.const 4
+        i32.mul
+        i32.load
+        call $print_i32
+
+        local.get 0
+        i32.const 1
+        i32.add
+        local.tee 0
+        local.get 1
+        i32.ne
+        br_if 0 
+      )
+
+  )
+
+  (func $start (type 0)
+      (local i32 i32)
+      global.get $max
+      local.set 1
+
+      (loop
+        local.get 0
+        i32.const 4
+        i32.mul
+        local.get 1
+        local.get 0
+        i32.sub
+        i32.store
+
+        local.get 0
+        i32.const 1
+        i32.add
+        local.tee 0
+        local.get 1
+        i32.ne
+        br_if 0 
+      )
+;;      call $print
+      i32.const 0
+      i32.const 0
+      global.get $max
+      call $qs
+;;      call $print
+  )
+
+
+  (memory (;0;) 256 256)
+
+  (start $start)
+
+  (func (export "read") (param i32) (result i32)
+    (i32.load (local.get 0))
+  )
+
+)
+
+(assert_return (invoke "read" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "read" (i32.const 4)) (i32.const 1))
+(assert_return (invoke "read" (i32.const 8)) (i32.const 2))
+


### PR DESCRIPTION
* Not every 2 or more reference of local variable needs copy to stack
* Fix computing RefCount bug

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>