### PR TITLE
Implementing instance offsets

### DIFF
--- a/src/api/wasm.cpp
+++ b/src/api/wasm.cpp
@@ -1240,8 +1240,10 @@ uint32_t wasm_instance_func_index(const wasm_instance_t* ins, const wasm_func_t*
     Instance* instance = const_cast<Instance*>(ins->get());
     Function* func = f->get();
 
-    const VectorWithFixedSize<Function*>& funcs = instance->functions();
-    for (size_t i = 0; i < funcs.size(); i++) {
+    const Function* const* funcs = instance->functions();
+    size_t size = instance->module()->numberOfFunctions();
+
+    for (size_t i = 0; i < size; i++) {
         if (funcs[i] == func) {
             return i;
         }

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -50,7 +50,7 @@ OpcodeTable::OpcodeTable()
     b.m_opcodeInAddress = const_cast<void*>(FillByteCodeOpcodeAddress[0]);
 #endif
     size_t pc = reinterpret_cast<size_t>(&b);
-    Interpreter::interpret(dummyState, pc, nullptr, nullptr, VectorWithFixedSize<Memory*>(), VectorWithFixedSize<Table*>(), VectorWithFixedSize<Global*>());
+    Interpreter::interpret(dummyState, pc, nullptr, nullptr, nullptr, nullptr, nullptr);
 #endif
 }
 
@@ -212,9 +212,9 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
                                             size_t programCounter,
                                             uint8_t* bp,
                                             Instance* instance,
-                                            const VectorWithFixedSize<Memory*>& memories,
-                                            const VectorWithFixedSize<Table*>& tables,
-                                            const VectorWithFixedSize<Global*>& globals)
+                                            Memory** memories,
+                                            Table** tables,
+                                            Global** globals)
 {
     state.m_programCounterPointer = &programCounter;
 
@@ -610,7 +610,7 @@ NextInstruction:
         :
     {
         GlobalGet32* code = (GlobalGet32*)programCounter;
-        ASSERT(code->index() < instance->m_globals.size());
+        ASSERT(code->index() < instance->module()->numberOfGlobalTypes());
         globals[code->index()]->value().writeNBytesToMemory<4>(bp + code->dstOffset());
         ADD_PROGRAM_COUNTER(GlobalGet32);
         NEXT_INSTRUCTION();
@@ -620,7 +620,7 @@ NextInstruction:
         :
     {
         GlobalGet64* code = (GlobalGet64*)programCounter;
-        ASSERT(code->index() < instance->m_globals.size());
+        ASSERT(code->index() < instance->module()->numberOfGlobalTypes());
         globals[code->index()]->value().writeNBytesToMemory<8>(bp + code->dstOffset());
         ADD_PROGRAM_COUNTER(GlobalGet64);
         NEXT_INSTRUCTION();
@@ -630,7 +630,7 @@ NextInstruction:
         :
     {
         GlobalSet32* code = (GlobalSet32*)programCounter;
-        ASSERT(code->index() < instance->m_globals.size());
+        ASSERT(code->index() < instance->module()->numberOfGlobalTypes());
         Value& val = globals[code->index()]->value();
         val.readFromStack<4>(bp + code->srcOffset());
         ADD_PROGRAM_COUNTER(GlobalSet32);
@@ -641,7 +641,7 @@ NextInstruction:
         :
     {
         GlobalSet64* code = (GlobalSet64*)programCounter;
-        ASSERT(code->index() < instance->m_globals.size());
+        ASSERT(code->index() < instance->module()->numberOfGlobalTypes());
         Value& val = globals[code->index()]->value();
         val.readFromStack<8>(bp + code->srcOffset());
         ADD_PROGRAM_COUNTER(GlobalSet64);
@@ -751,7 +751,7 @@ NextInstruction:
         :
     {
         TableGet* code = (TableGet*)programCounter;
-        ASSERT(code->tableIndex() < instance->m_tables.size());
+        ASSERT(code->tableIndex() < instance->module()->numberOfTableTypes());
         Table* table = tables[code->tableIndex()];
         void* val = table->getElement(state, readValue<uint32_t>(bp, code->srcOffset()));
         writeValue(bp, code->dstOffset(), val);
@@ -764,7 +764,7 @@ NextInstruction:
         :
     {
         TableSet* code = (TableSet*)programCounter;
-        ASSERT(code->tableIndex() < instance->m_tables.size());
+        ASSERT(code->tableIndex() < instance->module()->numberOfTableTypes());
         Table* table = tables[code->tableIndex()];
         void* ptr = readValue<void*>(bp, code->src1Offset());
         table->setElement(state, readValue<uint32_t>(bp, code->src0Offset()), ptr);
@@ -777,7 +777,7 @@ NextInstruction:
         :
     {
         TableGrow* code = (TableGrow*)programCounter;
-        ASSERT(code->tableIndex() < instance->m_tables.size());
+        ASSERT(code->tableIndex() < instance->module()->numberOfTableTypes());
         Table* table = tables[code->tableIndex()];
         size_t size = table->size();
 
@@ -800,7 +800,7 @@ NextInstruction:
         :
     {
         TableSize* code = (TableSize*)programCounter;
-        ASSERT(code->tableIndex() < instance->m_tables.size());
+        ASSERT(code->tableIndex() < instance->module()->numberOfTableTypes());
         Table* table = tables[code->tableIndex()];
         size_t size = table->size();
         writeValue<uint32_t>(bp, code->dstOffset(), size);
@@ -813,8 +813,8 @@ NextInstruction:
         :
     {
         TableCopy* code = (TableCopy*)programCounter;
-        ASSERT(code->dstIndex() < instance->m_tables.size());
-        ASSERT(code->srcIndex() < instance->m_tables.size());
+        ASSERT(code->dstIndex() < instance->module()->numberOfTableTypes());
+        ASSERT(code->srcIndex() < instance->module()->numberOfTableTypes());
         Table* dstTable = tables[code->dstIndex()];
         Table* srcTable = tables[code->srcIndex()];
 
@@ -832,7 +832,7 @@ NextInstruction:
         :
     {
         TableFill* code = (TableFill*)programCounter;
-        ASSERT(code->tableIndex() < instance->m_tables.size());
+        ASSERT(code->tableIndex() < instance->module()->numberOfTableTypes());
         Table* table = tables[code->tableIndex()];
 
         int32_t index = readValue<int32_t>(bp, code->srcOffsets()[0]);
@@ -854,7 +854,7 @@ NextInstruction:
         int32_t srcStart = readValue<int32_t>(bp, code->srcOffsets()[1]);
         int32_t size = readValue<int32_t>(bp, code->srcOffsets()[2]);
 
-        ASSERT(code->tableIndex() < instance->m_tables.size());
+        ASSERT(code->tableIndex() < instance->module()->numberOfTableTypes());
         Table* table = tables[code->tableIndex()];
         table->init(state, instance, &sg, dstStart, srcStart, size);
         ADD_PROGRAM_COUNTER(TableInit);

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -38,9 +38,9 @@ private:
                                           size_t programCounter,
                                           uint8_t* bp,
                                           Instance* instance,
-                                          const VectorWithFixedSize<Memory*>& memories,
-                                          const VectorWithFixedSize<Table*>& tables,
-                                          const VectorWithFixedSize<Global*>& globals);
+                                          Memory** memories,
+                                          Table** tables,
+                                          Global** globals);
 
     static void callOperation(ExecutionState& state,
                               size_t& programCounter,

--- a/src/runtime/Instance.cpp
+++ b/src/runtime/Instance.cpp
@@ -27,6 +27,28 @@
 
 namespace Walrus {
 
+Instance* Instance::newInstance(Module* module)
+{
+    // Must follow the order in Module::instantiate.
+    size_t numberOfRefs = module->numberOfMemoryTypes() + module->numberOfGlobalTypes()
+        + module->numberOfTableTypes() + module->numberOfFunctions() + module->numberOfTagTypes();
+
+    void* result = malloc(alignedSize() + numberOfRefs * sizeof(void*));
+
+    // Placement new.
+    new (result) Instance(module);
+
+    // Initialize data.
+    return reinterpret_cast<Instance*>(result);
+}
+
+void Instance::freeInstance(Instance* instance)
+{
+    instance->~Instance();
+
+    free(reinterpret_cast<void*>(instance));
+}
+
 Instance::Instance(Module* module)
     : m_module(module)
 {

--- a/src/runtime/Instance.h
+++ b/src/runtime/Instance.h
@@ -81,7 +81,8 @@ class Instance : public Object {
 public:
     typedef Vector<Instance*, std::allocator<Instance*>> InstanceVector;
 
-    Instance(Module* module);
+    static Instance* newInstance(Module* module);
+    static void freeInstance(Instance* instance);
 
     virtual Object::Kind kind() const override
     {
@@ -117,16 +118,26 @@ public:
     Memory* resolveExportMemory(std::string& name);
     Global* resolveExportGlobal(std::string& name);
 
-    const VectorWithFixedSize<Function*>& functions() { return m_functions; }
+    const Function* const* functions() { return m_functions; }
 
 private:
+    Instance(Module* module);
+    ~Instance() {}
+
+    static size_t alignedSize()
+    {
+        return (sizeof(Instance) + sizeof(void*) - 1) & ~(sizeof(void*) - 1);
+    }
+
     Module* m_module;
 
-    VectorWithFixedSize<Function*> m_functions;
-    VectorWithFixedSize<Table*> m_tables;
-    VectorWithFixedSize<Memory*> m_memories;
-    VectorWithFixedSize<Global*> m_globals;
-    VectorWithFixedSize<Tag*> m_tags;
+    // The initialization in Module::instantiate and Instance::newInstance must follow this order.
+    // Ordered in use frequency order.
+    Memory** m_memories;
+    Global** m_globals;
+    Table** m_tables;
+    Function** m_functions;
+    Tag** m_tags;
 
     VectorWithFixedSize<DataSegment, std::allocator<DataSegment>> m_dataSegments;
     VectorWithFixedSize<ElementSegment, std::allocator<ElementSegment>> m_elementSegments;

--- a/src/runtime/Module.h
+++ b/src/runtime/Module.h
@@ -338,6 +338,11 @@ public:
         return m_store;
     }
 
+    size_t numberOfFunctions()
+    {
+        return m_functions.size();
+    }
+
     ModuleFunction* function(uint32_t index) const
     {
         ASSERT(index < m_functions.size());
@@ -350,10 +355,20 @@ public:
         return m_functionTypes[index];
     }
 
+    size_t numberOfTableTypes()
+    {
+        return m_tableTypes.size();
+    }
+
     TableType* tableType(uint32_t index) const
     {
         ASSERT(index < m_tableTypes.size());
         return m_tableTypes[index];
+    }
+
+    size_t numberOfMemoryTypes()
+    {
+        return m_memoryTypes.size();
     }
 
     MemoryType* memoryType(uint32_t index) const
@@ -362,10 +377,20 @@ public:
         return m_memoryTypes[index];
     }
 
+    size_t numberOfGlobalTypes()
+    {
+        return m_globalTypes.size();
+    }
+
     GlobalType* globalType(uint32_t index) const
     {
         ASSERT(index < m_globalTypes.size());
         return m_globalTypes[index];
+    }
+
+    size_t numberOfTagTypes()
+    {
+        return m_tagTypes.size();
     }
 
     const VectorWithFixedSize<ImportType*, std::allocator<ImportType*>>& imports() const

--- a/src/runtime/Store.cpp
+++ b/src/runtime/Store.cpp
@@ -31,7 +31,7 @@ Store::~Store()
 {
     // deallocate Modules and Instances
     for (size_t i = 0; i < m_instances.size(); i++) {
-        delete m_instances[i];
+        Instance::freeInstance(m_instances[i]);
     }
 
     for (size_t i = 0; i < m_modules.size(); i++) {


### PR DESCRIPTION
I have started to implement a low-level interface for instance. It is just a concept, it can be changed in any way. The key points:
- Instance has a c++ header, but after that it is a raw byte array. 
- All WebAssembly data has a byte offset, which is computed at compile time. Both interpreter and jit can use these offsets to access the data, no std::vector or std::shared_ptr is required. The offsets can be part of jit instructions and interpreter byte codes.
- The WebAssembly data is now the full data structure (e.g. memory), not a reference pointer. This can be changed if reference support is needed.

What do you think?