### PR TITLE
Improve RefNull and RefIsNull operations

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -1251,69 +1251,6 @@ private:
     ByteCodeStackOffset m_dstOffset;
 };
 
-class RefNull : public ByteCode {
-public:
-    RefNull(Value::Type type, ByteCodeStackOffset dstOffset)
-        : ByteCode(OpcodeKind::RefNullOpcode)
-        , m_type(type)
-        , m_dstOffset(dstOffset)
-    {
-    }
-
-    Value::Type type() const { return m_type; }
-    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
-
-#if !defined(NDEBUG)
-    virtual void dump(size_t pos)
-    {
-        DUMP_BYTECODE_OFFSET(dstOffset);
-        if (m_type == Value::FuncRef) {
-            printf("funcref");
-        } else {
-            ASSERT(m_type == Value::ExternRef);
-            printf("externref");
-        }
-    }
-
-    virtual size_t byteCodeSize()
-    {
-        return sizeof(RefNull);
-    }
-#endif
-
-private:
-    Value::Type m_type;
-    ByteCodeStackOffset m_dstOffset;
-};
-
-class RefIsNull : public ByteCode {
-public:
-    RefIsNull(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
-        : ByteCode(OpcodeKind::RefIsNullOpcode)
-        , m_srcOffset(srcOffset)
-        , m_dstOffset(dstOffset)
-    {
-    }
-
-    ByteCodeStackOffset srcOffset() const { return m_srcOffset; }
-    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
-
-#if !defined(NDEBUG)
-    virtual void dump(size_t pos)
-    {
-        DUMP_BYTECODE_OFFSET(srcOffset);
-        DUMP_BYTECODE_OFFSET(dstOffset);
-    }
-    virtual size_t byteCodeSize()
-    {
-        return sizeof(RefIsNull);
-    }
-#endif
-protected:
-    ByteCodeStackOffset m_srcOffset;
-    ByteCodeStackOffset m_dstOffset;
-};
-
 class GlobalGet32 : public ByteCode {
 public:
     GlobalGet32(ByteCodeStackOffset dstOffset, uint32_t index)

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -880,28 +880,6 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
-    DEFINE_OPCODE(RefNull)
-        :
-    {
-        RefNull* code = (RefNull*)programCounter;
-        Value(code->type(), Value::Null).writeToMemory(code->dstOffset() + bp);
-
-        ADD_PROGRAM_COUNTER(RefNull);
-        NEXT_INSTRUCTION();
-    }
-
-    DEFINE_OPCODE(RefIsNull)
-        :
-    {
-        RefIsNull* code = (RefIsNull*)programCounter;
-
-        Value val(reinterpret_cast<Function*>(readValue<void*>(bp, code->srcOffset())));
-        writeValue(bp, code->dstOffset(), (int32_t)val.isNull());
-
-        ADD_PROGRAM_COUNTER(RefIsNull);
-        NEXT_INSTRUCTION();
-    }
-
     DEFINE_OPCODE(Throw)
         :
     {

--- a/src/interpreter/Opcode.h
+++ b/src/interpreter/Opcode.h
@@ -207,8 +207,6 @@ enum OpcodeKind : size_t {
     WABT_OPCODE(___, ___, I32, ___, 0, 0xfc, 0x0f, TableGrow, "table.grow", "")                \
     WABT_OPCODE(___, ___, ___, ___, 0, 0xfc, 0x10, TableSize, "table.size", "")                \
     WABT_OPCODE(___, I32, ___, I32, 0, 0xfc, 0x11, TableFill, "table.fill", "")                \
-    WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xd0, RefNull, "ref.null", "")                       \
-    WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xd1, RefIsNull, "ref.is_null", "")                  \
     WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xd2, RefFunc, "ref.func", "")                       \
     WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xe7, Move32, "move_32", "")                         \
     WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xe8, Move64, "move_64", "")                         \

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -1550,14 +1550,22 @@ public:
 
     virtual void OnRefNullExpr(Type type) override
     {
-        auto dst = pushVMStack(Walrus::valueSizeInStack(Walrus::Value::Type::FuncRef));
-        pushByteCode(Walrus::RefNull(toValueKind(type), dst));
+        ASSERT(sizeof(uintptr_t) == 4 || sizeof(uintptr_t) == 8);
+        Walrus::ByteCodeStackOffset dst = pushVMStack(Walrus::valueSizeInStack(Walrus::Value::Type::FuncRef));
+
+        if (sizeof(uintptr_t) == 4) {
+            pushByteCode(Walrus::Const32(dst, Walrus::Value::Null));
+        } else {
+            pushByteCode(Walrus::Const64(dst, Walrus::Value::Null));
+        }
     }
 
     virtual void OnRefIsNullExpr() override
     {
+        ASSERT(sizeof(uintptr_t) == 4 || sizeof(uintptr_t) == 8);
         auto src = popVMStack();
-        pushByteCode(Walrus::RefIsNull(src, pushVMStack(Walrus::valueSizeInStack(Walrus::Value::Type::I32))));
+        auto dst = pushVMStack(Walrus::valueSizeInStack(Walrus::Value::Type::I32));
+        pushByteCode(Walrus::UnaryOperation(sizeof(uintptr_t) == 4 ? Walrus::I32EqzOpcode : Walrus::I64EqzOpcode, src, dst));
     }
 
     virtual void OnNopExpr() override

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -51,7 +51,7 @@ public:
     // https://webassembly.github.io/spec/core/syntax/types.html
 
     // RefNull
-    static constexpr uintptr_t NullBits = ~uintptr_t(0);
+    static constexpr uintptr_t NullBits = uintptr_t(0);
     enum RefNull { Null };
     enum ForceInit { Force };
 

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -391,13 +391,15 @@ static Walrus::Value toWalrusValue(wabt::Const& c)
         if (c.ref_bits() == wabt::Const::kRefNullBits) {
             return Walrus::Value(Walrus::Value::FuncRef, Walrus::Value::Null);
         }
-        return Walrus::Value(Walrus::Value::FuncRef, c.ref_bits(), Walrus::Value::Force);
+        // Add one similar to wabt interpreter.
+        return Walrus::Value(Walrus::Value::FuncRef, c.ref_bits() + 1, Walrus::Value::Force);
     }
     case wabt::Type::ExternRef: {
         if (c.ref_bits() == wabt::Const::kRefNullBits) {
             return Walrus::Value(Walrus::Value::ExternRef, Walrus::Value::Null);
         }
-        return Walrus::Value(Walrus::Value::ExternRef, c.ref_bits(), Walrus::Value::Force);
+        // Add one similar to wabt interpreter.
+        return Walrus::Value(Walrus::Value::ExternRef, c.ref_bits() + 1, Walrus::Value::Force);
     }
     default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -463,9 +465,9 @@ static bool equals(Walrus::Value& v, wabt::Const& c)
         if (c.ref_bits() == constNull.ref_bits()) {
             // check RefNull
             return v.isNull();
-        } else {
-            return c.ref_bits() == reinterpret_cast<uintptr_t>(v.asExternal());
         }
+        // Add one similar to wabt interpreter.
+        return (c.ref_bits() + 1) == reinterpret_cast<uintptr_t>(v.asExternal());
     } else if (c.type() == wabt::Type::FuncRef && v.type() == Walrus::Value::FuncRef) {
         // FIXME value of c.ref_bits() for RefNull
         wabt::Const constNull;
@@ -473,9 +475,9 @@ static bool equals(Walrus::Value& v, wabt::Const& c)
         if (c.ref_bits() == constNull.ref_bits()) {
             // check RefNull
             return v.isNull();
-        } else {
-            return c.ref_bits() == reinterpret_cast<uintptr_t>(v.asFunction());
         }
+        // Add one similar to wabt interpreter.
+        return (c.ref_bits() + 1) == reinterpret_cast<uintptr_t>(v.asFunction());
     }
     return false;
 }


### PR DESCRIPTION
I have found a bug:
```
(module
(func (export "defNull") (result externref) (local externref)
   local.get 0
)
)

(assert_return (invoke "defNull") (ref.null extern))
```

This fails because the memory is initialized to zero, and null is defined as `~0`. I checked wabt, and they use 0 as null:
https://github.com/Samsung/walrus/blob/interp/third_party/wabt/src/interp/interp.cc#L55

There is a test with `(ref.extern 0)`, which should pass. I think we can do the same thing as the wabt test runner:
https://github.com/Samsung/walrus/blob/interp/third_party/wabt/src/tools/spectest-interp.cc#L825
