### PR TITLE
Replace exception throws with boolean return

### DIFF
--- a/src/runtime/Memory.cpp
+++ b/src/runtime/Memory.cpp
@@ -101,11 +101,32 @@ private:
 
 void Memory::init(ExecutionState& state, DataSegment* source, uint32_t dstStart, uint32_t srcStart, uint32_t srcSize)
 {
-    checkAccess(state, dstStart, 0, srcSize);
+    checkAccess(state, dstStart, srcSize);
+
     if (srcStart >= source->sizeInByte() || srcStart + srcSize > source->sizeInByte()) {
         throwException(state, srcStart, srcStart + srcSize, srcSize);
     }
 
+    this->initMemory(source, dstStart, srcStart, srcSize);
+}
+
+void Memory::copy(ExecutionState& state, uint32_t dstStart, uint32_t srcStart, uint32_t size)
+{
+    checkAccess(state, srcStart, size);
+    checkAccess(state, dstStart, size);
+
+    this->copyMemory(dstStart, srcStart, size);
+}
+
+void Memory::fill(ExecutionState& state, uint32_t start, uint8_t value, uint32_t size)
+{
+    checkAccess(state, start, size);
+
+    this->fillMemory(start, value, size);
+}
+
+void Memory::initMemory(DataSegment* source, uint32_t dstStart, uint32_t srcStart, uint32_t srcSize)
+{
     auto data = source->data()->initData();
     std::copy(source->data()->initData().begin() + srcStart, source->data()->initData().begin() + srcStart + srcSize,
 #if defined(WALRUS_BIG_ENDIAN)
@@ -115,11 +136,8 @@ void Memory::init(ExecutionState& state, DataSegment* source, uint32_t dstStart,
 #endif
 }
 
-void Memory::copy(ExecutionState& state, uint32_t dstStart, uint32_t srcStart, uint32_t size)
+void Memory::copyMemory(uint32_t dstStart, uint32_t srcStart, uint32_t size)
 {
-    checkAccess(state, srcStart, 0, size);
-    checkAccess(state, dstStart, 0, size);
-
 #if defined(WALRUS_BIG_ENDIAN)
     auto srcBegin = m_buffer + m_sizeInByte + srcStart - size;
     auto dstBegin = m_buffer + m_sizeInByte + dstStart - size;
@@ -136,9 +154,8 @@ void Memory::copy(ExecutionState& state, uint32_t dstStart, uint32_t srcStart, u
     }
 }
 
-void Memory::fill(ExecutionState& state, uint32_t start, uint8_t value, uint32_t size)
+void Memory::fillMemory(uint32_t start, uint8_t value, uint32_t size)
 {
-    checkAccess(state, start, 0, size);
 #if defined(WALRUS_BIG_ENDIAN)
     std::fill(m_buffer + m_sizeInByte - start - size, m_buffer + m_sizeInByte - start, value);
 #else

--- a/src/runtime/Table.h
+++ b/src/runtime/Table.h
@@ -99,6 +99,10 @@ private:
 
     void throwException(ExecutionState& state) const;
 
+    void initTable(Instance* instance, ElementSegment* source, uint32_t dstStart, uint32_t srcStart, uint32_t srcSize);
+    void copyTable(const Table* srcTable, uint32_t n, uint32_t srcIndex, uint32_t dstIndex);
+    void fillTable(uint32_t n, void* value, uint32_t index);
+
     // Table has elements of reference type (FuncRef | ExternRef)
     Value::Type m_type;
     uint32_t m_size;


### PR DESCRIPTION
Replaced exception throws with boolean return for better performance for JIT callbacks.

Signed-off-by: Gergo Csizi gergocs@inf.u-szeged.hu