### PR TITLE
Implement base for Walrus WASI

### DIFF
--- a/src/runtime/SpecTest.h
+++ b/src/runtime/SpecTest.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023-present Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Walrus.h"
+
+namespace Walrus {
+
+class SpecTestFunctionTypes {
+    MAKE_STACK_ALLOCATED();
+
+public:
+    enum Index : uint8_t {
+        // The R is meant to represent the results, after R are the result types.
+        NONE = 0,
+        I32R,
+        RI32,
+        I64R,
+        F32R,
+        F64R,
+        I32F32R,
+        F64F64R,
+        INVALID,
+        INDEX_NUM,
+    };
+
+    SpecTestFunctionTypes()
+    {
+        m_vector.reserve(INDEX_NUM);
+        size_t index = 0;
+
+        ValueTypeVector* param;
+        ValueTypeVector* result;
+
+        {
+            // NONE
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // I32R
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::I32);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // RI32
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            result->push_back(Value::Type::I32);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // I64
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::I64);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // F32
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::F32);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // F64
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::F64);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // I32F32
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::F32);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // F64F64
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::F64);
+            param->push_back(Value::Type::F64);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // INVALID
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::Void);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+
+        ASSERT(index == INDEX_NUM);
+    }
+
+    ~SpecTestFunctionTypes()
+    {
+        for (size_t i = 0; i < m_vector.size(); i++) {
+            delete m_vector[i];
+        }
+    }
+
+    FunctionType* operator[](const size_t idx)
+    {
+        ASSERT(idx < m_vector.size());
+        return m_vector[idx];
+    }
+
+private:
+    FunctionTypeVector m_vector;
+};
+
+} // namespace Walrus

--- a/src/wasi/Wasi.cpp
+++ b/src/wasi/Wasi.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023-present Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wasi/Wasi.h"
+
+namespace Walrus {
+
+WASI::WasiFunc* WASI::find(std::string funcName)
+{
+    for (unsigned i = 0; i < WasiFuncName::FuncEnd; ++i) {
+        if (m_wasiFunctions[i].name == funcName) {
+            return &m_wasiFunctions[i];
+        }
+    }
+    return nullptr;
+}
+
+void WASI::test(ExecutionState& state, const uint32_t argc, Value* argv, Value* result, void* data)
+{
+    printf("No argument test succesful.\n");
+}
+
+void WASI::printI32(ExecutionState& state, const uint32_t argc, Value* argv, Value* result, void* data)
+{
+    printf("Recieved number: %d.\n", argv[0].asI32());
+}
+
+void WASI::writeI32(ExecutionState& state, const uint32_t argc, Value* argv, Value* result, void* data)
+{
+    printf("Writing 42 to stack.\n");
+    result[0] = Value((int32_t)42);
+}
+
+void WASI::proc_exit(ExecutionState& state, const uint32_t argc, Value* argv, Value* result, void* data)
+{
+    ASSERT(argc == 1 && argv[0].type() == Value::I32);
+    exit(argv[0].asI32());
+    ASSERT_NOT_REACHED();
+}
+
+void WASI::fillWasiFuncTable()
+{
+#define WASI_FUNC_TABLE(NAME, FUNCTYPE)                                                             \
+    m_wasiFunctions[WASI::WasiFuncName::NAME##FUNC].name = #NAME;                                   \
+    m_wasiFunctions[WASI::WasiFuncName::NAME##FUNC].functionType = SpecTestFunctionTypes::FUNCTYPE; \
+    m_wasiFunctions[WASI::WasiFuncName::NAME##FUNC].ptr = &WASI::NAME;
+    FOR_EACH_WASI_FUNC(WASI_FUNC_TABLE)
+#undef WASI_FUNC_TABLE
+}
+
+WASI::WASI()
+{
+    fillWasiFuncTable();
+}
+
+} // namespace Walrus

--- a/src/wasi/Wasi.h
+++ b/src/wasi/Wasi.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023-present Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Walrus.h"
+#include "runtime/Value.h"
+#include "runtime/Function.h"
+#include "runtime/ObjectType.h"
+#include "runtime/SpecTest.h"
+
+namespace Walrus {
+
+class WASI {
+public:
+    WASI();
+
+    ~WASI()
+    {
+    }
+
+    struct WasiFunc {
+        std::string name;
+        SpecTestFunctionTypes::Index functionType;
+        ImportedFunction::ImportedFunctionCallback ptr;
+    };
+
+#define FOR_EACH_WASI_FUNC(F) \
+    F(test, NONE)             \
+    F(printI32, I32R)         \
+    F(writeI32, RI32)         \
+    F(proc_exit, I32R)
+
+    enum WasiFuncName : size_t {
+#define DECLARE_FUNCTION(NAME, FUNCTYPE) NAME##FUNC,
+        FOR_EACH_WASI_FUNC(DECLARE_FUNCTION)
+#undef DECLARE_FUNCTION
+            FuncEnd,
+    };
+
+    void fillWasiFuncTable();
+    WasiFunc* find(std::string funcName);
+
+    static void test(ExecutionState& state, const uint32_t argc, Value* argv, Value* result, void* data);
+    static void printI32(ExecutionState& state, const uint32_t argc, Value* argv, Value* result, void* data);
+    static void writeI32(ExecutionState& state, const uint32_t argc, Value* argv, Value* result, void* data);
+    static void proc_exit(ExecutionState& state, const uint32_t argc, Value* argv, Value* result, void* data);
+
+    WasiFunc m_wasiFunctions[FuncEnd];
+};
+
+} // namespace Walrus

--- a/test/wasi/example.wast
+++ b/test/wasi/example.wast
@@ -1,0 +1,14 @@
+(module
+  (import "wasi_snapshot_preview1" "test" (func $test))
+  (import "wasi_snapshot_preview1" "printI32" (func $print (param i32)))
+  (import "wasi_snapshot_preview1" "writeI32" (func $write (result i32)))
+
+  (func (export "start")
+    call $test
+    call $write
+    call $print
+  )
+)
+
+
+(assert_return (invoke "start"))

--- a/test/wasi/proc_exit.wast
+++ b/test/wasi/proc_exit.wast
@@ -1,0 +1,11 @@
+(module
+  (import "wasi_snapshot_preview1" "proc_exit" (func $exit (param i32)))
+
+
+  (func (export "start")
+    i32.const 0
+    call $exit
+  )
+)
+
+(assert_return (invoke "start"))

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -99,7 +99,7 @@ def run(args, cwd=None, env=None, stdout=None, checkresult=True, report=False):
 def readfile(filename):
     with open(filename, 'r') as f:
         return f.readlines()
-    
+
 def _run_wast_tests(engine, files, is_fail):
     fails = 0
     for file in files:
@@ -150,6 +150,23 @@ def run_core_tests(engine):
 
     if fail_total > 0:
         raise Exception("wasm-test-core failed")
+
+@runner('wasi', default=True)
+def run_basic_tests(engine):
+    TEST_DIR = join(PROJECT_SOURCE_DIR, 'test', 'wasi')
+
+    print('Running wasi tests:')
+    xpass = glob(join(TEST_DIR, '*.wast'))
+    xpass_result = _run_wast_tests(engine, xpass, False)
+
+    tests_total = len(xpass)
+    fail_total = xpass_result
+    print('TOTAL: %d' % (tests_total))
+    print('%sPASS : %d%s' % (COLOR_GREEN, tests_total, COLOR_RESET))
+    print('%sFAIL : %d%s' % (COLOR_RED, fail_total, COLOR_RESET))
+
+    if fail_total > 0:
+        raise Exception("basic wasi tests failed")
 
 def main():
     parser = ArgumentParser(description='Walrus Test Suite Runner')


### PR DESCRIPTION
I have started working on implemeting WASI in Walrus.

As I have seen WASI is in a change right now where they are abandoning their witx format for wit. They are in a constant change and it could be troublesome to import other WASI systems in Walrus, as all other WebAssembly runtimes implemented their own version too as I have seen (on the basis of the official c-api).

This base can help us start implementing our own version too. This is just a rough base though, and needs some working.

My basic thought were:
- only import functions that are used by the module

- have a constant list with our implemented functions (this needs work, but I am open to other structures too)

- be easily expendable

The function list right now is just for example, I do not mean to actually implement it this way.