### PR TITLE
Fix bulk.wast test

### DIFF
--- a/test/wasm-spec/core/bulk.wast
+++ b/test/wasm-spec/core/bulk.wast
@@ -219,7 +219,7 @@
 (assert_trap (invoke "init" (i32.const 2) (i32.const 0) (i32.const 2))
     "out of bounds table access")
 (assert_trap (invoke "call" (i32.const 2))
-    "uninitialized element 2")
+    "uninitialized element")
 
 (invoke "init" (i32.const 0) (i32.const 1) (i32.const 2))
 (assert_return (invoke "call" (i32.const 0)) (i32.const 1))


### PR DESCRIPTION
Typo in the test. No other exception checks has any index in the whole spec test.