### PR TITLE
Bugfix and improve debug mode

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -256,6 +256,8 @@ public:
 
     Opcode opcode() const;
     size_t getSize();
+    virtual const std::string getName() const { return "MISSING NAME"; };
+    virtual void printExtra(size_t pos) { return; };
 
 protected:
     friend class Interpreter;
@@ -302,9 +304,13 @@ public:
     uint32_t value() const { return m_value; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("const32 ");
+        return "const32";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(dstOffset);
         printf("value: %" PRId32, m_value);
     }
@@ -330,9 +336,13 @@ public:
     uint64_t value() const { return m_value; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("const64 ");
+        return "const64";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(dstOffset);
         printf("value: %" PRIu64, m_value);
     }
@@ -356,11 +366,6 @@ public:
     const ByteCodeStackOffset* srcOffset() const { return m_srcOffset; }
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
     void setDstOffset(ByteCodeStackOffset o) { m_dstOffset = o; }
-#if !defined(NDEBUG)
-    void dump(size_t pos)
-    {
-    }
-#endif
 
 protected:
     ByteCodeStackOffset m_srcOffset[2];
@@ -368,10 +373,13 @@ protected:
 };
 
 #if !defined(NDEBUG)
-#define DEFINE_BINARY_BYTECODE_DUMP(name)                                                                                                             \
-    void dump(size_t pos)                                                                                                                             \
-    {                                                                                                                                                 \
-        printf(#name "src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32, (uint32_t)m_srcOffset[0], (uint32_t)m_srcOffset[1], (uint32_t)m_dstOffset); \
+#define DEFINE_BINARY_BYTECODE_DUMP(name)                                                                                                       \
+                                                                                                                                                \
+    const std::string getName() const override { return #name; }                                                                                \
+                                                                                                                                                \
+    void printExtra(size_t pos) override                                                                                                        \
+    {                                                                                                                                           \
+        printf("src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32, (uint32_t)m_srcOffset[0], (uint32_t)m_srcOffset[1], (uint32_t)m_dstOffset); \
     }
 #else
 #define DEFINE_BINARY_BYTECODE_DUMP(name)
@@ -398,11 +406,6 @@ public:
     }
     ByteCodeStackOffset srcOffset() const { return m_srcOffset; }
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
-#if !defined(NDEBUG)
-    void dump(size_t pos)
-    {
-    }
-#endif
 
 protected:
     ByteCodeStackOffset m_srcOffset;
@@ -410,10 +413,12 @@ protected:
 };
 
 #if !defined(NDEBUG)
-#define DEFINE_UNARY_BYTECODE_DUMP(name)                                                               \
-    void dump(size_t pos)                                                                              \
-    {                                                                                                  \
-        printf(#name " src: %" PRIu32 " dst: %" PRIu32, (uint32_t)m_srcOffset, (uint32_t)m_dstOffset); \
+#define DEFINE_UNARY_BYTECODE_DUMP(name)                                                        \
+    const std::string getName() const override { return #name; }                                \
+                                                                                                \
+    void printExtra(size_t pos) override                                                        \
+    {                                                                                           \
+        printf("src: %" PRIu32 " dst: %" PRIu32, (uint32_t)m_srcOffset, (uint32_t)m_dstOffset); \
     }
 #else
 #define DEFINE_UNARY_BYTECODE_DUMP(name)
@@ -466,9 +471,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("call ");
+        return "call";
+    }
+
+    void printExtra(size_t pos) override
+    {
         printf("index: %" PRId32 " ", m_index);
         size_t c = 0;
         auto arr = stackOffsets();
@@ -482,7 +491,6 @@ public:
         for (size_t i = 0; i < m_functionType->result().size(); i++) {
             printf("%" PRIu32 " ", (uint32_t)arr[c++]);
         }
-        printf(" ");
     }
 #endif
 
@@ -513,9 +521,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("call_indirect ");
+        return "call_indirect";
+    }
+
+    void printExtra(size_t pos) override
+    {
         printf("tableIndex: %" PRId32 " ", m_tableIndex);
         DUMP_BYTECODE_OFFSET(calleeOffset);
 
@@ -531,7 +543,6 @@ public:
         for (size_t i = 0; i < m_functionType->result().size(); i++) {
             printf("%" PRIu32 " ", (uint32_t)arr[c++]);
         }
-        printf(" ");
     }
 #endif
 
@@ -554,9 +565,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("move32 ");
+        return "move32";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffset);
         DUMP_BYTECODE_OFFSET(dstOffset);
     }
@@ -580,9 +595,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("move64 ");
+        return "move64";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffset);
         DUMP_BYTECODE_OFFSET(dstOffset);
     }
@@ -606,9 +625,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("load32 ");
+        return "load32";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffset);
         DUMP_BYTECODE_OFFSET(dstOffset);
     }
@@ -632,9 +655,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("load64 ");
+        return "load64";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffset);
         DUMP_BYTECODE_OFFSET(dstOffset);
     }
@@ -658,9 +685,13 @@ public:
     ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("store32 ");
+        return "store32";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(src0Offset);
         DUMP_BYTECODE_OFFSET(src1Offset);
     }
@@ -684,9 +715,13 @@ public:
     ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("store64 ");
+        return "store64";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(src0Offset);
         DUMP_BYTECODE_OFFSET(src1Offset);
     }
@@ -712,9 +747,14 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("jump dst: %" PRId32, (int32_t)pos + m_offset);
+        return "jump";
+    }
+
+    void printExtra(size_t pos) override
+    {
+        printf("dst: %" PRId32, (int32_t)pos + m_offset);
     }
 #endif
 
@@ -739,9 +779,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("jump_if_true ");
+        return "jump_if_true";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffset);
         printf("dst: %" PRId32, (int32_t)pos + m_offset);
     }
@@ -769,9 +813,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("jump_if_false ");
+        return "jump_if_false";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffset);
         printf("dst: %" PRId32, (int32_t)pos + m_offset);
     }
@@ -804,9 +852,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("select ");
+        return "select";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(condOffset);
         DUMP_BYTECODE_OFFSET(src0Offset);
         DUMP_BYTECODE_OFFSET(src1Offset);
@@ -843,9 +895,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("br_table ");
+        return "br_table";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(condOffset);
         printf("tableSize: %" PRIu32 ", defaultOffset: %" PRId32, m_tableSize, m_defaultOffset);
         printf(" table contents: ");
@@ -873,9 +929,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("memory.size ");
+        return "memory.size";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(dstOffset);
     }
 #endif
@@ -905,9 +965,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("memory.init ");
+        return "memory.init";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffsets[0]);
         DUMP_BYTECODE_OFFSET(srcOffsets[1]);
         DUMP_BYTECODE_OFFSET(srcOffsets[2]);
@@ -936,9 +1000,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("memory.copy ");
+        return "memory.copy";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffsets[0]);
         DUMP_BYTECODE_OFFSET(srcOffsets[1]);
         DUMP_BYTECODE_OFFSET(srcOffsets[2]);
@@ -963,9 +1031,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("memory.fill ");
+        return "memory.fill";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffsets[0]);
         DUMP_BYTECODE_OFFSET(srcOffsets[1]);
         DUMP_BYTECODE_OFFSET(srcOffsets[2]);
@@ -989,9 +1061,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("data.drop ");
+        return "data.drop";
+    }
+
+    void printExtra(size_t pos) override
+    {
         printf("segmentIndex: %" PRIu32, m_segmentIndex);
     }
 #endif
@@ -1014,9 +1090,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("memory.grow ");
+        return "memory.grow";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffset);
         DUMP_BYTECODE_OFFSET(dstOffset);
     }
@@ -1042,11 +1122,6 @@ public:
     ByteCodeStackOffset srcOffset() const { return m_srcOffset; }
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
-#if !defined(NDEBUG)
-    void dump(size_t pos)
-    {
-    }
-#endif
 protected:
     uint32_t m_offset;
     ByteCodeStackOffset m_srcOffset;
@@ -1054,10 +1129,12 @@ protected:
 };
 
 #if !defined(NDEBUG)
-#define DEFINE_LOAD_BYTECODE_DUMP(name)                                                                                                        \
-    void dump(size_t pos)                                                                                                                      \
-    {                                                                                                                                          \
-        printf(#name " src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32, (uint32_t)m_srcOffset, (uint32_t)m_dstOffset, (uint32_t)m_offset); \
+#define DEFINE_LOAD_BYTECODE_DUMP(name)                                                                                                  \
+    const std::string getName() const override { return #name; }                                                                         \
+                                                                                                                                         \
+    void printExtra(size_t pos) override                                                                                                 \
+    {                                                                                                                                    \
+        printf(" src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32, (uint32_t)m_srcOffset, (uint32_t)m_dstOffset, (uint32_t)m_offset); \
     }
 #else
 #define DEFINE_LOAD_BYTECODE_DUMP(name)
@@ -1088,11 +1165,6 @@ public:
     ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
     ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
 
-#if !defined(NDEBUG)
-    void dump(size_t pos)
-    {
-    }
-#endif
 protected:
     uint32_t m_offset;
     ByteCodeStackOffset m_src0Offset;
@@ -1100,10 +1172,12 @@ protected:
 };
 
 #if !defined(NDEBUG)
-#define DEFINE_STORE_BYTECODE_DUMP(name)                                                                                                          \
-    void dump(size_t pos)                                                                                                                         \
-    {                                                                                                                                             \
-        printf(#name " src0: %" PRIu32 "src1: %" PRIu32 " offset: %" PRIu32, (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_offset); \
+#define DEFINE_STORE_BYTECODE_DUMP(name)                                                                                                    \
+    const std::string getName() const override { return #name; }                                                                            \
+                                                                                                                                            \
+    void printExtra(size_t pos) override                                                                                                    \
+    {                                                                                                                                       \
+        printf(" src0: %" PRIu32 "src1: %" PRIu32 " offset: %" PRIu32, (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_offset); \
     }
 #else
 #define DEFINE_STORE_BYTECODE_DUMP(name)
@@ -1141,9 +1215,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("table.get ");
+        return "table.get";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffset);
         DUMP_BYTECODE_OFFSET(dstOffset);
         printf("tableIndex: %" PRIu32, m_tableIndex);
@@ -1171,9 +1249,13 @@ public:
     uint32_t tableIndex() const { return m_tableIndex; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("table.set ");
+        return "table.set";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(src0Offset);
         DUMP_BYTECODE_OFFSET(src1Offset);
         printf("tableIndex: %" PRIu32, m_tableIndex);
@@ -1203,9 +1285,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("table.grow ");
+        return "table.grow";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(src0Offset);
         DUMP_BYTECODE_OFFSET(src1Offset);
         DUMP_BYTECODE_OFFSET(dstOffset);
@@ -1233,9 +1319,13 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("table.size ");
+        return "table.size";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(dstOffset);
         printf("tableIndex: %" PRIu32, m_tableIndex);
     }
@@ -1264,9 +1354,13 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("table.copy ");
+        return "table.copy";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffsets[0]);
         DUMP_BYTECODE_OFFSET(srcOffsets[1]);
         DUMP_BYTECODE_OFFSET(srcOffsets[2]);
@@ -1295,9 +1389,13 @@ public:
         return m_srcOffsets;
     }
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("table.fill ");
+        return "table.fill";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffsets[0]);
         DUMP_BYTECODE_OFFSET(srcOffsets[1]);
         DUMP_BYTECODE_OFFSET(srcOffsets[2]);
@@ -1327,9 +1425,13 @@ public:
         return m_srcOffsets;
     }
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("table.init ");
+        return "table.init";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(srcOffsets[0]);
         DUMP_BYTECODE_OFFSET(srcOffsets[1]);
         DUMP_BYTECODE_OFFSET(srcOffsets[2]);
@@ -1357,9 +1459,14 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("elem.drop segmentIndex: %" PRIu32, m_segmentIndex);
+        return "elem.drop";
+    }
+
+    void printExtra(size_t pos) override
+    {
+        printf("segmentIndex: %" PRIu32, m_segmentIndex);
     }
 #endif
 
@@ -1380,9 +1487,13 @@ public:
     uint32_t funcIndex() const { return m_funcIndex; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("ref.func ");
+        return "ref.func";
+    }
+
+    void printExtra(size_t pos) override
+    {
         DUMP_BYTECODE_OFFSET(dstOffset);
         printf("funcIndex: %" PRIu32, m_funcIndex);
     }
@@ -1406,9 +1517,13 @@ public:
     uint32_t index() const { return m_index; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("global.get32 ");
+        return "global.get32";
+    }
+
+    void printExtra(size_t pos) override
+    {
         printf("index: %" PRId32,
                m_index);
     }
@@ -1432,9 +1547,13 @@ public:
     uint32_t index() const { return m_index; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("global.get64 ");
+        return "global.get64";
+    }
+
+    void printExtra(size_t pos) override
+    {
         printf("index: %" PRId32,
                m_index);
     }
@@ -1458,9 +1577,13 @@ public:
     uint32_t index() const { return m_index; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("global.set32 ");
+        return "global.set32";
+    }
+
+    void printExtra(size_t pos) override
+    {
         printf("index: %" PRId32,
                m_index);
     }
@@ -1484,9 +1607,13 @@ public:
     uint32_t index() const { return m_index; }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("global.set64 ");
+        return "global.set64";
+    }
+
+    void printExtra(size_t pos) override
+    {
         printf("index: %" PRId32,
                m_index);
     }
@@ -1518,10 +1645,14 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("throw tagIndex: %" PRId32 " ",
-               m_tagIndex);
+        return "throw";
+    }
+
+    void printExtra(size_t pos) override
+    {
+        printf("tagIndex: %" PRId32 " ", m_tagIndex);
 
         if (m_tagIndex != std::numeric_limits<uint32_t>::max()) {
             auto arr = dataOffsets();
@@ -1529,7 +1660,6 @@ public:
             for (size_t i = 0; i < offsetsSize(); i++) {
                 printf("%" PRIu32 " ", (uint32_t)arr[i]);
             }
-            printf(" ");
         }
     }
 #endif
@@ -1547,9 +1677,9 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("unreachable");
+        return "unreachable";
     }
 #endif
 
@@ -1575,14 +1705,18 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
+    {
+        return "end";
+    }
+
+    void printExtra(size_t pos) override
     {
         auto arr = resultOffsets();
-        printf("end resultOffsets: ");
+        printf("resultOffsets: ");
         for (size_t i = 0; i < offsetsSize(); i++) {
             printf("%" PRIu32 " ", arr[i]);
         }
-        printf(" ");
     }
 #endif
 
@@ -1598,9 +1732,9 @@ public:
     }
 
 #if !defined(NDEBUG)
-    void dump(size_t pos)
+    const std::string getName() const override
     {
-        printf("fill opcode table");
+        return "fill opcode table";
     }
 #endif
 };

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -1297,7 +1297,7 @@ public:
             ASSERT(peekVMStackSize() == Walrus::valueSizeInStack(toValueKind(Type::I32)));
             auto stackPos = popVMStack();
             size_t pos = m_currentFunction->currentByteCodeSize();
-            pushByteCode(Walrus::JumpIfFalse(stackPos, sizeof(Walrus::JumpIfFalse) + sizeof(Walrus::End) + sizeof(uint16_t) * m_currentFunctionType->result().size()), WASMOpcode::BrIfOpcode);
+            pushByteCode(Walrus::JumpIfFalse(stackPos, sizeof(Walrus::JumpIfFalse) + sizeof(Walrus::End) + sizeof(Walrus::ByteCodeStackOffset) * m_currentFunctionType->result().size()), WASMOpcode::BrIfOpcode);
             for (size_t i = 0; i < m_currentFunctionType->result().size(); i++) {
                 ASSERT((m_vmStack.rbegin() + i)->m_size == Walrus::valueSizeInStack(m_currentFunctionType->result()[m_currentFunctionType->result().size() - i - 1]));
             }
@@ -1414,7 +1414,7 @@ public:
         if (tagIndex != std::numeric_limits<Index>::max()) {
             auto functionType = m_result.m_functionTypes[m_result.m_tagTypes[tagIndex]->sigIndex()];
             auto& param = functionType->param();
-            m_currentFunction->expandByteCode(sizeof(uint16_t) * param.size());
+            m_currentFunction->expandByteCode(sizeof(Walrus::ByteCodeStackOffset) * param.size());
             Walrus::Throw* code = m_currentFunction->peekByteCode<Walrus::Throw>(pos);
             for (size_t i = 0; i < param.size(); i++) {
                 code->dataOffsets()[param.size() - i - 1] = (m_vmStack.rbegin() + i)->m_position;


### PR DESCRIPTION
-  print parse errors before abort

-  print interpreter error before abort if debug mode set

-  print error at lexer initialization fail

-  print "assert failed" instead of just abort

-  make printing data fancier in debug mode

-  remove dump() in ByteCode and replace it with getName() and printExtra()

-  fix 2 typo

-  bugfix at table access



Old debug mode:
```
function type 0x556f7987a5d0
requiredStackSize 16, requiredStackSizeDueToLocal 0
0: I32Eqz src: 0 dst: 8
16: jump_if_true srcOffset: 8 dst: 64
32: const32 dstOffset: 8 value: 42
48: move64 srcOffset: 8 dstOffset: 0 
64: end resultOffsets: 0  
function type 0x556f7987a5d0
requiredStackSize 32, requiredStackSizeDueToLocal 8
0: I32Eqz src: 0 dst: 16
16: jump_if_true srcOffset: 16 dst: 128
32: const32 dstOffset: 24 value: 1
48: I32Eqsrc1: 0 src2: 24 dst: 16
64: jump_if_true srcOffset: 16 dst: 176
80: const32 dstOffset: 16 value: 7
96: move64 srcOffset: 16 dstOffset: 8 
112: jump dst: 208
128: const32 dstOffset: 16 value: 42
144: move64 srcOffset: 16 dstOffset: 8 
160: jump dst: 208
176: const32 dstOffset: 16 value: 99
192: move64 srcOffset: 16 dstOffset: 8 
208: end resultOffsets: 8  
invoke block1(0) expect value(0) (line: 35) : OK
invoke block1(1) expect value(42) (line: 36) : OK
invoke block2(0) expect value(42) (line: 38) : OK
invoke block2(1) expect value(99) (line: 39) : OK
invoke block2(2) expect value(7) (line: 40) : OK
```

New one:
```
| function type                   : 0x55f83d3bc5d0
| required stack size             :       16 bytes
| required stack size due to local:        0 bytes
| bytecode size                   :      122 bytes
|
|  address        | size | opcode          | note      
|-----------------+------+-----------------+-----------------
|               0 |   24 | I32Eqz          | src: 0 dst: 8
|              24 |   24 | jump_if_true    | srcOffset: 8 dst: 96
|              48 |   24 | const32         | dstOffset: 8 value: 42
|              72 |   24 | move64          | srcOffset: 8 dstOffset: 0 
|              96 |   26 | end             | resultOffsets: 0 
|-----------------+------+-----------------+-----------------


| function type                   : 0x55f83d3bc5d0
| required stack size             :       32 bytes
| required stack size due to local:        8 bytes
| bytecode size                   :      338 bytes
|
|  address        | size | opcode          | note      
|-----------------+------+-----------------+-----------------
|               0 |   24 | I32Eqz          | src: 0 dst: 16
|              24 |   24 | jump_if_true    | srcOffset: 16 dst: 192
|              48 |   24 | const32         | dstOffset: 24 value: 1
|              72 |   24 | I32Eq           | src1: 0 src2: 24 dst: 16
|              96 |   24 | jump_if_true    | srcOffset: 16 dst: 264
|             120 |   24 | const32         | dstOffset: 16 value: 7
|             144 |   24 | move64          | srcOffset: 16 dstOffset: 8 
|             168 |   24 | jump            | dst: 312
|             192 |   24 | const32         | dstOffset: 16 value: 42
|             216 |   24 | move64          | srcOffset: 16 dstOffset: 8 
|             240 |   24 | jump            | dst: 312
|             264 |   24 | const32         | dstOffset: 16 value: 99
|             288 |   24 | move64          | srcOffset: 16 dstOffset: 8 
|             312 |   26 | end             | resultOffsets: 8 
|-----------------+------+-----------------+-----------------

invoke block1(0) expect value(0) (line: 35) : OK
invoke block1(1) expect value(42) (line: 36) : OK
invoke block2(0) expect value(42) (line: 38) : OK
invoke block2(1) expect value(99) (line: 39) : OK
invoke block2(2) expect value(7) (line: 40) : OK
```