### PR TITLE
Print error message

### DIFF
--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -1716,7 +1716,7 @@ public:
             ASSERT(peekVMStackValueType() == Walrus::Value::Type::I32);
             auto stackPos = popVMStack();
             size_t pos = m_currentFunction->currentByteCodeSize();
-            pushByteCode(Walrus::JumpIfFalse(stackPos), WASMOpcode::BrIfOpcode);
+            pushByteCode(Walrus::JumpIfFalse(stackPos, sizeof(Walrus::JumpIfFalse) + sizeof(Walrus::End) + sizeof(Walrus::ByteCodeStackOffset) * m_currentFunctionType->result().size()), WASMOpcode::BrIfOpcode);
             for (size_t i = 0; i < m_currentFunctionType->result().size(); i++) {
                 ASSERT((m_vmStack.rbegin() + i)->valueType() == m_currentFunctionType->result()[m_currentFunctionType->result().size() - i - 1]);
             }
@@ -1861,7 +1861,7 @@ public:
         if (tagIndex != std::numeric_limits<Index>::max()) {
             auto functionType = m_result.m_functionTypes[m_result.m_tagTypes[tagIndex]->sigIndex()];
             auto& param = functionType->param();
-            m_currentFunction->expandByteCode(sizeof(uint16_t) * param.size());
+            m_currentFunction->expandByteCode(sizeof(Walrus::ByteCodeStackOffset) * param.size());
             Walrus::Throw* code = m_currentFunction->peekByteCode<Walrus::Throw>(pos);
             for (size_t i = 0; i < param.size(); i++) {
                 code->dataOffsets()[param.size() - i - 1] = (m_vmStack.rbegin() + i)->position();

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -363,6 +363,26 @@ public:
         return false;
     }
 
+    operator std::string() const
+    {
+        switch (m_type) {
+        case I32:
+            return std::to_string(asI32());
+        case I64:
+            return std::to_string(asI64());
+        case F32:
+            return std::to_string(asF32());
+        case F64:
+            return std::to_string(asF64());
+        case FuncRef:
+        case ExternRef:
+            return std::to_string((size_t)(asExternal()));
+        default:
+            ASSERT_NOT_REACHED();
+            return "";
+        }
+    }
+
 private:
     union {
         int32_t m_i32;


### PR DESCRIPTION
- print lexer initialisation error
- print syntax error
- print semantic error
- print assert fail
- print unequal call paramterer size in assert error
- print not-defined function call in asser error

fix 2 typo (replace uint16_t with Walrus::ByteCodeStackOffset).

fix another typo. Because of it 3 tests
failed (**binary.wast**, **binary-leb128.wast**, **elem.wast**), but it didn't throw assert failed and the ExecuteWASM() returned with an error that wasn't caught.

For example in **elem.wast:174-177** where it tries to write nothing to a 0 sized table:
```
(module
  (table 0 funcref)
  (elem (i32.const 0))
)
```