### PR TITLE
Improve debug mode

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -606,7 +606,6 @@ public:
         for (size_t i = 0; i < m_functionType->result().size(); i++) {
             printf("%" PRIu32 " ", (uint32_t)arr[c++]);
         }
-        printf(" ");
     }
 #endif
 
@@ -655,7 +654,6 @@ public:
         for (size_t i = 0; i < m_functionType->result().size(); i++) {
             printf("%" PRIu32 " ", (uint32_t)arr[c++]);
         }
-        printf(" ");
     }
 #endif
 
@@ -1731,7 +1729,6 @@ public:
             for (size_t i = 0; i < offsetsSize(); i++) {
                 printf("%" PRIu32 " ", (uint32_t)arr[i]);
             }
-            printf(" ");
         }
     }
 #endif
@@ -1784,7 +1781,6 @@ public:
         for (size_t i = 0; i < offsetsSize(); i++) {
             printf("%" PRIu32 " ", arr[i]);
         }
-        printf(" ");
     }
 #endif
 

--- a/src/runtime/Module.cpp
+++ b/src/runtime/Module.cpp
@@ -368,13 +368,16 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
 #if !defined(NDEBUG)
 void ModuleFunction::dumpByteCode()
 {
-    printf("function type %p\n", m_functionType);
-    printf("requiredStackSize %u, requiredStackSizeDueToLocal %u\n", m_requiredStackSize, m_requiredStackSizeDueToLocal);
+    printf("\n");
+    printf("required stack size: %u bytes\n", m_requiredStackSize);
+    printf("required stack size due to local: %u bytes\n", m_requiredStackSizeDueToLocal);
+    printf("bytecode size: %zu bytes\n", m_byteCode.size());
+    printf("\n");
 
     size_t idx = 0;
     while (idx < m_byteCode.size()) {
         ByteCode* code = reinterpret_cast<ByteCode*>(&m_byteCode[idx]);
-        printf("%zu: ", idx);
+        printf("%6zu ", idx);
 
         switch (code->opcode()) {
 #define GENERATE_BYTECODE_CASE(name, ...)    \
@@ -392,6 +395,7 @@ void ModuleFunction::dumpByteCode()
         printf("\n");
         idx += code->getSize();
     }
+    printf("\n");
 }
 #endif
 


### PR DESCRIPTION
Now the debug mode is better arranged, easier to examine. Dump() functions in ByteCode.h have been divided into getName() and printExtra() functions.

Old debug mode:
```
function type 0x556f7987a5d0
requiredStackSize 16, requiredStackSizeDueToLocal 0
0: I32Eqz src: 0 dst: 8
16: jump_if_true srcOffset: 8 dst: 64
32: const32 dstOffset: 8 value: 42
48: move64 srcOffset: 8 dstOffset: 0 
64: end resultOffsets: 0  
function type 0x556f7987a5d0
requiredStackSize 32, requiredStackSizeDueToLocal 8
0: I32Eqz src: 0 dst: 16
16: jump_if_true srcOffset: 16 dst: 128
32: const32 dstOffset: 24 value: 1
48: I32Eqsrc1: 0 src2: 24 dst: 16
64: jump_if_true srcOffset: 16 dst: 176
80: const32 dstOffset: 16 value: 7
96: move64 srcOffset: 16 dstOffset: 8 
112: jump dst: 208
128: const32 dstOffset: 16 value: 42
144: move64 srcOffset: 16 dstOffset: 8 
160: jump dst: 208
176: const32 dstOffset: 16 value: 99
192: move64 srcOffset: 16 dstOffset: 8 
208: end resultOffsets: 8  
invoke block1(0) expect value(0) (line: 35) : OK
invoke block1(1) expect value(42) (line: 36) : OK
invoke block2(0) expect value(42) (line: 38) : OK
invoke block2(1) expect value(99) (line: 39) : OK
invoke block2(2) expect value(7) (line: 40) : OK
```

New debug mode:
```
| function type                   : 0x55f83d3bc5d0
| required stack size             :       16 bytes
| required stack size due to local:        0 bytes
| bytecode size                   :      122 bytes
|
|  address        | size | opcode          | note      
|-----------------+------+-----------------+-----------------
|               0 |   24 | I32Eqz          | src: 0 dst: 8
|              24 |   24 | jump_if_true    | srcOffset: 8 dst: 96
|              48 |   24 | const32         | dstOffset: 8 value: 42
|              72 |   24 | move64          | srcOffset: 8 dstOffset: 0 
|              96 |   26 | end             | resultOffsets: 0 
|-----------------+------+-----------------+-----------------


| function type                   : 0x55f83d3bc5d0
| required stack size             :       32 bytes
| required stack size due to local:        8 bytes
| bytecode size                   :      338 bytes
|
|  address        | size | opcode          | note      
|-----------------+------+-----------------+-----------------
|               0 |   24 | I32Eqz          | src: 0 dst: 16
|              24 |   24 | jump_if_true    | srcOffset: 16 dst: 192
|              48 |   24 | const32         | dstOffset: 24 value: 1
|              72 |   24 | I32Eq           | src1: 0 src2: 24 dst: 16
|              96 |   24 | jump_if_true    | srcOffset: 16 dst: 264
|             120 |   24 | const32         | dstOffset: 16 value: 7
|             144 |   24 | move64          | srcOffset: 16 dstOffset: 8 
|             168 |   24 | jump            | dst: 312
|             192 |   24 | const32         | dstOffset: 16 value: 42
|             216 |   24 | move64          | srcOffset: 16 dstOffset: 8 
|             240 |   24 | jump            | dst: 312
|             264 |   24 | const32         | dstOffset: 16 value: 99
|             288 |   24 | move64          | srcOffset: 16 dstOffset: 8 
|             312 |   26 | end             | resultOffsets: 8 
|-----------------+------+-----------------+-----------------

invoke block1(0) expect value(0) (line: 35) : OK
invoke block1(1) expect value(42) (line: 36) : OK
invoke block2(0) expect value(42) (line: 38) : OK
invoke block2(1) expect value(99) (line: 39) : OK
invoke block2(2) expect value(7) (line: 40) : OK
```