### PR TITLE
Improve dead code elimination

### DIFF
--- a/test/basic/trycatch.wast
+++ b/test/basic/trycatch.wast
@@ -30,8 +30,32 @@
     )
     (i32.const 300)
   )
+
+  (func (export "dead-code")(result i32)
+    (block (result i32)
+      i32.const 5
+
+      (try (param i32) (result i32)
+        (do
+           br 1
+        )
+        (catch $e0
+           i32.const 1
+           br 1
+        )
+        (catch_all
+           i32.const 2
+           br 1
+        )
+      )
+
+      i32.const 6
+      i32.add
+    )
+  )
 )
 
 (assert_return (invoke "sss" (i32.const 1))(i32.const 100))
 (assert_return (invoke "sss" (i32.const 2))(i32.const 200))
 (assert_return (invoke "sss" (i32.const 3))(i32.const 300))
+(assert_return (invoke "dead-code")(i32.const 5))


### PR DESCRIPTION
Eliminates unnecessary jumps for if-else and try-catch blocks.
Furthermore br to try-catch blocks is not a loop anymore.
