### PR TITLE
Fix an issue in the shell

### DIFF
--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -871,6 +871,10 @@ static void runExports(Store* store, const std::string& filename, const std::vec
 
     auto module = parseResult.first;
 
+    if (useJIT) {
+        module->jitCompile(jitVerbose);
+    }
+
     const auto& importTypes = module->imports();
 
     if (importTypes.size() != 0) {


### PR DESCRIPTION
The runExports function didn't used JIT even if it was turned on. This patch should fix this issue.

Signed-off-by: Gergo Csizi gergocs@inf.u-szeged.hu