### PR TITLE
Fix ALLOCA macro to prevent memory leak.

### DIFF
--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -1359,7 +1359,7 @@ NEVER_INLINE void Interpreter::callOperation(
     Function* target = instance->function(code->index());
     const FunctionType* ft = target->functionType();
     const ValueTypeVector& param = ft->param();
-    ALLOCA(Value, paramVector, sizeof(Value) * param.size(), isAllocaParam);
+    ALLOCA(Value, paramVector, sizeof(Value) * param.size());
 
     size_t c = 0;
     for (size_t i = 0; i < param.size(); i++) {
@@ -1367,7 +1367,7 @@ NEVER_INLINE void Interpreter::callOperation(
     }
 
     const ValueTypeVector& result = ft->result();
-    ALLOCA(Value, resultVector, sizeof(Value) * result.size(), isAllocaResult);
+    ALLOCA(Value, resultVector, sizeof(Value) * result.size());
     size_t codeExtraOffsetsSize = sizeof(ByteCodeStackOffset) * ft->param().size() + sizeof(ByteCodeStackOffset) * ft->result().size();
 
     target->call(state, param.size(), paramVector, resultVector);
@@ -1375,13 +1375,6 @@ NEVER_INLINE void Interpreter::callOperation(
     for (size_t i = 0; i < result.size(); i++) {
         uint8_t* resultStackPointer = bp + code->stackOffsets()[c++];
         resultVector[i].writeToMemory(resultStackPointer);
-    }
-
-    if (UNLIKELY(!isAllocaParam)) {
-        delete[] paramVector;
-    }
-    if (UNLIKELY(!isAllocaResult)) {
-        delete[] resultVector;
     }
 
     programCounter += sizeof(Call) + codeExtraOffsetsSize;
@@ -1409,7 +1402,7 @@ NEVER_INLINE void Interpreter::callIndirectOperation(
         Trap::throwException(state, "indirect call type mismatch");
     }
     const ValueTypeVector& param = ft->param();
-    ALLOCA(Value, paramVector, sizeof(Value) * param.size(), isAllocaParam);
+    ALLOCA(Value, paramVector, sizeof(Value) * param.size());
 
     size_t c = 0;
     for (size_t i = 0; i < param.size(); i++) {
@@ -1417,7 +1410,7 @@ NEVER_INLINE void Interpreter::callIndirectOperation(
     }
 
     const ValueTypeVector& result = ft->result();
-    ALLOCA(Value, resultVector, sizeof(Value) * result.size(), isAllocaResult);
+    ALLOCA(Value, resultVector, sizeof(Value) * result.size());
     size_t codeExtraOffsetsSize = sizeof(ByteCodeStackOffset) * ft->param().size() + sizeof(ByteCodeStackOffset) * ft->result().size();
 
     target->call(state, param.size(), paramVector, resultVector);
@@ -1427,14 +1420,6 @@ NEVER_INLINE void Interpreter::callIndirectOperation(
         resultVector[i].writeToMemory(resultStackPointer);
     }
 
-    if (UNLIKELY(!isAllocaParam)) {
-        delete[] paramVector;
-    }
-    if (UNLIKELY(!isAllocaResult)) {
-        delete[] resultVector;
-    }
-
     programCounter += sizeof(CallIndirect) + codeExtraOffsetsSize;
 }
-
 } // namespace Walrus

--- a/src/runtime/Function.cpp
+++ b/src/runtime/Function.cpp
@@ -45,7 +45,7 @@ void DefinedFunction::call(ExecutionState& state, const uint32_t argc, Value* ar
 {
     ExecutionState newState(state, this);
     checkStackLimit(newState);
-    ALLOCA(uint8_t, functionStackBase, m_moduleFunction->requiredStackSize(), isAlloca);
+    ALLOCA(uint8_t, functionStackBase, m_moduleFunction->requiredStackSize());
     uint8_t* functionStackPointer = functionStackBase;
 
     // init parameter space
@@ -99,10 +99,6 @@ void DefinedFunction::call(ExecutionState& state, const uint32_t argc, Value* ar
     const ValueTypeVector& resultTypeInfo = ft->result();
     for (size_t i = 0; i < resultTypeInfo.size(); i++) {
         result[i] = Value(resultTypeInfo[i], functionStackBase + resultOffsets[i]);
-    }
-
-    if (UNLIKELY(!isAlloca)) {
-        delete[] functionStackBase;
     }
 }
 

--- a/src/runtime/Module.cpp
+++ b/src/runtime/Module.cpp
@@ -226,16 +226,12 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
             Walrus::Trap trap;
             trap.run([](Walrus::ExecutionState& state, void* d) {
                 RunData* data = reinterpret_cast<RunData*>(d);
-                ALLOCA(uint8_t, functionStackBase, data->mf->requiredStackSize(), isAlloca);
+                ALLOCA(uint8_t, functionStackBase, data->mf->requiredStackSize());
 
                 DefinedFunction fakeFunction(data->instance, data->mf);
                 ExecutionState newState(state, &fakeFunction);
                 auto resultOffset = Interpreter::interpret(newState, functionStackBase);
                 data->instance->m_globals[data->index]->setValue(Value(data->type, functionStackBase + resultOffset[0]));
-
-                if (UNLIKELY(!isAlloca)) {
-                    delete[] functionStackBase;
-                }
             },
                      &data);
         }
@@ -261,7 +257,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
                 Walrus::Trap trap;
                 trap.run([](Walrus::ExecutionState& state, void* d) {
                     RunData* data = reinterpret_cast<RunData*>(d);
-                    ALLOCA(uint8_t, functionStackBase, data->elem->moduleFunction()->requiredStackSize(), isAlloca);
+                    ALLOCA(uint8_t, functionStackBase, data->elem->moduleFunction()->requiredStackSize());
 
                     DefinedFunction fakeFunction(data->instance,
                                                  data->elem->moduleFunction());
@@ -270,10 +266,6 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
                     auto resultOffset = Interpreter::interpret(newState, functionStackBase);
                     Value offset(Value::I32, functionStackBase + resultOffset[0]);
                     data->index = offset.asI32();
-
-                    if (UNLIKELY(!isAlloca)) {
-                        delete[] functionStackBase;
-                    }
                 },
                          &data);
             }
@@ -312,7 +304,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
         auto result = trap.run([](Walrus::ExecutionState& state, void* d) {
             RunData* data = reinterpret_cast<RunData*>(d);
             if (data->init->moduleFunction()->currentByteCodeSize()) {
-                ALLOCA(uint8_t, functionStackBase, data->init->moduleFunction()->requiredStackSize(), isAlloca);
+                ALLOCA(uint8_t, functionStackBase, data->init->moduleFunction()->requiredStackSize());
 
                 DefinedFunction fakeFunction(data->instance,
                                              data->init->moduleFunction());
@@ -320,10 +312,6 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
 
                 auto resultOffset = Interpreter::interpret(newState, functionStackBase);
                 Value offset(Value::I32, functionStackBase + resultOffset[0]);
-
-                if (UNLIKELY(!isAlloca)) {
-                    delete[] functionStackBase;
-                }
 
                 Memory* m = data->instance->memory(0);
                 const auto& initData = data->init->initData();


### PR DESCRIPTION
If you don't use unique_ptr, the memory leak can occur if there is c++ exception.