### PR TITLE
Fix benchmark runner

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -212,6 +212,26 @@ jobs:
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 15
 
+  build-test-performance:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install Packages
+      run: |
+        sudo apt update
+        sudo apt install -y ninja-build gcc-multilib g++-multilib
+        sudo pip install py-markdown-table
+    - name: Build x64
+      env:
+        BUILD_OPTIONS: -DWALRUS_ARCH=x64 -DWALRUS_HOST=linux -DWALRUS_MODE=release -DWALRUS_OUTPUT=shell -GNinja
+      run: |
+        cmake -H. -Bout/linux/x64 $BUILD_OPTIONS
+        ninja -Cout/linux/x64
+    - name: Run Tests
+      run: test/wasmBenchmarker/benchmark.py --engines $GITHUB_WORKSPACE/out/linux/x64/walrus --iterations 3
+
   built-test-wasm-c-api:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
* use absolute path for test directory
* add a case where emsdk is already installed
* measure average execution time instead of min time