### PR TITLE
Improve function call performance

### DIFF
--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -18,6 +18,10 @@
 #define __WalrusInterpreter__
 
 #include "runtime/ExecutionState.h"
+#include "runtime/Function.h"
+#include "runtime/Instance.h"
+#include "runtime/Module.h"
+#include "runtime/Tag.h"
 #include "interpreter/ByteCode.h"
 
 namespace Walrus {
@@ -28,19 +32,78 @@ class Table;
 class Global;
 
 class Interpreter {
-public:
-    static ByteCodeStackOffset* interpret(ExecutionState& state,
-                                          uint8_t* bp);
-
 private:
     friend class ByteCodeTable;
+    friend class DefinedFunction;
+    friend class DefinedFunctionWithTryCatch;
+
+    template <const bool considerException>
+    ALWAYS_INLINE static void callInterpreter(ExecutionState& state, DefinedFunction* function, uint8_t* bp, ByteCodeStackOffset* offsets,
+                                              uint16_t parameterOffsetCount, uint16_t resultOffsetCount)
+    {
+        ExecutionState newState(state, function);
+        CHECK_STACK_LIMIT(newState);
+
+        auto moduleFunction = function->moduleFunction();
+        ALLOCA(uint8_t, functionStackBase, moduleFunction->requiredStackSize());
+
+        // init parameter space
+        for (size_t i = 0; i < parameterOffsetCount; i++) {
+            ((size_t*)functionStackBase)[i] = *((size_t*)(bp + offsets[i]));
+        }
+
+        size_t programCounter = reinterpret_cast<size_t>(moduleFunction->byteCode());
+        ByteCodeStackOffset* resultOffsets;
+        if (considerException) {
+            while (true) {
+                try {
+                    resultOffsets = interpret(newState, programCounter, functionStackBase, function->instance());
+                    break;
+                } catch (std::unique_ptr<Exception>& e) {
+                    for (size_t i = e->m_programCounterInfo.size(); i > 0; i--) {
+                        if (e->m_programCounterInfo[i - 1].first == &newState) {
+                            programCounter = e->m_programCounterInfo[i - 1].second;
+                            break;
+                        }
+                    }
+                    if (e->isUserException()) {
+                        bool isCatchSucessful = false;
+                        Tag* tag = e->tag().value();
+                        size_t offset = programCounter - reinterpret_cast<size_t>(moduleFunction->byteCode());
+                        for (const auto& item : moduleFunction->catchInfo()) {
+                            if (item.m_tryStart <= offset && offset < item.m_tryEnd) {
+                                if (item.m_tagIndex == std::numeric_limits<uint32_t>::max() || function->instance()->tag(item.m_tagIndex) == tag) {
+                                    programCounter = item.m_catchStartPosition + reinterpret_cast<size_t>(moduleFunction->byteCode());
+                                    uint8_t* sp = functionStackBase + item.m_stackSizeToBe;
+                                    if (item.m_tagIndex != std::numeric_limits<uint32_t>::max() && tag->functionType()->paramStackSize()) {
+                                        memcpy(sp, e->userExceptionData().data(), tag->functionType()->paramStackSize());
+                                    }
+                                    isCatchSucessful = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (isCatchSucessful) {
+                            continue;
+                        }
+                    }
+                    throw std::unique_ptr<Exception>(std::move(e));
+                }
+            }
+        } else {
+            resultOffsets = interpret(newState, programCounter, functionStackBase, function->instance());
+        }
+
+        offsets += parameterOffsetCount;
+        for (size_t i = 0; i < resultOffsetCount; i++) {
+            *((size_t*)(bp + offsets[i])) = *((size_t*)(functionStackBase + resultOffsets[i]));
+        }
+    }
+
     static ByteCodeStackOffset* interpret(ExecutionState& state,
                                           size_t programCounter,
                                           uint8_t* bp,
-                                          Instance* instance,
-                                          Memory** memories,
-                                          Table** tables,
-                                          Global** globals);
+                                          Instance* instance);
 
     static void callOperation(ExecutionState& state,
                               size_t& programCounter,

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -471,8 +471,8 @@ private:
     bool m_inInitExpr;
     Walrus::ModuleFunction* m_currentFunction;
     Walrus::FunctionType* m_currentFunctionType;
-    uint32_t m_initialFunctionStackSize;
-    uint32_t m_functionStackSizeSoFar;
+    uint16_t m_initialFunctionStackSize;
+    uint16_t m_functionStackSizeSoFar;
 
     std::vector<VMStackInfo> m_vmStack;
     std::vector<BlockInfo> m_blockInfo;
@@ -1879,6 +1879,7 @@ public:
     {
         BlockInfo b(BlockInfo::TryCatch, sigType, *this);
         m_blockInfo.push_back(b);
+        m_currentFunction->m_hasTryCatch = true;
     }
 
     void processCatchExpr(Index tagIndex)

--- a/src/runtime/Function.h
+++ b/src/runtime/Function.h
@@ -121,6 +121,22 @@ protected:
     ModuleFunction* m_moduleFunction;
 };
 
+class DefinedFunctionWithTryCatch : public DefinedFunction {
+    friend class DefinedFunction;
+    friend class Module;
+
+public:
+    virtual void interpreterCall(ExecutionState& state, uint8_t* bp, ByteCodeStackOffset* offsets,
+                                 uint16_t parameterOffsetCount, uint16_t resultOffsetCount) override;
+
+protected:
+    DefinedFunctionWithTryCatch(Instance* instance,
+                                ModuleFunction* moduleFunction)
+        : DefinedFunction(instance, moduleFunction)
+    {
+    }
+};
+
 class ImportedFunction : public Function {
 public:
     typedef std::function<void(ExecutionState& state, Value* argv, Value* result, void* data)> ImportedFunctionCallback;

--- a/src/runtime/Instance.cpp
+++ b/src/runtime/Instance.cpp
@@ -51,6 +51,11 @@ void Instance::freeInstance(Instance* instance)
 
 Instance::Instance(Module* module)
     : m_module(module)
+    , m_memories(nullptr)
+    , m_globals(nullptr)
+    , m_tables(nullptr)
+    , m_functions(nullptr)
+    , m_tags(nullptr)
 {
     module->store()->appendInstance(this);
 }

--- a/src/runtime/Instance.h
+++ b/src/runtime/Instance.h
@@ -124,7 +124,7 @@ private:
     Instance(Module* module);
     ~Instance() {}
 
-    static size_t alignedSize()
+    static constexpr size_t alignedSize()
     {
         return (sizeof(Instance) + sizeof(void*) - 1) & ~(sizeof(void*) - 1);
     }

--- a/src/runtime/Module.h
+++ b/src/runtime/Module.h
@@ -175,8 +175,9 @@ public:
 
     ModuleFunction(FunctionType* functionType);
 
+    bool hasTryCatch() const { return m_hasTryCatch; }
+    uint16_t requiredStackSize() const { return m_requiredStackSize; }
     FunctionType* functionType() const { return m_functionType; }
-    uint32_t requiredStackSize() const { return m_requiredStackSize; }
 
     template <typename CodeType>
     void pushByteCode(const CodeType& code)
@@ -218,8 +219,9 @@ public:
     }
 
 private:
+    bool m_hasTryCatch;
+    uint16_t m_requiredStackSize;
     FunctionType* m_functionType;
-    uint32_t m_requiredStackSize;
     ValueTypeVector m_local;
     Vector<uint8_t, std::allocator<uint8_t>> m_byteCode;
 #if !defined(NDEBUG)


### PR DESCRIPTION
* Divide function into user-defined function and user-defined function /w try-catch
* Non try-catch user-defined function should not use c++ try-catch
* Reduce parameter count of Interpreter::interpret