### PR TITLE
Align memory to pointer size.

### DIFF
--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -54,25 +54,25 @@ size_t ByteCode::getSize()
     switch (this->opcode()) {
     case ThrowOpcode: {
         Throw* throwCode = reinterpret_cast<Throw*>(this);
-        return sizeof(Throw) + sizeof(ByteCodeStackOffset) * throwCode->offsetsSize();
+        return ByteCode::pointerAlignedSize(sizeof(Throw) + sizeof(ByteCodeStackOffset) * throwCode->offsetsSize());
     }
     case CallOpcode: {
         Call* call = reinterpret_cast<Call*>(this);
-        return sizeof(Call) + sizeof(ByteCodeStackOffset) * call->parameterOffsetsSize()
-            + sizeof(ByteCodeStackOffset) * call->resultOffsetsSize();
+        return ByteCode::pointerAlignedSize(sizeof(Call) + sizeof(ByteCodeStackOffset) * call->parameterOffsetsSize()
+                                            + sizeof(ByteCodeStackOffset) * call->resultOffsetsSize());
     }
     case BrTableOpcode: {
         BrTable* brTable = reinterpret_cast<BrTable*>(this);
-        return sizeof(BrTable) + sizeof(int32_t) * brTable->tableSize();
+        return ByteCode::pointerAlignedSize(sizeof(BrTable) + sizeof(int32_t) * brTable->tableSize());
     }
     case CallIndirectOpcode: {
         CallIndirect* callIndirect = reinterpret_cast<CallIndirect*>(this);
-        return sizeof(CallIndirect) + sizeof(ByteCodeStackOffset) * callIndirect->parameterOffsetsSize()
-            + sizeof(ByteCodeStackOffset) * callIndirect->resultOffsetsSize();
+        return ByteCode::pointerAlignedSize(sizeof(CallIndirect) + sizeof(ByteCodeStackOffset) * callIndirect->parameterOffsetsSize()
+                                            + sizeof(ByteCodeStackOffset) * callIndirect->resultOffsetsSize());
     }
     case EndOpcode: {
         End* end = reinterpret_cast<End*>(this);
-        return sizeof(End) + sizeof(ByteCodeStackOffset) * end->offsetsSize();
+        return ByteCode::pointerAlignedSize(sizeof(End) + sizeof(ByteCodeStackOffset) * end->offsetsSize());
     }
     default: {
         return g_byteCodeSize[this->opcode()];

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -528,6 +528,11 @@ public:
     };
     // clang-format on
 
+    static size_t pointerAlignedSize(const size_t originalSize)
+    {
+        return (originalSize + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1);
+    }
+
     Opcode opcode() const;
     size_t getSize();
 

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -1313,8 +1313,8 @@ NEVER_INLINE void Interpreter::callOperation(
     Call* code = (Call*)programCounter;
     Function* target = instance->function(code->index());
     target->interpreterCall(state, bp, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize());
-    programCounter += (sizeof(Call) + sizeof(ByteCodeStackOffset) * code->parameterOffsetsSize()
-                       + sizeof(ByteCodeStackOffset) * code->resultOffsetsSize());
+    programCounter += ByteCode::pointerAlignedSize(sizeof(Call) + sizeof(ByteCodeStackOffset) * code->parameterOffsetsSize()
+                                                   + sizeof(ByteCodeStackOffset) * code->resultOffsetsSize());
 }
 
 NEVER_INLINE void Interpreter::callIndirectOperation(
@@ -1340,7 +1340,7 @@ NEVER_INLINE void Interpreter::callIndirectOperation(
     }
 
     target->interpreterCall(state, bp, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize());
-    programCounter += (sizeof(CallIndirect) + sizeof(ByteCodeStackOffset) * code->parameterOffsetsSize()
-                       + sizeof(ByteCodeStackOffset) * code->resultOffsetsSize());
+    programCounter += ByteCode::pointerAlignedSize(sizeof(CallIndirect) + sizeof(ByteCodeStackOffset) * code->parameterOffsetsSize()
+                                                   + sizeof(ByteCodeStackOffset) * code->resultOffsetsSize());
 }
 } // namespace Walrus

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -1164,7 +1164,8 @@ public:
         auto resultCount = computeFunctionParameterOrResultOffsetCount(functionType->result());
         pushByteCode(Walrus::Call(index, parameterCount, resultCount), WASMOpcode::CallOpcode);
 
-        m_currentFunction->expandByteCode(sizeof(Walrus::ByteCodeStackOffset) * (parameterCount + resultCount));
+        m_currentFunction->expandByteCode(Walrus::ByteCode::pointerAlignedSize(sizeof(Walrus::ByteCodeStackOffset) * (parameterCount + resultCount)));
+        ASSERT(m_currentFunction->currentByteCodeSize() % sizeof(void*) == 0);
         auto code = m_currentFunction->peekByteCode<Walrus::Call>(callPos);
 
         generateCallExpr(code, parameterCount, resultCount, functionType);
@@ -1179,7 +1180,8 @@ public:
         auto resultCount = computeFunctionParameterOrResultOffsetCount(functionType->result());
         pushByteCode(Walrus::CallIndirect(popVMStack(), tableIndex, functionType, parameterCount, resultCount),
                      WASMOpcode::CallIndirectOpcode);
-        m_currentFunction->expandByteCode(sizeof(Walrus::ByteCodeStackOffset) * (parameterCount + resultCount));
+        m_currentFunction->expandByteCode(Walrus::ByteCode::pointerAlignedSize(sizeof(Walrus::ByteCodeStackOffset) * (parameterCount + resultCount)));
+        ASSERT(m_currentFunction->currentByteCodeSize() % sizeof(void*) == 0);
 
         auto code = m_currentFunction->peekByteCode<Walrus::CallIndirect>(callPos);
         generateCallExpr(code, parameterCount, resultCount, functionType);
@@ -1626,7 +1628,8 @@ public:
         pushByteCode(Walrus::End(offsetCount), WASMOpcode::EndOpcode);
 
         auto& result = m_currentFunctionType->result();
-        m_currentFunction->expandByteCode(sizeof(Walrus::ByteCodeStackOffset) * offsetCount);
+        m_currentFunction->expandByteCode(Walrus::ByteCode::pointerAlignedSize(sizeof(Walrus::ByteCodeStackOffset) * offsetCount));
+        ASSERT(m_currentFunction->currentByteCodeSize() % sizeof(void*) == 0);
         Walrus::End* end = m_currentFunction->peekByteCode<Walrus::End>(pos);
         size_t offsetIndex = 0;
         for (size_t i = 0; i < result.size(); i++) {
@@ -1820,7 +1823,8 @@ public:
         pushByteCode(Walrus::BrTable(stackPos, numTargets), WASMOpcode::BrTableOpcode);
 
         if (numTargets) {
-            m_currentFunction->expandByteCode(sizeof(int32_t) * numTargets);
+            m_currentFunction->expandByteCode(Walrus::ByteCode::pointerAlignedSize(sizeof(int32_t) * numTargets));
+            ASSERT(m_currentFunction->currentByteCodeSize() % sizeof(void*) == 0);
 
             for (Index i = 0; i < numTargets; i++) {
                 emitBrTableCase(brTableCode, targetDepths[i], sizeof(Walrus::BrTable) + i * sizeof(int32_t));
@@ -1860,7 +1864,8 @@ public:
         if (tagIndex != std::numeric_limits<Index>::max()) {
             auto functionType = m_result.m_functionTypes[m_result.m_tagTypes[tagIndex]->sigIndex()];
             auto& param = functionType->param();
-            m_currentFunction->expandByteCode(sizeof(Walrus::ByteCodeStackOffset) * param.size());
+            m_currentFunction->expandByteCode(Walrus::ByteCode::pointerAlignedSize(sizeof(Walrus::ByteCodeStackOffset) * param.size()));
+            ASSERT(m_currentFunction->currentByteCodeSize() % sizeof(void*) == 0);
             Walrus::Throw* code = m_currentFunction->peekByteCode<Walrus::Throw>(pos);
             for (size_t i = 0; i < param.size(); i++) {
                 code->dataOffsets()[param.size() - i - 1] = (m_vmStack.rbegin() + i)->position();


### PR DESCRIPTION
Some architectures like ARM32 doesn't support non-aligned memory operations thus I aligned the memory.

Without it Walrus crashes on ARM32.