### PR TITLE
Fix for i64.const store with computed offset

### DIFF
--- a/src/jit/MemoryInl.h
+++ b/src/jit/MemoryInl.h
@@ -701,10 +701,10 @@ static void emitStore(sljit_compiler* compiler, Instruction* instr)
 
             if (SLJIT_IS_MEM(valueArgPair.arg1)) {
                 addr.options = MemAddress::LoadToReg2;
+            }
 
-                if (opcode == SLJIT_MOV) {
-                    addr.options |= MemAddress::DontSetR1;
-                }
+            if (opcode == SLJIT_MOV && !SLJIT_IS_REG(valueArgPair.arg1)) {
+                addr.options |= MemAddress::DontSetR1;
             }
         }
 #else /* !SLJIT_32BIT_ARCHITECTURE */

--- a/test/jit/indirect_i64_const_store.wast
+++ b/test/jit/indirect_i64_const_store.wast
@@ -1,0 +1,15 @@
+(module
+ (memory 1 1)
+ ;; regression test for 32bit JIT
+ (func (export "i64_indirect_store_const") (param i32)
+    (i64.store
+        (local.get 0)
+        (i64.const 0xcafebabe)
+    )
+ )
+ (func (export "i64_load") (param i32) (result i64)
+    (i64.load (local.get 0))
+ )
+)
+(invoke "i64_indirect_store_const" (i32.const 10))
+(assert_return (invoke "i64_load" (i32.const 10)) (i64.const 0xcafebabe))


### PR DESCRIPTION
As I understand it, the JIT had a bug where it would clobber registers on 32 bit ISAs with 64 bit stores when the offset was computed and the data was a constant.  I discovered the bug while running the `k_nucleotide` test on ARM, then we debugged it with @zherczeg , plus I added a regression test for it and verified that it indeed catches the bug on x86 and ARM.