### PR TITLE
Implement 128 bit select in JIT

### DIFF
--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -344,6 +344,8 @@ static void simdOperandToArg(sljit_compiler* compiler, Operand* operand, JITArg&
 
 #include "FloatMathInl.h"
 
+void emitSelect128(sljit_compiler*, Instruction*, sljit_s32);
+
 #if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
 #include "IntMath32Inl.h"
 #else /* !SLJIT_32BIT_ARCHITECTURE */

--- a/src/jit/IntMath32Inl.h
+++ b/src/jit/IntMath32Inl.h
@@ -866,6 +866,14 @@ void emitSelect(sljit_compiler* compiler, Instruction* instr, sljit_s32 type)
         return emitFloatSelect(compiler, instr, type);
     }
 
+    if (select->valueSize() == 16) {
+#ifdef HAS_SIMD
+        return emitSelect128(compiler, instr, type);
+#else /* HAS_SIMD */
+        RELEASE_ASSERT_NOT_REACHED();
+#endif /* HAS_SIMD */
+    }
+
     if (select->valueSize() == 4) {
         JITArg args[3] = { operands, operands + 1, operands + 3 };
 

--- a/src/jit/IntMath64Inl.h
+++ b/src/jit/IntMath64Inl.h
@@ -355,6 +355,14 @@ void emitSelect(sljit_compiler* compiler, Instruction* instr, sljit_s32 type)
         return emitFloatSelect(compiler, instr, type);
     }
 
+    if (select->valueSize() == 16) {
+#ifdef HAS_SIMD
+        return emitSelect128(compiler, instr, type);
+#else /* HAS_SIMD */
+        RELEASE_ASSERT_NOT_REACHED();
+#endif /* HAS_SIMD */
+    }
+
     bool is32 = select->valueSize() == 4;
     sljit_s32 movOpcode = is32 ? SLJIT_MOV32 : SLJIT_MOV;
     JITArg args[3] = { operands, operands + 1, operands + 3 };

--- a/test/basic/v128_select.wast
+++ b/test/basic/v128_select.wast
@@ -1,0 +1,22 @@
+(module
+  (func (export "select128") (param i32) (result v128)
+    v128.const i64x2 0xaaaaaaaaaaaaaaaa 0xaaaaaaaaaaaaaaaa
+    v128.const i64x2 0xbbbbbbbbbbbbbbbb 0xbbbbbbbbbbbbbbbb
+    local.get 0
+    select
+  )
+
+  (func (export "cmp_select128") (param i32) (result v128)
+    v128.const i64x2 0xaaaaaaaaaaaaaaaa 0xaaaaaaaaaaaaaaaa
+    v128.const i64x2 0xbbbbbbbbbbbbbbbb 0xbbbbbbbbbbbbbbbb
+    local.get 0
+    i32.const 1234
+    i32.eq
+    select
+  )
+)
+
+(assert_return (invoke "select128" (i32.const -1)) (v128.const i64x2 0xaaaaaaaaaaaaaaaa 0xaaaaaaaaaaaaaaaa))
+(assert_return (invoke "select128" (i32.const 0)) (v128.const i64x2 0xbbbbbbbbbbbbbbbb 0xbbbbbbbbbbbbbbbb))
+(assert_return (invoke "cmp_select128" (i32.const 1234)) (v128.const i64x2 0xaaaaaaaaaaaaaaaa 0xaaaaaaaaaaaaaaaa))
+(assert_return (invoke "cmp_select128" (i32.const 0)) (v128.const i64x2 0xbbbbbbbbbbbbbbbb 0xbbbbbbbbbbbbbbbb))


### PR DESCRIPTION
This commit implements `select` for `v128` arguments for architectures that support SIMD and adds a check so it no longer fails silently if it's unsupported.

Caveat: It also adds a new test, but it fails under ARM 32 on the CI.  As I understand it, we do not currently care about emulating SIMD in the JIT, so that's expected.  Should the test be disabled in JIT when there is no SIMD support, or is the CI not set up correctly and the ARM 32 runner should be fixed to support SIMD?

cc: @zherczeg