### PR TITLE
Re-enable float select

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -1132,10 +1132,11 @@ protected:
 
 class Select : public ByteCode {
 public:
-    Select(ByteCodeStackOffset condOffset, uint16_t size, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst)
+    Select(ByteCodeStackOffset condOffset, uint16_t size, bool isFloat, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst)
         : ByteCode(Opcode::SelectOpcode)
         , m_condOffset(condOffset)
         , m_valueSize(size)
+        , m_isFloat(isFloat)
         , m_src0Offset(src0)
         , m_src1Offset(src1)
         , m_dstOffset(dst)
@@ -1143,10 +1144,8 @@ public:
     }
 
     ByteCodeStackOffset condOffset() const { return m_condOffset; }
-    uint16_t valueSize() const
-    {
-        return m_valueSize;
-    }
+    uint16_t valueSize() const { return m_valueSize; }
+    bool isFloat() const { return m_isFloat != 0; }
     ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
     ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
@@ -1164,7 +1163,8 @@ public:
 
 protected:
     ByteCodeStackOffset m_condOffset;
-    uint16_t m_valueSize;
+    uint8_t m_valueSize;
+    uint8_t m_isFloat;
     ByteCodeStackOffset m_src0Offset;
     ByteCodeStackOffset m_src1Offset;
     ByteCodeStackOffset m_dstOffset;

--- a/src/jit/IntMath32Inl.h
+++ b/src/jit/IntMath32Inl.h
@@ -860,11 +860,13 @@ void emitSelect(sljit_compiler* compiler, Instruction* instr, sljit_s32 type)
     JITArg cond;
     ASSERT(instr->opcode() == ByteCode::SelectOpcode && instr->paramCount() == 3);
 
-    if (false) {
+    Select* select = reinterpret_cast<Select*>(instr->byteCode());
+
+    if (select->isFloat()) {
         return emitFloatSelect(compiler, instr, type);
     }
 
-    if (reinterpret_cast<Select*>(instr->byteCode())->valueSize() == 4) {
+    if (select->valueSize() == 4) {
         JITArg args[3] = { operands, operands + 1, operands + 3 };
 
         if (type == -1) {

--- a/src/jit/IntMath64Inl.h
+++ b/src/jit/IntMath64Inl.h
@@ -349,11 +349,13 @@ void emitSelect(sljit_compiler* compiler, Instruction* instr, sljit_s32 type)
     Operand* operands = instr->operands();
     assert(instr->opcode() == ByteCode::SelectOpcode && instr->paramCount() == 3);
 
-    if (false) {
+    Select* select = reinterpret_cast<Select*>(instr->byteCode());
+
+    if (select->isFloat()) {
         return emitFloatSelect(compiler, instr, type);
     }
 
-    bool is32 = reinterpret_cast<Select*>(instr->byteCode())->valueSize() == 4;
+    bool is32 = select->valueSize() == 4;
     sljit_s32 movOpcode = is32 ? SLJIT_MOV32 : SLJIT_MOV;
     JITArg args[3] = { operands, operands + 1, operands + 3 };
 

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -1847,7 +1847,8 @@ public:
         auto src1 = popVMStack();
         auto src0 = popVMStack();
         auto dst = computeExprResultPosition(type);
-        pushByteCode(Walrus::Select(stackPos, Walrus::valueSize(type), src0, src1, dst), WASMOpcode::SelectOpcode);
+        bool isFloat = type == Walrus::Value::F32 || type == Walrus::Value::F64;
+        pushByteCode(Walrus::Select(stackPos, Walrus::valueSize(type), isFloat, src0, src1, dst), WASMOpcode::SelectOpcode);
     }
 
     virtual void OnThrowExpr(Index tagIndex) override


### PR DESCRIPTION
The 16 bit value is split into two 8 bit value, so it does not affect interpreter.