### PR TITLE
Implement directory mapping and WASI file functions

### DIFF
--- a/src/runtime/SpecTest.h
+++ b/src/runtime/SpecTest.h
@@ -29,6 +29,8 @@ public:
         I32_RI32,
         I32I32_RI32,
         I32I32I32I32_RI32,
+        I32I64I32I32_RI32,
+        I32I32I32I32I32I64I64I32I32_RI32,
         RI32,
         I64R,
         F32R,
@@ -83,6 +85,33 @@ public:
             result = new ValueTypeVector();
             param->push_back(Value::Type::I32);
             param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I32);
+            result->push_back(Value::Type::I32);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // I32I64I32I32_RI32
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I64);
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I32);
+            result->push_back(Value::Type::I32);
+            m_vector[index++] = new FunctionType(param, result);
+        }
+        {
+            // I32I32I32I32I32I64I64I32I32_RI32
+            param = new ValueTypeVector();
+            result = new ValueTypeVector();
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I32);
+            param->push_back(Value::Type::I64);
+            param->push_back(Value::Type::I64);
             param->push_back(Value::Type::I32);
             param->push_back(Value::Type::I32);
             result->push_back(Value::Type::I32);

--- a/src/wasi/Environ.h
+++ b/src/wasi/Environ.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023-present Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Walrus {
+
+void WASI::environ_sizes_get(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t count = argv[0].asI32();
+    uint32_t buf = argv[1].asI32();
+
+    uvwasi_size_t* uvCount = reinterpret_cast<uvwasi_size_t*>(instance->memory(0)->buffer() + count);
+    uvwasi_size_t* uvBufSize = reinterpret_cast<uvwasi_size_t*>(instance->memory(0)->buffer() + buf);
+
+    result[0] = Value(static_cast<uint16_t>(uvwasi_environ_sizes_get(WASI::m_uvwasi, uvCount, uvBufSize)));
+}
+
+void WASI::environ_get(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t env = argv[0].asI32();
+    uint32_t environBuf = argv[1].asI32();
+
+    char** uvEnviron = reinterpret_cast<char**>(instance->memory(0)->buffer() + env);
+    char* uvEnvironBuf = reinterpret_cast<char*>(instance->memory(0)->buffer() + environBuf);
+
+    result[0] = Value(static_cast<uint16_t>(uvwasi_environ_get(WASI::m_uvwasi, uvEnviron, uvEnvironBuf)));
+}
+
+} // namespace Walrus

--- a/src/wasi/Fd.h
+++ b/src/wasi/Fd.h
@@ -31,13 +31,52 @@ void WASI::fd_write(ExecutionState& state, Value* argv, Value* result, Instance*
     std::vector<uvwasi_ciovec_t> iovs(iovcnt);
     for (uint32_t i = 0; i < iovcnt; i++) {
         iovs[i].buf = instance->memory(0)->buffer() + *reinterpret_cast<uint32_t*>(instance->memory(0)->buffer() + iovptr + i * 8);
-        iovs[i].buf_len = *(instance->memory(0)->buffer() + iovptr + 4 + i * 8);
+        iovs[i].buf_len = *reinterpret_cast<uint32_t*>(instance->memory(0)->buffer() + iovptr + 4 + i * 8);
     }
 
-    uvwasi_size_t out_addr = *(instance->memory(0)->buffer() + out);
+    uvwasi_size_t* out_addr = (uvwasi_size_t*)(instance->memory(0)->buffer() + out);
 
-    result[0] = Value(static_cast<int16_t>(uvwasi_fd_write(WASI::m_uvwasi, fd, iovs.data(), iovs.size(), &out_addr)));
-    *(instance->memory(0)->buffer() + out) = out_addr;
+    result[0] = Value(static_cast<int16_t>(uvwasi_fd_write(WASI::m_uvwasi, fd, iovs.data(), iovs.size(), out_addr)));
+    *(instance->memory(0)->buffer() + out) = *out_addr;
+}
+
+void WASI::fd_read(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t fd = argv[0].asI32();
+    uint32_t iovptr = argv[1].asI32();
+    uint32_t iovcnt = argv[2].asI32();
+    uint32_t out = argv[3].asI32();
+
+    std::vector<uvwasi_iovec_t> iovs(iovcnt);
+    for (uint32_t i = 0; i < iovcnt; i++) {
+        iovs[i].buf = instance->memory(0)->buffer() + *reinterpret_cast<uint32_t*>(instance->memory(0)->buffer() + iovptr + i * 8);
+        iovs[i].buf_len = *reinterpret_cast<uint32_t*>(instance->memory(0)->buffer() + iovptr + 4 + i * 8);
+    }
+
+    uvwasi_size_t* out_addr = (uvwasi_size_t*)(instance->memory(0)->buffer() + out);
+
+    result[0] = Value(static_cast<int16_t>(uvwasi_fd_read(WASI::m_uvwasi, fd, iovs.data(), iovs.size(), out_addr)));
+    *(instance->memory(0)->buffer() + out) = *out_addr;
+}
+
+void WASI::fd_close(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t fd = argv[0].asI32();
+
+    result[0] = Value(static_cast<int16_t>(uvwasi_fd_close(WASI::m_uvwasi, fd)));
+}
+
+void WASI::fd_seek(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t fd = argv[0].asI32();
+    uint64_t fileDelta = argv[1].asI32();
+    uint32_t whence = argv[2].asI32();
+    uint64_t newOffset = argv[3].asI32();
+
+    uvwasi_filesize_t out_addr = *(instance->memory(0)->buffer() + newOffset);
+
+    result[0] = Value(static_cast<int16_t>(uvwasi_fd_seek(WASI::m_uvwasi, fd, fileDelta, whence, &out_addr)));
+    *(instance->memory(0)->buffer() + newOffset) = out_addr;
 }
 
 } // namespace Walrus

--- a/src/wasi/Path.h
+++ b/src/wasi/Path.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023-present Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Walrus {
+
+void WASI::path_open(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t fd = argv[0].asI32();
+    uint32_t dirflags = argv[1].asI32();
+    uint32_t path_offset = argv[2].asI32();
+    uint32_t len = argv[3].asI32();
+    uint32_t oflags = argv[4].asI32();
+    uint64_t rights = argv[5].asI64();
+    uint64_t right_inheriting = argv[6].asI64();
+    uint32_t fdflags = argv[7].asI32();
+    uint32_t ret_fd_offset = argv[8].asI32();
+
+    uvwasi_fd_t* ret_fd = reinterpret_cast<uvwasi_fd_t*>(instance->memory(0)->buffer() + ret_fd_offset);
+
+    const char* path = reinterpret_cast<char*>(instance->memory(0)->buffer() + path_offset);
+
+    result[0] = Value(static_cast<uint16_t>(
+        uvwasi_path_open(WASI::m_uvwasi,
+                         fd,
+                         dirflags,
+                         path,
+                         len,
+                         oflags,
+                         rights,
+                         right_inheriting,
+                         fdflags,
+                         ret_fd)));
+}
+
+} // namespace Walrus

--- a/src/wasi/Wasi.h
+++ b/src/wasi/Wasi.h
@@ -116,11 +116,12 @@ public:
 #undef TO_ENUM
     // end of type definitions
 
-    WASI();
+    WASI(std::vector<uvwasi_preopen_s>& preopenDirs, bool shareHostEnv);
 
     ~WASI()
     {
         ::uvwasi_destroy(m_uvwasi);
+        free(m_uvwasi);
     }
 
     struct WasiFunc {
@@ -129,11 +130,17 @@ public:
         WasiFunction::WasiFunctionCallback ptr;
     };
 
-#define FOR_EACH_WASI_FUNC(F)  \
-    F(proc_exit, I32R)         \
-    F(proc_raise, I32_RI32)    \
-    F(random_get, I32I32_RI32) \
-    F(fd_write, I32I32I32I32_RI32)
+#define FOR_EACH_WASI_FUNC(F)                      \
+    F(proc_exit, I32R)                             \
+    F(proc_raise, I32_RI32)                        \
+    F(random_get, I32I32_RI32)                     \
+    F(fd_write, I32I32I32I32_RI32)                 \
+    F(fd_read, I32I32I32I32_RI32)                  \
+    F(fd_close, I32_RI32)                          \
+    F(fd_seek, I32I64I32I32_RI32)                  \
+    F(path_open, I32I32I32I32I32I64I64I32I32_RI32) \
+    F(environ_get, I32I32_RI32)                    \
+    F(environ_sizes_get, I32I32_RI32)
 
     enum WasiFuncName : size_t {
 #define DECLARE_FUNCTION(NAME, FUNCTYPE) NAME##FUNC,
@@ -150,6 +157,12 @@ public:
     static void proc_exit(ExecutionState& state, Value* argv, Value* result, Instance* instance);
     static void proc_raise(ExecutionState& state, Value* argv, Value* result, Instance* instance);
     static void fd_write(ExecutionState& state, Value* argv, Value* result, Instance* instance);
+    static void fd_read(ExecutionState& state, Value* argv, Value* result, Instance* instance);
+    static void fd_close(ExecutionState& state, Value* argv, Value* result, Instance* instance);
+    static void fd_seek(ExecutionState& state, Value* argv, Value* result, Instance* instance);
+    static void path_open(ExecutionState& state, Value* argv, Value* result, Instance* instance);
+    static void environ_get(ExecutionState& state, Value* argv, Value* result, Instance* instance);
+    static void environ_sizes_get(ExecutionState& state, Value* argv, Value* result, Instance* instance);
     static void random_get(ExecutionState& state, Value* argv, Value* result, Instance* instance);
 
     static WasiFunc m_wasiFunctions[FuncEnd];

--- a/test/wasi/environ.wast
+++ b/test/wasi/environ.wast
@@ -1,0 +1,75 @@
+(module
+  (import "wasi_snapshot_preview1" "fd_write" (func $wasi_fd_write (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "environ_get" (func $wasi_environ_get (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "environ_sizes_get" (func $wasi_environ_sizes_get (param i32 i32) (result i32)))
+  (memory 1)
+  
+  (export "memory" (memory 0))
+  (export "environ" (func $environ))
+  (data (i32.const 100) "500" )
+
+  (func $environ
+  (local $i i32)
+    i32.const 0 ;; environment variables count
+    i32.const 12 ;; environment variables overall size in characters
+    call $wasi_environ_sizes_get
+    drop
+
+    i32.const 500 ;; envp
+    i32.const 500 ;; envp[0]
+    call $wasi_environ_get
+    drop
+
+    ;; Memory + 50 = 500, start of output string.
+    i32.const 50
+    i32.const 500
+    i32.store
+
+    ;; Memory + 54 = size of output string.
+    i32.const 54
+    i32.const 12
+    i32.load
+    i32.store
+    
+    ;; Replace '\0' with '\n' for readable printing.
+    i32.const 0
+    local.set $i
+    (loop $loop
+      i32.const 500
+      local.get $i
+      i32.add
+      i32.load8_u
+
+      i32.eqz
+      (if
+        (then
+          i32.const 500
+          local.get $i
+          i32.add
+          i32.const 10
+          i32.store8
+        )
+      )
+
+      local.get $i
+      i32.const 1
+      i32.add
+      local.tee $i
+
+      i32.const 12
+      i32.load
+      i32.lt_u
+      br_if $loop
+    )
+
+    (call $wasi_fd_write
+          (i32.const 1)  ;;file descriptor
+          (i32.const 50) ;;offset of str offset
+          (i32.const 1)  ;;iovec length
+          (i32.const 200) ;;result offset
+    )
+    drop
+  )
+)
+
+(assert_return (invoke "environ"))

--- a/test/wasi/hello_world.wast
+++ b/test/wasi/hello_world.wast
@@ -1,5 +1,5 @@
 (module
-  (import "wasi_snapshot_preview1" "fd_write" (func $wasi_fd_write (param i32 i32 i32 i32) (result i32))) 
+  (import "wasi_snapshot_preview1" "fd_write" (func $wasi_fd_write (param i32 i32 i32 i32) (result i32)))
   (memory 1)
   
   (export "memory" (memory 0))

--- a/test/wasi/random_get.wast
+++ b/test/wasi/random_get.wast
@@ -1,10 +1,21 @@
 (module
   (import "wasi_snapshot_preview1" "random_get" (func $random (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
   (memory 1)
   (export "_start" (func $_start))
   (func $_start
     (call $random (i32.const 10) (i32.const 5))
-    drop
+    i32.eqz
+    (if
+      (then
+        i32.const 0
+        call $proc_exit
+      )
+      (else
+        i32.const 1
+        call $proc_exit
+      )
+    )
   )
 )
 

--- a/test/wasi/read_from_file.wast
+++ b/test/wasi/read_from_file.wast
@@ -1,0 +1,64 @@
+(module
+ (import "wasi_snapshot_preview1" "path_open" (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write" (func $wasi_fd_write (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_read" (func $wasi_fd_read (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+  
+
+  (memory 1)
+  
+  (export "memory" (memory 0))
+  (export "read_from_file" (func $read_from_file))
+  (data (i32.const 300) "./write_to_this.txt")
+
+  (; This test searches for the file 'write_to_this.txt' in the first opened directory 
+     and reads 13 characters out of it.
+     It will only read from the file if the directories were mapped correctly ;)
+
+  (func $read_from_file
+
+    i32.const 3 ;; Directory file descriptior, by default 3 is the first opened directory
+    i32.const 1 ;;lookupflags: directory
+    i32.const 300 ;; Offset of file name in memory
+    i32.const 19 ;; Length of file name
+    i32.const 0 ;; oflags: none
+    i64.const 4098 ;; rights: path_open, fd_read
+    i64.const 4098 ;; rights_inheriting: path_open, fd_read
+    i32.const 0 ;; fdflags: none
+    i32.const 0 ;; Offset to store at the opened file descriptor in memory
+    call $path_open
+    
+    i32.eqz ;; fail if file could not be opened
+    (if
+      (then)
+      (else
+        i32.const 1
+        call $proc_exit
+      )
+    )
+
+    (i32.store (i32.const 104) (i32.const 13))
+    (i32.store (i32.const 100) (i32.const 0))
+    (i32.store (i32.const 200) (i32.const 500))
+
+    (call $wasi_fd_read
+      (i32.const 0)
+      (i32.load) ;; opened file descriptor
+      
+      (i32.const 100) ;; store content at this location
+      (i32.const 1) ;; make it into a single buffer
+      (i32.const 200) ;; store number of read characters to this location
+    )
+    drop
+
+    (call $wasi_fd_write
+          (i32.const 1)  ;;file descriptor
+          (i32.const 100) ;;offset of str offset
+          (i32.const 1)  ;;iovec length
+          (i32.const 200) ;;result offset
+    )
+    drop
+  )
+)
+
+(assert_return (invoke "read_from_file"))

--- a/test/wasi/write_to_file.wast
+++ b/test/wasi/write_to_file.wast
@@ -1,0 +1,53 @@
+(module
+  (import "wasi_snapshot_preview1" "path_open" (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))  
+  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+
+  (memory $memory 1)
+  (data (i32.const 200) "Hello World!\n") ;; String we want to write to file
+  (data (i32.const 300) "./write_to_this.txt") ;; Filename in current directory (where Walrus is ran from)
+
+  (; This test searches for the file 'write_to_this.txt' in the first opened directory.
+          It will only write into the file if the directories were mapped correctly. ;)
+
+  (func $write_to_file
+    i32.const 3 ;; Directory file descriptior, by default 3 is the first opened directory
+    i32.const 1 ;; lookupflags: directory
+    i32.const 300 ;; Offset of file name in memory
+    i32.const 19 ;; Length of file name
+    i32.const 0 ;; oflags: none
+    i64.const 8256 ;; rights: path_open, fd_write
+    i64.const 8256 ;; rights_inheriting: path_open, fd_write
+    i32.const 0 ;; fdflags: none
+    i32.const 0 ;; Offset to store at the opened file descriptor in memory
+    call $path_open
+
+    i32.eqz ;; fail if file could not be opened
+    (if
+      (then)
+      (else
+        i32.const 1
+        call $proc_exit
+      )
+    )
+
+    i32.const 500 ;; offset of str offset
+    i32.const 200 ;; offset of str
+    i32.store
+
+    i32.const 504 ;; str length offset
+    i32.const 13
+    i32.store
+
+    i32.const 0 ;; load file descriptior
+    i32.load
+    i32.const 500 ;; offset of str offset
+    i32.const 1 ;; iovec length
+    i32.const 0 ;; offset of written characters
+    call $fd_write
+    drop
+  )
+
+  (export "_start" (func $write_to_file))
+  (export "memory" (memory 0))
+)

--- a/test/wasi/write_to_this.txt
+++ b/test/wasi/write_to_this.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -20,7 +20,8 @@ import os
 import traceback
 import sys
 import time
-import re, fnmatch
+import re
+import fnmatch
 
 from argparse import ArgumentParser
 from difflib import unified_diff
@@ -101,10 +102,11 @@ def readfile(filename):
     with open(filename, 'r') as f:
         return f.readlines()
 
+
 def _run_wast_tests(engine, files, is_fail):
     fails = 0
     for file in files:
-        proc = Popen([engine, file], stdout=PIPE) if not jit else Popen([engine, '--jit', file], stdout=PIPE)
+        proc = Popen([engine, "--mapdirs", "./test/wasi", "/var", file], stdout=PIPE) if not jit else Popen([engine,  "--mapdirs", "./test/wasi", "/var", "--jit", file], stdout=PIPE)
         out, _ = proc.communicate()
 
         if is_fail and proc.returncode or not is_fail and not proc.returncode:
@@ -135,6 +137,7 @@ def run_basic_tests(engine):
     if fail_total > 0:
         raise Exception("basic tests failed")
 
+
 @runner('wasm-test-core', default=True)
 def run_core_tests(engine):
     TEST_DIR = join(PROJECT_SOURCE_DIR, 'test', 'wasm-spec', 'core')
@@ -151,6 +154,7 @@ def run_core_tests(engine):
 
     if fail_total > 0:
         raise Exception("wasm-test-core failed")
+
 
 @runner('wasi', default=True)
 def run_basic_tests(engine):
@@ -169,6 +173,7 @@ def run_basic_tests(engine):
     if fail_total > 0:
         raise Exception("basic wasi tests failed")
 
+
 @runner('jit', default=True)
 def run_basic_tests(engine):
     TEST_DIR = join(PROJECT_SOURCE_DIR, 'test', 'jit')
@@ -185,6 +190,7 @@ def run_basic_tests(engine):
 
     if fail_total > 0:
         raise Exception("basic wasm-test-core failed")
+
 
 def main():
     parser = ArgumentParser(description='Walrus Test Suite Runner')


### PR DESCRIPTION
Refactor the importing of WASI functions to be clearer. 
Implement path_open, fd_seek, fd_read, environ_sizes_get, environ_get for file acces.
Implement the mapping of real directories to virtual ones so that WASI can use different directories. 
Add flag '--mapdirs' '`real`' '`virtual`' for mapping directories. 
Add flag '--env' for sharing host envrionment variables. 
Add flag '--help' for printing available walrus options. 
Also improve random_get test to not have a result.