### PR TITLE
Remove incorrect assert from MemoryInl.h.

### DIFF
--- a/src/jit/MemoryInl.h
+++ b/src/jit/MemoryInl.h
@@ -735,7 +735,6 @@ static void emitStore(sljit_compiler* compiler, Instruction* instr)
 #if (defined SLJIT_FPU_UNALIGNED && SLJIT_FPU_UNALIGNED)
         sljit_emit_fop1(compiler, opcode, addr.memArg.arg, addr.memArg.argw, addr.loadArg.arg, addr.loadArg.argw);
 #else /* SLJIT_FPU_UNALIGNED */
-        ASSERT(addr.memArg.argw == 0);
         sljit_emit_fmem(compiler, opcode | SLJIT_MEM_STORE | SLJIT_MEM_UNALIGNED, addr.loadArg.arg, addr.memArg.arg, addr.memArg.argw);
 #endif /* SLJIT_FPU_UNALIGNED */
         return;

--- a/test/jit/memory.wast
+++ b/test/jit/memory.wast
@@ -1,0 +1,9 @@
+(module
+    (memory 1)
+    (func (export "storeload_f32") (param i32) (param f32) (result f32)
+          (f32.store offset=1 (i32.const 0) (local.get 1))
+          (f32.load offset=1 (i32.const 0))
+    )
+)
+
+(assert_return (invoke "storeload_f32" (i32.const 0) (f32.const 1234)) (f32.const 1234))


### PR DESCRIPTION
Fixes the `sample.js` TensorFlow test on armhf.