### PR TITLE
Fix fusion of 64 bit compare with select on 32 bit

### DIFF
--- a/src/jit/IntMath32Inl.h
+++ b/src/jit/IntMath32Inl.h
@@ -1057,7 +1057,7 @@ static bool emitCompare(sljit_compiler* compiler, Instruction* instr)
         }
 
         if (isSelect) {
-            emitSelect(compiler, instr, type);
+            emitSelect(compiler, nextInstr, type);
             return true;
         }
 

--- a/test/jit/select1.wast
+++ b/test/jit/select1.wast
@@ -98,6 +98,13 @@
 
     select
 )
+(func (export "fused64") (result i32)
+    i32.const 0xaa
+    i32.const 0xbb
+    i64.const 0
+    i64.eqz
+    select
+)
 )
 
 (assert_return (invoke "test1") (i32.const 5) (i32.const 267386880))
@@ -106,3 +113,4 @@
 (assert_return (invoke "test4") (i32.const 6))
 (assert_return (invoke "test5") (f64.const 6.6))
 (assert_return (invoke "test6") (i32.const 6))
+(assert_return (invoke "fused64") (i32.const 0xaa))


### PR DESCRIPTION
Discovered by @zherczeg .
Previously `emitSelect` would crash in an `ASSERT` when checking the instruction count.

I am a bit wary of the `emit*` instructions not actually checking whether they are being called on the right instruction class, if `select` had the same number of operands as one of the comparison instructions, the assert would not have caught it, and the `reinterpret_cast` would have been called on the select.  That is probably not a serious enough bug to cause a sandbox escape, but it could result in arbitrary reads within the module memory.  At the very least it could lead to data corruption bugs that would be hard to track down.