### PR TITLE
Compile function earlier and free resources

### DIFF
--- a/src/jit/Analysis.cpp
+++ b/src/jit/Analysis.cpp
@@ -134,7 +134,7 @@ static bool isSameConst(std::vector<Instruction*>& instDeps)
     return true;
 }
 
-void JITCompiler::buildParamDependencies(uint32_t requiredStackSize, size_t nextTryBlock)
+void JITCompiler::buildParamDependencies(uint32_t requiredStackSize)
 {
     for (InstructionListItem* item = m_first; item != nullptr; item = item->next()) {
         if (item->isLabel()) {
@@ -142,6 +142,7 @@ void JITCompiler::buildParamDependencies(uint32_t requiredStackSize, size_t next
         }
     }
 
+    size_t nextTryBlock = m_tryBlockStart;
     bool updateDeps = true;
     std::vector<InstructionListItem*> currentDeps(requiredStackSize);
 
@@ -162,12 +163,12 @@ void JITCompiler::buildParamDependencies(uint32_t requiredStackSize, size_t next
                 do {
                     for (auto it : tryBlocks()[nextTryBlock].catchBlocks) {
                         if (it.tagIndex == std::numeric_limits<uint32_t>::max()) {
-                            it.handler->m_dependencyCtx->update(currentDeps);
+                            it.u.handler->m_dependencyCtx->update(currentDeps);
                         } else {
                             TagType* tagType = module()->tagType(it.tagIndex);
                             uint32_t size = module()->functionType(tagType->sigIndex())->param().size();
 
-                            it.handler->m_dependencyCtx->update(currentDeps, it.stackSizeToBe, it.stackSizeToBe + size);
+                            it.u.handler->m_dependencyCtx->update(currentDeps, it.stackSizeToBe, it.stackSizeToBe + size);
                         }
                     }
 

--- a/src/jit/TryCatchInl.h
+++ b/src/jit/TryCatchInl.h
@@ -63,7 +63,7 @@ InstanceConstData::InstanceConstData(std::vector<TrapBlock>& trapBlocks, std::ve
         m_tryBlocks.push_back(TryBlock(catchStart, catchCount, it.parent, sljit_get_label_addr(it.returnToLabel)));
 
         for (auto catchIt : it.catchBlocks) {
-            m_catchBlocks.push_back(CatchBlock(sljit_get_label_addr(catchIt.handler->label()), catchIt.stackSizeToBe, catchIt.tagIndex));
+            m_catchBlocks.push_back(CatchBlock(sljit_get_label_addr(catchIt.u.handlerLabel), catchIt.stackSizeToBe, catchIt.tagIndex));
         }
 
         catchStart += catchCount;
@@ -124,7 +124,7 @@ void InstanceConstData::append(std::vector<TrapBlock>& trapBlocks, std::vector<W
         m_tryBlocks.push_back(TryBlock(catchStart, catchCount, parent, sljit_get_label_addr(it.returnToLabel)));
 
         for (auto catchIt : it.catchBlocks) {
-            m_catchBlocks.push_back(CatchBlock(sljit_get_label_addr(catchIt.handler->label()), catchIt.stackSizeToBe, catchIt.tagIndex));
+            m_catchBlocks.push_back(CatchBlock(sljit_get_label_addr(catchIt.u.handlerLabel), catchIt.stackSizeToBe, catchIt.tagIndex));
         }
 
         catchStart += catchCount;


### PR DESCRIPTION
Cuts the memory consumption of jit compiling by around 1/3. Mostly code reorganization, but a few extra loops were added. These should have little impact on compilation performance.