### PR TITLE
Start implementing comfigurable temporaries

### DIFF
--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -24,22 +24,13 @@
 #include "runtime/Table.h"
 #include "runtime/Tag.h"
 #include "jit/Compiler.h"
+#include "jit/SljitLir.h"
 #include "util/MathOperation.h"
 
 #include <math.h>
 #include <map>
 
 // Inlined platform independent assembler backend.
-#define SLJIT_CONFIG_AUTO 1
-#define SLJIT_CONFIG_STATIC 1
-#define SLJIT_VERBOSE 0
-
-#if defined(NDEBUG)
-#define SLJIT_DEBUG 0
-#else
-#define SLJIT_DEBUG 1
-#endif
-
 extern "C" {
 #include "../../third_party/sljit/sljit_src/sljitLir.c"
 }

--- a/src/jit/Compiler.h
+++ b/src/jit/Compiler.h
@@ -165,8 +165,9 @@ class Instruction : public InstructionListItem {
 public:
     // Various info bits. Depends on type.
     static const uint16_t kIs32Bit = 1 << 0;
-    static const uint16_t kKeepInstruction = 1 << 1;
-    static const uint16_t kEarlyReturn = 1 << 2;
+    static const uint16_t kIsCallback = 1 << 1;
+    static const uint16_t kKeepInstruction = 1 << 2;
+    static const uint16_t kEarlyReturn = 1 << 3;
 
     ByteCode::Opcode opcode() { return m_opcode; }
 
@@ -202,30 +203,63 @@ public:
         return reinterpret_cast<BrTableInstruction*>(this);
     }
 
+    uint8_t tmpReg(size_t n)
+    {
+        ASSERT(n < sizeof(m_tmpRegs));
+        return m_tmpRegs[n];
+    }
+
+    void setTmpReg(size_t n, uint8_t value)
+    {
+        ASSERT(n < sizeof(m_tmpRegs));
+        m_tmpRegs[n] = value;
+    }
+
+    inline void setTmpReg2(uint8_t value1, uint8_t value2)
+    {
+        m_tmpRegs[0] = value1;
+        m_tmpRegs[1] = value2;
+    }
+
+    inline void setTmpReg3(uint8_t value1, uint8_t value2, uint8_t value3)
+    {
+        setTmpReg2(value1, value2);
+        m_tmpRegs[2] = value3;
+    }
+
+    inline void setTmpReg4(uint8_t value1, uint8_t value2, uint8_t value3, uint8_t value4)
+    {
+        setTmpReg3(value1, value2, value3);
+        m_tmpRegs[3] = value4;
+    }
+
 protected:
     explicit Instruction(ByteCode* byteCode, Group group, ByteCode::Opcode opcode, uint32_t paramCount, Operand* operands, InstructionListItem* prev)
         : InstructionListItem(group, prev)
         , m_byteCode(byteCode)
+        , m_operands(operands)
         , m_opcode(opcode)
         , m_paramCount(paramCount)
-        , m_operands(operands)
     {
+        memset(m_tmpRegs, 0, sizeof(m_tmpRegs));
     }
 
     explicit Instruction(ByteCode* byteCode, Group group, ByteCode::Opcode opcode, InstructionListItem* prev)
         : InstructionListItem(group, prev)
         , m_byteCode(byteCode)
+        , m_operands(nullptr)
         , m_opcode(opcode)
         , m_paramCount(0)
-        , m_operands(nullptr)
     {
+        memset(m_tmpRegs, 0, sizeof(m_tmpRegs));
     }
 
 private:
     ByteCode* m_byteCode;
+    Operand* m_operands;
     ByteCode::Opcode m_opcode;
     uint32_t m_paramCount;
-    Operand* m_operands;
+    uint8_t m_tmpRegs[4];
 };
 
 union InstructionValue {

--- a/src/jit/SljitLir.h
+++ b/src/jit/SljitLir.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023-present Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __WalrusSljitLir__
+#define __WalrusSljitLir__
+
+// Setup the configuration
+#define SLJIT_CONFIG_AUTO 1
+#define SLJIT_CONFIG_STATIC 1
+#define SLJIT_VERBOSE 0
+
+#if defined(NDEBUG)
+#define SLJIT_DEBUG 0
+#else
+#define SLJIT_DEBUG 1
+#endif
+
+extern "C" {
+#include "../../third_party/sljit/sljit_src/sljitLir.h"
+}
+
+#endif // __WalrusSljitLir__


### PR DESCRIPTION
This is the first patch of a larger scope rework. It starts to add configurable temporary registers to some instruction categories. I am not sure this will be enough in the long run, so there might be several rework rounds before it gets its final shape. But I hope it is a good start. The configurable temporaries will be needed for dynamic register allocation.