### PR TITLE
Bugfix

### DIFF
--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -602,7 +602,7 @@ static void executeInvokeAction(wabt::InvokeAction* action, Walrus::Function* fn
     auto trapResult = trap.run([](Walrus::ExecutionState& state, void* d) {
         RunData* data = reinterpret_cast<RunData*>(d);
         Walrus::ValueVector result;
-        result.resize(data->expectedResult.size());
+        result.resize(data->fn->functionType()->result().size());
         data->fn->call(state, data->args.data(), result.data());
         if (data->expectedResult.size()) {
             if (data->fn->functionType()->result().size() != data->expectedResult.size()) {


### PR DESCRIPTION
If WebAssembly function is expected to crash, but it does return with one or more values then Walrus crashes with segmentation fault because vector for the return values is allocated according to the number of the expected return values.

Now, vector is allocated according to the number of the return values of the given function. Moreover, error printing has been improved in this case.

For example:
```wast
(module
    (func (export "doubleIt") (param $x f32) (result f32)
        (f32.mul (local.get $x) (f32.const 2.0))
    )
)

(assert_return (invoke "doubleIt" (f32.const 3.6)) (f32.const 7.2))
(assert_trap (invoke "doubleIt" (f32.const 3.6)) "integer overflow")
```

Its result:
```
$ ./out/x64/debug/walrus program.wast
invoke doubleIt(3.600000) expect value(7.200000) (line: 7) : OK
Segmentation fault (core dumped)
```

With this patch, its result:
```
$ ./out/x64/debug/walrus program.wast
invoke doubleIt(3.600000) expect value(7.200000) (line: 7) : OK
Assertion failed at 8: doubleIt(3.600000) returned with 1 parameter(s) {7.200000} but expected 0
RELEASE_ASSERT_NOT_REACHED at /home/gpeter/Dokumentumok/walrus/src/shell/Shell.cpp (626)
Aborted (core dumped)
```

Of course, this assert_trap is incorrect but in my humble opinion, Walrus should print error message instead of crashing with segmentation fault.