### PR TITLE
Unify equalZero and jumpIf instructions

### DIFF
--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -49,29 +49,29 @@ ByteCode::Opcode ByteCode::opcode() const
 }
 #endif
 
-size_t ByteCode::getSize()
+size_t ByteCode::getSize() const
 {
     switch (this->opcode()) {
     case ThrowOpcode: {
-        Throw* throwCode = reinterpret_cast<Throw*>(this);
+        const Throw* throwCode = reinterpret_cast<const Throw*>(this);
         return ByteCode::pointerAlignedSize(sizeof(Throw) + sizeof(ByteCodeStackOffset) * throwCode->offsetsSize());
     }
     case CallOpcode: {
-        Call* call = reinterpret_cast<Call*>(this);
+        const Call* call = reinterpret_cast<const Call*>(this);
         return ByteCode::pointerAlignedSize(sizeof(Call) + sizeof(ByteCodeStackOffset) * call->parameterOffsetsSize()
                                             + sizeof(ByteCodeStackOffset) * call->resultOffsetsSize());
     }
     case BrTableOpcode: {
-        BrTable* brTable = reinterpret_cast<BrTable*>(this);
+        const BrTable* brTable = reinterpret_cast<const BrTable*>(this);
         return ByteCode::pointerAlignedSize(sizeof(BrTable) + sizeof(int32_t) * brTable->tableSize());
     }
     case CallIndirectOpcode: {
-        CallIndirect* callIndirect = reinterpret_cast<CallIndirect*>(this);
+        const CallIndirect* callIndirect = reinterpret_cast<const CallIndirect*>(this);
         return ByteCode::pointerAlignedSize(sizeof(CallIndirect) + sizeof(ByteCodeStackOffset) * callIndirect->parameterOffsetsSize()
                                             + sizeof(ByteCodeStackOffset) * callIndirect->resultOffsetsSize());
     }
     case EndOpcode: {
-        End* end = reinterpret_cast<End*>(this);
+        const End* end = reinterpret_cast<const End*>(this);
         return ByteCode::pointerAlignedSize(sizeof(End) + sizeof(ByteCodeStackOffset) * end->offsetsSize());
     }
     default: {

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -534,7 +534,7 @@ public:
     }
 
     Opcode opcode() const;
-    size_t getSize();
+    size_t getSize() const;
 
 protected:
     friend class Interpreter;
@@ -2204,7 +2204,7 @@ public:
         return reinterpret_cast<ByteCodeStackOffset*>(reinterpret_cast<size_t>(this) + sizeof(Throw));
     }
 
-    uint32_t offsetsSize()
+    uint32_t offsetsSize() const
     {
         return m_offsetsSize;
     }
@@ -2260,7 +2260,7 @@ public:
         return reinterpret_cast<ByteCodeStackOffset*>(reinterpret_cast<size_t>(this) + sizeof(End));
     }
 
-    uint32_t offsetsSize()
+    uint32_t offsetsSize() const
     {
         return m_offsetsSize;
     }
@@ -2268,10 +2268,13 @@ public:
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
-        auto arr = resultOffsets();
-        printf("end resultOffsets: ");
-        for (size_t i = 0; i < offsetsSize(); i++) {
-            printf("%" PRIu32 " ", arr[i]);
+        printf("end");
+        if (offsetsSize()) {
+            printf(" resultOffsets: ");
+            auto arr = resultOffsets();
+            for (size_t i = 0; i < offsetsSize(); i++) {
+                printf("%" PRIu32 " ", arr[i]);
+            }
         }
     }
 #endif

--- a/src/runtime/Module.h
+++ b/src/runtime/Module.h
@@ -206,6 +206,11 @@ public:
         m_byteCode.resizeWithUninitializedValues(m_byteCode.size() + s);
     }
 
+    void resizeByteCode(size_t newSize)
+    {
+        m_byteCode.resizeWithUninitializedValues(newSize);
+    }
+
     size_t currentByteCodeSize() const
     {
         return m_byteCode.size();

--- a/test/basic/optimalisationCheck.wast
+++ b/test/basic/optimalisationCheck.wast
@@ -1,0 +1,50 @@
+;; tests for Walrus where optimalisation shouldn't occure
+
+(module
+
+  ;; in the following tests there will be an EqualZero, then
+  ;; a JumpIfTrue/JumpIfFalse that should not be unified
+
+  (func (export "test1") (param $input i32) (result i32)
+    i32.const 1
+    i32.eqz
+    local.get $input
+    br_if 0
+    drop
+    i32.const 1
+  )
+
+  (func (export "test2") (param $input i32) (result i32)
+    local.get $input
+    i32.eqz
+    i32.const 0
+    if (result i32)
+      i32.const 1
+    else
+      i32.const 0
+    end
+    i32.add
+  )
+
+  (func (export "test3") (param $input i32) (result i32)
+    i32.const 1
+    block (result i32)
+      i32.const 0
+      local.get $input
+      br_if 0
+      drop
+      i32.const 0
+      i32.eqz
+    end
+    br_if 0
+    drop
+    i32.const 0
+  )
+)
+
+(assert_return (invoke "test1" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "test1" (i32.const 1)) (i32.const 0))
+(assert_return (invoke "test2" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "test2" (i32.const 1)) (i32.const 0))
+(assert_return (invoke "test3" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "test3" (i32.const 1)) (i32.const 0))


### PR DESCRIPTION
This patch:

- fixes a getter function. `getSize()` getter function of **ByteCode** class should be **const**.

- unifies **equalZero** and **jumpIf** instructions.

In the benchmark tests, this unification of bytecodes occurs usually **70 times** per test, and **results +3% faster execution** (in some tests, it results +6% faster execution).