### PR TITLE
Remove bytecode duplication

### DIFF
--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -1429,10 +1429,6 @@ public:
     void keepBlockResultsIfNeeds(BlockInfo& blockInfo, const std::pair<size_t, size_t>& dropSize)
     {
         if (blockInfo.m_shouldRestoreVMStackAtEnd) {
-            if (dropSize.second) {
-                generateMoveValuesCodeRegardToDrop(dropSize);
-            }
-
             if (!blockInfo.m_byteCodeGenerationStopped) {
                 if (blockInfo.m_returnValueType.IsIndex()) {
                     auto ft = m_result.m_functionTypes[blockInfo.m_returnValueType];


### PR DESCRIPTION
I found that the parser duplicates move instructions at the end of blocks in some cases.

For example:
```wasm
(module
  (func (result i32 i32 i32)
    (block (result i32 i32 i32)
      i32.const 1
      i32.const 2
      i32.const 3
    )
  )
)
```

Results this:
```
required stack size: 48 bytes
stack: [(constant 1, i32, pos 0) (constant 2, i32, pos 8) (constant 3, i32, pos 16) ....]
bytecode size: 168 bytes

     0 const32 dstOffset: 0 value: 1
    16 const32 dstOffset: 8 value: 2
    32 const32 dstOffset: 16 value: 3
    48 move32 srcOffset: 0 dstOffset: 24 
    64 move32 srcOffset: 8 dstOffset: 32 
    80 move32 srcOffset: 16 dstOffset: 40 
    96 move32 srcOffset: 16 dstOffset: 40 
   112 move32 srcOffset: 8 dstOffset: 32 
   128 move32 srcOffset: 0 dstOffset: 24 
   144 end resultOffsets: 24 32 40
```

The duplication occures in `keepBlockResultsIfNeeds(...)` function, [here](https://github.com/Samsung/walrus/blob/a0c5d2b1b92ab4f618634e300888d44f3627befb/src/parser/WASMParser.cpp#L1433) and [here](https://github.com/Samsung/walrus/blob/a0c5d2b1b92ab4f618634e300888d44f3627befb/src/parser/WASMParser.cpp#L1450).

By removing the first one (with the if statement), it does not duplicate the bytecode:
```
required stack size: 48 bytes
stack: [(constant 1, i32, pos 0) (constant 2, i32, pos 8) (constant 3, i32, pos 16) ....]
bytecode size: 120 bytes

     0 const32 dstOffset: 0 value: 1
    16 const32 dstOffset: 8 value: 2
    32 const32 dstOffset: 16 value: 3
    48 move32 srcOffset: 16 dstOffset: 40 
    64 move32 srcOffset: 8 dstOffset: 32 
    80 move32 srcOffset: 0 dstOffset: 24 
    96 end resultOffsets: 24 32 40
```
It also passes the tests and the benchmark tests as well.

But unfortunately, I'm not completely aware of the impact of this change on Walrus. Could someone help me, please?