### PR TITLE
Introducing variables in jit

### DIFF
--- a/src/jit/FloatConvInl.h
+++ b/src/jit/FloatConvInl.h
@@ -675,7 +675,7 @@ static void emitConvertFloat(sljit_compiler* compiler, Instruction* instr)
     sljit_s32 argTypes = (flags & SourceIs64Bit) ? SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_F64, 1) : SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_F32, 1);
 
     /* Destination must not be immediate. */
-    ASSERT(operands[1].item == nullptr);
+    ASSERT(VARIABLE_TYPE(operands[1].ref) != Operand::Immediate);
 
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
     arg.set(operands + 1);

--- a/src/jit/InstList.cpp
+++ b/src/jit/InstList.cpp
@@ -17,6 +17,7 @@
 #include "Walrus.h"
 
 #include "jit/Compiler.h"
+#include "jit/SljitLir.h"
 #include "runtime/ObjectType.h"
 
 #include <map>
@@ -30,6 +31,31 @@ uint32_t Instruction::resultCount()
     }
 
     return reinterpret_cast<ExtendedInstruction*>(this)->value().resultCount;
+}
+
+uint32_t Instruction::valueTypeToOperandType(Value::Type type)
+{
+    switch (type) {
+    case Value::I32:
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+    case Value::FuncRef:
+    case Value::ExternRef:
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+        return Instruction::Int32Operand;
+    case Value::I64:
+#if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
+    case Value::FuncRef:
+    case Value::ExternRef:
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+        return Instruction::Int64Operand;
+    case Value::V128:
+        return Instruction::V128Operand;
+    case Value::F32:
+        return Instruction::Float32Operand;
+    default:
+        ASSERT(type == Value::F64);
+        return Instruction::Float64Operand;
+    }
 }
 
 ComplexInstruction::~ComplexInstruction()
@@ -47,8 +73,8 @@ BrTableInstruction::~BrTableInstruction()
     delete[] m_targetLabels;
 }
 
-BrTableInstruction::BrTableInstruction(ByteCode* byteCode, size_t targetLabelCount, InstructionListItem* prev)
-    : Instruction(byteCode, Instruction::BrTable, ByteCode::BrTableOpcode, 1, &m_inlineParam, prev)
+BrTableInstruction::BrTableInstruction(ByteCode* byteCode, size_t targetLabelCount)
+    : Instruction(byteCode, Instruction::BrTable, ByteCode::BrTableOpcode, 1, &m_inlineParam)
     , m_targetLabelCount(targetLabelCount)
 {
     m_targetLabels = new Label*[targetLabelCount];
@@ -97,6 +123,35 @@ void Label::merge(Label* other)
     }
 }
 
+VariableRef VariableList::getMergeHeadSlowCase(VariableRef ref)
+{
+    ASSERT(variables[ref].info & kIsMerged);
+
+    VariableRef parent = variables[ref].u.parent;
+
+    ASSERT(parent < ref);
+
+    if (!(variables[parent].info & kIsMerged)) {
+        return parent;
+    }
+
+    // Update parents.
+    parent = variables[parent].u.parent;
+
+    while (variables[parent].info & kIsMerged) {
+        ASSERT(variables[parent].u.parent < parent);
+        parent = variables[parent].u.parent;
+    }
+
+    do {
+        VariableRef next = variables[ref].u.parent;
+        variables[ref].u.parent = parent;
+        ref = next;
+    } while (variables[ref].info & kIsMerged);
+
+    return parent;
+}
+
 Instruction* JITCompiler::append(ByteCode* byteCode, Instruction::Group group, ByteCode::Opcode opcode, uint32_t paramCount, uint32_t resultCount)
 {
     Instruction* instr;
@@ -104,22 +159,22 @@ Instruction* JITCompiler::append(ByteCode* byteCode, Instruction::Group group, B
 
     switch (operandCount) {
     case 0:
-        instr = new Instruction(byteCode, group, opcode, 0, nullptr, m_last);
+        instr = new Instruction(byteCode, group, opcode, 0, nullptr);
         break;
     case 1:
-        instr = new SimpleInstruction<1>(byteCode, group, opcode, paramCount, m_last);
+        instr = new SimpleInstruction<1>(byteCode, group, opcode, paramCount);
         break;
     case 2:
-        instr = new SimpleInstruction<2>(byteCode, group, opcode, paramCount, m_last);
+        instr = new SimpleInstruction<2>(byteCode, group, opcode, paramCount);
         break;
     case 3:
-        instr = new SimpleInstruction<3>(byteCode, group, opcode, paramCount, m_last);
+        instr = new SimpleInstruction<3>(byteCode, group, opcode, paramCount);
         break;
     case 4:
-        instr = new SimpleInstruction<4>(byteCode, group, opcode, paramCount, m_last);
+        instr = new SimpleInstruction<4>(byteCode, group, opcode, paramCount);
         break;
     default:
-        instr = new ComplexInstruction(byteCode, group, opcode, paramCount, operandCount, m_last);
+        instr = new ComplexInstruction(byteCode, group, opcode, paramCount, operandCount);
         break;
     }
 
@@ -139,22 +194,22 @@ ExtendedInstruction* JITCompiler::appendExtended(ByteCode* byteCode, Instruction
 
     switch (operandCount) {
     case 0:
-        instr = new ExtendedInstruction(byteCode, group, opcode, 0, nullptr, m_last);
+        instr = new ExtendedInstruction(byteCode, group, opcode, 0, nullptr);
         break;
     case 1:
-        instr = new SimpleExtendedInstruction<1>(byteCode, group, opcode, paramCount, m_last);
+        instr = new SimpleExtendedInstruction<1>(byteCode, group, opcode, paramCount);
         break;
     case 2:
-        instr = new SimpleExtendedInstruction<2>(byteCode, group, opcode, paramCount, m_last);
+        instr = new SimpleExtendedInstruction<2>(byteCode, group, opcode, paramCount);
         break;
     case 3:
-        instr = new SimpleExtendedInstruction<3>(byteCode, group, opcode, paramCount, m_last);
+        instr = new SimpleExtendedInstruction<3>(byteCode, group, opcode, paramCount);
         break;
     case 4:
-        instr = new SimpleExtendedInstruction<4>(byteCode, group, opcode, paramCount, m_last);
+        instr = new SimpleExtendedInstruction<4>(byteCode, group, opcode, paramCount);
         break;
     default:
-        instr = new ComplexExtendedInstruction(byteCode, group, opcode, paramCount, operandCount, m_last);
+        instr = new ComplexExtendedInstruction(byteCode, group, opcode, paramCount, operandCount);
         break;
     }
 
@@ -173,13 +228,12 @@ Instruction* JITCompiler::appendBranch(ByteCode* byteCode, ByteCode::Opcode opco
     ExtendedInstruction* branch;
 
     if (opcode == ByteCode::JumpOpcode) {
-        branch = new ExtendedInstruction(byteCode, Instruction::DirectBranch, ByteCode::JumpOpcode, 0, nullptr, m_last);
+        branch = new ExtendedInstruction(byteCode, Instruction::DirectBranch, ByteCode::JumpOpcode, 0, nullptr);
     } else {
-        branch = new SimpleExtendedInstruction<1>(byteCode, Instruction::DirectBranch, opcode, 1, m_last);
+        branch = new SimpleExtendedInstruction<1>(byteCode, Instruction::DirectBranch, opcode, 1);
 
         Operand* operands = branch->operands();
-        operands[0].item = nullptr;
-        operands[0].offset = offset;
+        operands[0].ref = offset;
     }
 
     branch->value().targetLabel = label;
@@ -190,11 +244,10 @@ Instruction* JITCompiler::appendBranch(ByteCode* byteCode, ByteCode::Opcode opco
 
 BrTableInstruction* JITCompiler::appendBrTable(ByteCode* byteCode, uint32_t numTargets, uint32_t offset)
 {
-    BrTableInstruction* branch = new BrTableInstruction(byteCode, numTargets + 1, m_last);
+    BrTableInstruction* branch = new BrTableInstruction(byteCode, numTargets + 1);
 
     Operand* operands = branch->operands();
-    operands[0].item = nullptr;
-    operands[0].offset = offset;
+    operands[0].ref = offset;
 
     append(branch);
     return branch;
@@ -202,7 +255,6 @@ BrTableInstruction* JITCompiler::appendBrTable(ByteCode* byteCode, uint32_t numT
 
 void JITCompiler::dump()
 {
-    std::map<InstructionListItem*, int> instrIndex;
     bool enableColors = (verboseLevel() >= 2);
     int counter = 0;
 
@@ -212,35 +264,32 @@ void JITCompiler::dump()
 #undef DECLARE_BYTECODE
     };
 
-    for (InstructionListItem* item = first(); item != nullptr; item = item->next()) {
-        instrIndex[item] = counter++;
-    }
-
     const char* defaultText = enableColors ? "\033[0m" : "";
     const char* instrText = enableColors ? "\033[1;35m" : "";
+    const char* variableText = enableColors ? "\033[1;32m" : "";
     const char* labelText = enableColors ? "\033[1;36m" : "";
-    const char* unusedText = enableColors ? "\033[1;33m" : "";
+    const char* highlightFlagText = enableColors ? "\033[1;33m" : "";
 
     for (InstructionListItem* item = first(); item != nullptr; item = item->next()) {
         if (item->isInstruction()) {
             Instruction* instr = item->asInstruction();
-            printf("%s%d%s: ", instrText, instrIndex[item], defaultText);
+            printf("%d: %s%s%s", static_cast<int>(instr->id()), instrText, byteCodeName[instr->opcode()], defaultText);
 
             if (enableColors) {
-                printf("(%p) ", item);
+                printf(" (%p)", item);
             }
 
-            printf("Opcode: %s\n", byteCodeName[instr->opcode()]);
+            printf("\n");
 
             switch (instr->group()) {
             case Instruction::Immediate: {
                 if (!(instr->info() & Instruction::kKeepInstruction)) {
-                    printf("  %sUnused%s\n", unusedText, defaultText);
+                    printf("  %sUnused%s\n", highlightFlagText, defaultText);
                 }
                 break;
             }
             case Instruction::DirectBranch: {
-                printf("  Jump to: %s%d%s\n", labelText, instrIndex[instr->asExtended()->value().targetLabel], defaultText);
+                printf("  Jump to: %s%d%s\n", labelText, static_cast<int>(instr->asExtended()->value().targetLabel->id()), defaultText);
                 break;
             }
             case Instruction::BrTable: {
@@ -248,7 +297,7 @@ void JITCompiler::dump()
                 Label** targetLabels = instr->asBrTable()->targetLabels();
 
                 for (size_t i = 0; i < targetLabelCount; i++) {
-                    printf("  Jump to: %s%d%s\n", labelText, instrIndex[*targetLabels], defaultText);
+                    printf("  Jump to: %s%d%s\n", labelText, static_cast<int>((*targetLabels)->id()), defaultText);
                     targetLabels++;
                 }
                 break;
@@ -258,56 +307,82 @@ void JITCompiler::dump()
             }
             }
 
+            if (instr->info() & Instruction::kIsMergeCompare) {
+                printf("  %sMergeCompare%s\n", highlightFlagText, defaultText);
+            }
+
             uint32_t paramCount = instr->paramCount();
             uint32_t size = paramCount + instr->resultCount();
-            Operand* param = instr->params();
+            Operand* operand = instr->operands();
 
             for (uint32_t i = 0; i < size; ++i) {
                 if (i < paramCount) {
-                    printf("  Param[%d]: %d", static_cast<int>(i), static_cast<int>(param->offset));
+                    printf("  Param[%d]: ", static_cast<int>(i));
+                } else {
+                    printf("  Result[%d]: ", static_cast<int>(i - paramCount));
+                }
 
-                    if (param->item != nullptr) {
-                        printf(" ref:%s%d%s\n", param->item->isLabel() ? labelText : instrText, instrIndex[param->item], defaultText);
+                VariableRef ref = operand->ref;
+                VariableList::Variable& variable = m_variableList->variables[ref];
+
+                if (variable.value != VARIABLE_SET_PTR(nullptr)) {
+                    const char* type = "Invalid";
+
+                    switch (variable.info & Instruction::TypeMask) {
+                    case Instruction::Int32Operand:
+                        type = "I32";
+                        break;
+                    case Instruction::Int64Operand:
+                        type = "I64";
+                        break;
+                    case Instruction::V128Operand:
+                        type = "V128";
+                        break;
+                    case Instruction::Float32Operand:
+                        type = "F32";
+                        break;
+                    case Instruction::Float64Operand:
+                        type = "F64";
+                        break;
+                    }
+
+                    printf("%s%d%s.%s", variableText, static_cast<int>(ref), defaultText, type);
+
+                    if (VARIABLE_TYPE(variable.value) == Operand::Offset) {
+                        printf(" (O:%d) [%d-%d]", static_cast<int>(VARIABLE_GET_OFFSET(variable.value)),
+                               static_cast<int>(variable.u.rangeStart), static_cast<int>(variable.rangeEnd));
+                    } else if (enableColors) {
+                        printf(" (I:%p)", VARIABLE_GET_IMM(variable.value));
                     } else {
-                        printf(" ref:%sAny%s\n", instrText, defaultText);
+                        printf(" (I)");
                     }
                 } else {
-                    printf("  Result[%d]: %d\n", static_cast<int>(i - paramCount), static_cast<int>(param->offset));
+                    printf("(flag)");
                 }
-                param++;
+
+                if (variable.info & VariableList::kIsCallback) {
+                    printf(" %sCallBack%s", highlightFlagText, defaultText);
+                } else if (variable.info & VariableList::kDestroysR0R1) {
+                    printf(" %sDestroysR0R1%s", highlightFlagText, defaultText);
+                }
+
+                printf("\n");
+                operand++;
             }
         } else {
-            printf("%s%d%s: ", labelText, instrIndex[item], defaultText);
+            printf("%s%d%s: Label", labelText, static_cast<int>(item->id()), defaultText);
 
             if (enableColors) {
-                printf("(%p) ", item);
+                printf(" (%p)", item);
             }
 
             Label* label = item->asLabel();
 
-            printf("Label:%s%s\n", (label->info() & Label::kHasTryInfo) ? " hasTryInfo" : "",
+            printf("%s%s\n", (label->info() & Label::kHasTryInfo) ? " hasTryInfo" : "",
                    (label->info() & Label::kHasCatchInfo) ? " hasCatchInfo" : "");
 
             for (auto it : label->branches()) {
-                printf("  Jump from: %s%d%s\n", instrText, instrIndex[it], defaultText);
-            }
-
-            size_t size = label->dependencyCount();
-
-            for (size_t i = 0; i < size; ++i) {
-                if (label->dependencies(i).size() == 0) {
-                    continue;
-                }
-
-                printf("  Param[%d]\n", static_cast<int>(i));
-
-                for (auto dependencyIt : label->dependencies(i)) {
-                    if (dependencyIt == nullptr) {
-                        printf("    %sAny%s instruction\n", instrText, defaultText);
-                    } else {
-                        printf("    %s%d%s instruction\n", instrText, instrIndex[dependencyIt], defaultText);
-                    }
-                }
+                printf("  Jump from: %s%d%s\n", instrText, static_cast<int>(it->id()), defaultText);
             }
         }
     }
@@ -315,7 +390,7 @@ void JITCompiler::dump()
 
 void JITCompiler::append(InstructionListItem* item)
 {
-    ASSERT(item->m_prev == m_last && item->m_next == nullptr);
+    ASSERT(item->m_next == nullptr);
 
     if (m_last != nullptr) {
         m_last->m_next = item;
@@ -324,60 +399,6 @@ void JITCompiler::append(InstructionListItem* item)
     }
 
     m_last = item;
-}
-
-InstructionListItem* JITCompiler::remove(InstructionListItem* item)
-{
-    InstructionListItem* prev = item->m_prev;
-    InstructionListItem* next = item->m_next;
-
-    if (prev == nullptr) {
-        ASSERT(m_first == item);
-        m_first = next;
-    } else {
-        ASSERT(m_first != item);
-        prev->m_next = next;
-    }
-
-    if (next == nullptr) {
-        ASSERT(m_last == item);
-        m_last = prev;
-    } else {
-        ASSERT(m_last != item);
-        next->m_prev = prev;
-    }
-
-    delete item;
-    return next;
-}
-
-void JITCompiler::replace(InstructionListItem* item, InstructionListItem* newItem)
-{
-    ASSERT(item != newItem);
-
-    InstructionListItem* prev = item->m_prev;
-    InstructionListItem* next = item->m_next;
-
-    newItem->m_prev = prev;
-    newItem->m_next = next;
-
-    if (prev == nullptr) {
-        ASSERT(m_first == item);
-        m_first = newItem;
-    } else {
-        ASSERT(m_first != item);
-        prev->m_next = newItem;
-    }
-
-    if (next == nullptr) {
-        ASSERT(m_last == item);
-        m_last = newItem;
-    } else {
-        ASSERT(m_last != item);
-        next->m_prev = newItem;
-    }
-
-    delete item;
 }
 
 } // namespace Walrus

--- a/src/jit/MemoryInl.h
+++ b/src/jit/MemoryInl.h
@@ -685,15 +685,15 @@ static void emitStore(sljit_compiler* compiler, Instruction* instr)
         }
 #ifdef HAS_SIMD
     } else if (opcode == 0) {
-        InstructionListItem* item = operands[1].item;
+        VariableRef ref = operands[1].ref;
 
-        if (item == nullptr || item->group() != Instruction::Immediate) {
+        if (VARIABLE_TYPE(ref) != Operand::Immediate) {
             addr.loadArg.set(operands + 1);
         } else {
-            ASSERT(item->asInstruction()->opcode() == ByteCode::Const128Opcode);
+            ASSERT(VARIABLE_GET_IMM(ref)->opcode() == ByteCode::Const128Opcode);
 
             addr.loadArg.arg = SLJIT_MEM0();
-            addr.loadArg.argw = reinterpret_cast<sljit_sw>(reinterpret_cast<Const128*>(item->asInstruction()->byteCode())->value());
+            addr.loadArg.argw = reinterpret_cast<sljit_sw>(reinterpret_cast<Const128*>(VARIABLE_GET_IMM(ref)->byteCode())->value());
         }
 
         if (SLJIT_IS_MEM(addr.loadArg.arg)) {

--- a/test/jit/select1.wast
+++ b/test/jit/select1.wast
@@ -106,6 +106,24 @@
    i64.eqz
    select
 )
+
+(func (export "test8") (param i32) (result i32 i32)
+   i32.const 5
+   i32.const 6
+
+   local.get 0
+   i32.const 7
+   i32.lt_s
+   select
+
+   local.get 0
+   i32.const 7
+   i32.gt_s
+
+   i32.const 8
+   local.get 0
+   select
+)
 )
 
 (assert_return (invoke "test1") (i32.const 5) (i32.const 267386880))
@@ -116,3 +134,4 @@
 (assert_return (invoke "test6") (i32.const 6))
 (assert_return (invoke "test7" (i64.const 0)) (i32.const 5))
 (assert_return (invoke "test7" (i64.const 100)) (i32.const 8))
+(assert_return (invoke "test8" (i32.const 20)) (i32.const 6) (i32.const 1))


### PR DESCRIPTION
It turned out whatever register allocation we implement, full data dependency tracking is needed. This patch extends the current data dependency tracking to full tracking. To limit the memory consumption increase, this data is deleted before the code generation, because it is not needed anymore. Various analyses are also moved earlier.