### PR TITLE
Refactor benchmarker

### DIFF
--- a/src/jit/FloatConvInl.h
+++ b/src/jit/FloatConvInl.h
@@ -149,7 +149,7 @@ static void emitConvertIntegerFromFloat(sljit_compiler* compiler, Instruction* i
     CompileContext* context = CompileContext::get(compiler);
     Operand* operands = instr->operands();
 
-    JITArg srcArg;
+    JITArg srcArg(operands);
     JITArg dstArg(operands + 1);
 
     sljit_s32 sourceReg = GET_SOURCE_REG(srcArg.arg, instr->requiredReg(0));
@@ -339,7 +339,7 @@ static void emitSaturatedConvertIntegerFromFloat(sljit_compiler* compiler, Instr
 
     Operand* operands = instr->operands();
 
-    JITArg srcArg;
+    JITArg srcArg(operands);
     JITArg dstArg(operands + 1);
 
     sljit_s32 sourceReg = GET_SOURCE_REG(srcArg.arg, instr->requiredReg(0));

--- a/test/wasmBenchmarker/benchmark.py
+++ b/test/wasmBenchmarker/benchmark.py
@@ -24,7 +24,10 @@ import time
 from os.path import abspath, dirname, join
 from markdownTable import markdownTable  # pip install py-markdown-table
 
-TEST_DIR = join(dirname(abspath(__file__)), 'ctests')
+
+TEST_DIR = join(dirname(abspath(__file__)), "ctests")
+
+DIFF_TRESHOLD = 1e-7
 
 expectedValues = {
     "change": 4,
@@ -53,49 +56,50 @@ expectedValues = {
     "simdMatrixMultiply": 3920.0,
     "ticTacToe": 4748900
 }
+
 # https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/simple.html#simple
 gameTests = ["mandelbrotFloat", "nbody", "gregory", "fannkuch", "kNucleotide"]
 
 simdTests = ["simdMandelbrotFloat", "simdMandelbrotDouble", "simdNbody", "simdMatrixMultiply"]
 
-def prepare_arg_pars():
+
+
+def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--test-dir', metavar='PATH', help='path to the test files written in c', nargs='?',
+    parser.add_argument("--test-dir", metavar="PATH", help="path to the test files written in c", nargs="?",
                         const=TEST_DIR, default=TEST_DIR)
-    parser.add_argument('--only-game', help='only run Game tests', action='store_true')
-    parser.add_argument('--only-simd', help='only run SIMD tests', action='store_true')
-    parser.add_argument('--run', metavar='TEST', help='only run one benchmark')
-    parser.add_argument('--engines', metavar='PATH', help='paths to wasm engines', nargs='+', default=['walrus'])
-    parser.add_argument('--report', metavar='PATH', help='path to the report', nargs='?', const='./report.md')
-    parser.add_argument('--iterations', metavar='NUMBER', help='how many times run the tests', nargs='?',
-                        const='10', default=10, type=int)
-    parser.add_argument('--compile-anyway', help='compile the tests even if they are compiled', action='store_true')
-    parser.add_argument('--mem', help='measure MAX RSS', action='store_true')
-    parser.add_argument('--jit', help='use JIT version of Walrus', action='store_true')
-    parser.add_argument('--verbose', help='prints extra informations e.g. paths', action='store_true')
+    parser.add_argument("--only-game", help="only run Game tests", action="store_true")
+    parser.add_argument("--only-simd", help="only run SIMD tests", action="store_true")
+    parser.add_argument("--run", metavar="TEST", help="only run one benchmark")
+    parser.add_argument("--engines", metavar="PATH", help="paths to wasm engines", nargs="+", default=["walrus"])
+    parser.add_argument("--report", metavar="PATH", help="path to the report", nargs="?", const="./report.md")
+    parser.add_argument("--iterations", metavar="NUMBER", help="how many times run the tests", nargs="?",
+                        const="10", default=10, type=int)
+    parser.add_argument("--compile-anyway", help="compile the tests even if they are compiled", action="store_true")
+    parser.add_argument("--mem", help="measure MAX RSS", action="store_true")
+    parser.add_argument("--jit", help="use JIT version of Walrus", action="store_true")
+    parser.add_argument("--verbose", help="prints extra informations e.g. paths", action="store_true")
     return parser.parse_args()
 
 
 def check_programs(engines, verbose):
     if os.system("git --version >/dev/null") != 0:
-        print("git not found")
-        exit(1)
+        raise Exception("Git not found!")
 
-    for e in engines:
-        path = e.split(" ")[0]
-        if os.path.isfile(path) is False:
-            print(path + " not found")
-            exit(1)
+    for engine in engines:
+        path = engine.split(" ")[0]
+        if not os.path.isfile(path):
+            raise Exception(f"{path} not found")
 
     if (verbose): print("Checks done")
 
 
 def get_emcc(verbose):
     emcc_path = None 
-    if os.getenv('EMSDK'):
-        emcc_path = join(os.getenv('EMSDK'), 'upstream/emscripten/emcc.py')
+    if os.getenv("EMSDK"):
+        emcc_path = join(os.getenv("EMSDK"), "upstream/emscripten/emcc.py")
         if os.path.exists(emcc_path):
-            if (verbose): print("EMCC already installed: " + emcc_path)
+            if (verbose): print(f"EMCC already installed: {emcc_path}")
             return emcc_path
 
     if os.path.exists("./emsdk/.git"):
@@ -109,29 +113,27 @@ def get_emcc(verbose):
         os.system("./emsdk/emsdk activate latest >/dev/null")
 
     emcc_path = "./emsdk/upstream/emscripten/emcc"
-    if (verbose): print("EMCC install done: " + emcc_path)
+    if (verbose): print(f"EMCC install done: {emcc_path}")
     return emcc_path
 
 
-def compile_tests(emcc_path, path, only_game=False, only_simd=False, compile_anyway=False, run=None, verbose=False):
+def compile_tests(emcc_path, path, only_game, only_simd, compile_anyway, run, verbose):
     if not os.path.exists(emcc_path):
-        print("invalid path for emcc: " + emcc_path)
-        exit(1)
+        raise Exception(f"Invalid path for emcc: {emcc_path}")
 
     if not os.path.exists(path):
-        print("invalid path for tests: " + path)
-        exit(1)
+        raise Exception(f"Invalid path for tests: {path}")
 
-    if not os.path.exists(path + "/wasm"):
-        os.makedirs(path + "/wasm")
+    if not os.path.exists(f"{path}/wasm"):
+        os.makedirs(f"{path}/wasm")
 
     path = os.path.abspath(path)
-    test_list = [file for file in os.listdir(path) if file.endswith('.c')]
+    test_list = [file for file in os.listdir(path) if file.endswith(".c")]
     test_list.sort()
-    test_names = []
+    test_names = list()
 
     for file in test_list:
-        name = file.split('.')[0]
+        name = file.split(".")[0]
 
         if (name not in gameTests and only_game) or \
            (name not in simdTests and only_simd) or \
@@ -140,124 +142,122 @@ def compile_tests(emcc_path, path, only_game=False, only_simd=False, compile_any
 
         test_names.append(name)
 
-        if not compile_anyway and os.path.exists(path + "/wasm/" + name + ".wasm"):
-            if (verbose): print(name + ".wasm is found; compilation skipped")
+        if not compile_anyway and os.path.exists(f"{path}/wasm/{name}.wasm"):
+            if (verbose): print(f"{name}.wasm is found; compilation skipped")
             continue
 
-        extraFlags = "-msimd128" if file.startswith("simd") else ""
-
-        if (verbose): print("compiling " + name)
-        bob_the_stringbuilder = emcc_path + " " + path + "/" + file + " " + extraFlags + " -s WASM=1 -s EXPORTED_FUNCTIONS=_runtime -s EXPORTED_RUNTIME_METHODS=ccall,cwrap -o " + path + "/wasm/" + name + ".wasm"
-        if verbose: print(bob_the_stringbuilder)
-        os.system(bob_the_stringbuilder)
+        flags = "-msimd128" if file.startswith("simd") else ""
+        flags += (" -s WASM=1 -s EXPORTED_FUNCTIONS=_runtime"
+                  " -s EXPORTED_RUNTIME_METHODS=ccall,cwrap"
+                  f" -o {path}/wasm/{name}.wasm")
+        if (verbose): print(f"compiling {name}")
+        command = f"{emcc_path} {path}/{file} {flags}"
+        if verbose: print(command)
+        os.system(command)
 
     return test_names
 
-def run_check_wasm(engine, path, name, jit=False, verbose=False):
-    if not os.path.exists(path):
-        print("invalid path for run")
-        exit(1)
 
-    tc_path = path + "/wasm/" + name + ".wasm"
+def run_wasm(engine, path, test_name, jit, verbose):
+    if not os.path.exists(path):
+        raise Exception(f"Invalid path for run: {path}")
+
+    tc_path =  f"{path}/wasm/{test_name}.wasm"
     flags = " --jit" if (jit and "walrus" in engine) else ""
 
-    result = subprocess.check_output(engine + " " + flags + " " + tc_path, shell=True)
+    result = subprocess.check_output(f"{engine} {flags} {tc_path}", shell=True)
 
-    if abs(float(f'{float(result):.8f}') - float(expectedValues[name])) > 0.0000001:
-        print("run failed with " + name + ".wasm", file=sys.stderr)
-        print("Expected: " + str(expectedValues[name]), file=sys.stderr)
-        print("Got: " + str(result), file=sys.stderr)
-        exit()
+    diff = abs(float(f"{float(result):.8f}") - float(expectedValues[test_name]))
+    if diff > DIFF_TRESHOLD:
+        message = (f"Run failed with {test_name}.wasm,"
+                   f" expected: {str(expectedValues[test_name])},"
+                   f" but got: {str(result)}")
+        raise Exception(message)
 
-    return True
 
-
-def measure_time(path, name, function, engine, jit=False, verbose=False):
+def measure_time(path, name, function, engine, jit, verbose):
     start_time = time.perf_counter_ns()
-    ret_val = function(engine, path, name, jit, verbose)
+    function(engine, path, name, jit, verbose)
     end_time = time.perf_counter_ns()
+    return (end_time - start_time)
 
-    if ret_val:
-        return end_time - start_time
-    else:
-        return math.nan
 
-def measure_memory(path, name, engine, jit=False):
+def measure_memory(path, name, engine, jit):
     if not os.path.exists(path):
-        print("invalid path for run")
-        exit(1)
+        raise Exception(f"Invalid path for run: {path}")
 
-    mem_tool = "/usr/bin/time -f %M "
-    tc_path = path + "/wasm/" + name + ".wasm"
+    mem_tool = "/usr/bin/time -f %M"
+    tc_path = f"{path}/wasm/{name}.wasm"
     flags = " --jit" if (jit and "walrus" in engine) else ""
-    run_cmd = mem_tool + engine + " " + flags + " " + tc_path
+    run_cmd = f"{mem_tool} {engine} {flags} {tc_path}"
 
     outputs = subprocess.check_output(run_cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
-    results = outputs.split('\n')
+    results = outputs.split("\n")
 
     return int(results[1])
 
-def run_tests(path, test_names, engines, number_of_runs, mem=False, jit=False, verbose=False):
-    ret_time_val = []
-    ret_mem_val = []
+
+def run_tests(path, test_names, engines, number_of_runs, mem, jit, verbose):
+    ret_time_val = list()
+    ret_mem_val = list()
     for name in test_names:
-        tc_path = path + "/wasm/" + name + ".wasm"
-        if (verbose): print("running " + name + " (TC path: "+ tc_path  + ")")
-        time_results = {}
-        mem_results = {}
-        for e in engines:
-            time_results[e] = []
-            mem_results[e] = []
-        for i in range(0, number_of_runs):
-            if (verbose): print("round " + str(i + 1))
-            for e in engines:
-                time_results[e].append(measure_time(path, name, run_check_wasm, e, jit))
+        tc_path = f"{path}/wasm/{name}.wasm"
+        if (verbose): print(f"running {name} (TC path: {tc_path})")
+        time_results = dict()
+        mem_results = dict()
+        for engine in engines:
+            time_results[engine] = list()
+            mem_results[engine] = list()
+        for i in range(number_of_runs):
+            if (verbose): print(f"round {i + 1}")
+            for engine in engines:
+                time_results[engine].append(measure_time(path, name, run_wasm, engine, jit, verbose))
                 if (mem):
-                    mem_results[e].append(measure_memory(path, name, e, jit))
+                    mem_results[engine].append(measure_memory(path, name, engine, jit))
 
         record = {"test": name}
-        for e in engines:
-            record[e] = "{:.3f}".format((sum(time_results[e]) / len(time_results[e])) / 1e9)
+        for engine in engines:
+            record[engine] = "{:.3f}".format((sum(time_results[engine]) / len(time_results[engine])) / 1e9)
         ret_time_val.append(record)
 
         if (mem):
             record = {"test": name}
-            for e in engines:
-                record[e] = "{:.1f}".format(sum(mem_results[e]) / len(mem_results[e]))
+            for engine in engines:
+                record[engine] = "{:.1f}".format(sum(mem_results[engine]) / len(mem_results[engine]))
             ret_mem_val.append(record)
 
-    return (ret_time_val, ret_mem_val)
+    return {"time" : ret_time_val, "mem" : ret_mem_val}
 
 
-def generate_report(data, fileName=None):
-    if fileName is None:
-        print(markdownTable(data).setParams(row_sep='markdown', quote=False).getMarkdown())
+def generate_report(data, file_name=None):
+    if file_name is None:
+        print(markdownTable(data).setParams(row_sep="markdown", quote=False).getMarkdown())
         return
-    with open(fileName, 'w') as file:
-        if fileName.endswith(".csv"):
+    with open(file_name, "w") as file:
+        if file_name.endswith(".csv"):
             header = "test"
-            engineNames = list()
+            engine_names = list()
             if len(data) > 0:
-                engineNames = list(data[0].keys())
-                engineNames.remove("test")
-            for engineName in engineNames:
-                header += ";" + engineName
-            print(header, file=file)
+                engine_names = list(data[0].keys())
+                engine_names.remove("test")
+            for engineName in engine_names:
+                header += f";{engineName}"
+            file.write(header)
             for record in data:
                 line = record["test"]
-                for engineName in engineNames:
-                    line += ";" + record[engineName]
-                print(line, file=file)
+                for engineName in engine_names:
+                    line += f";{record[engineName]}"
+                file.write(line)
             return
-        print(markdownTable(data).setParams(row_sep='markdown', quote=False).getMarkdown(), file=file)
+        file.write(markdownTable(data).setParams(row_sep="markdown", quote=False).getMarkdown())
 
 
 def main():
-    args = prepare_arg_pars()
-    if (args.verbose): print("Test dir: " + TEST_DIR)
+    args = parse_args()
+    if (args.verbose): print(f"Test dir: {TEST_DIR}")
 
     if args.engines is None:
-        print("You need to specify the engine locations")
+        print("You need to specify the engine locations", file=sys.stderr)
         exit(1)
 
     check_programs(args.engines, args.verbose)
@@ -265,10 +265,10 @@ def main():
     test_names = compile_tests(emcc_path, args.test_dir, args.only_game, args.only_simd, args.compile_anyway, args.run, args.verbose)
 
     result_data = run_tests(args.test_dir, test_names, args.engines, args.iterations, args.mem, args.jit, args.verbose)
-    generate_report(result_data[0], args.report)
+    generate_report(result_data["time"], args.report)
     if (args.mem):
-        generate_report(result_data[1], args.report)
+        generate_report(result_data["mem"], args.report)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
- unify names (e.g. "engine" insted of "e")
- unify naming convention (snake_case everywhere)
- unify string markers (double quotation mark everywhere)
- fstring (instead of string concatenation)
- remove default values (they were unused)
- raise error insted of terminating

Moreover, 2 typos have been fixed in FloatConvInl.h.

Signed-off-by: Görög Péter Sándor gorogpetersandor@gmail.com