### PR TITLE
Introduce move.f32 and move.f64

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -52,9 +52,11 @@ class FunctionType;
     F(TableSize)                \
     F(TableFill)                \
     F(RefFunc)                  \
-    F(Move32)                   \
-    F(Move64)                   \
-    F(Move128)                  \
+    F(MoveI32)                  \
+    F(MoveF32)                  \
+    F(MoveI64)                  \
+    F(MoveF64)                  \
+    F(MoveV128)                 \
     F(Jump)                     \
     F(JumpIfTrue)               \
     F(JumpIfFalse)              \
@@ -863,10 +865,10 @@ protected:
     uint16_t m_resultOffsetsSize;
 };
 
-class Move32 : public ByteCode {
+class Move : public ByteCode {
 public:
-    Move32(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
-        : ByteCode(Opcode::Move32Opcode)
+    Move(Opcode opcode, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : ByteCode(opcode)
         , m_srcOffset(srcOffset)
         , m_dstOffset(dstOffset)
     {
@@ -874,71 +876,95 @@ public:
 
     ByteCodeStackOffset srcOffset() const { return m_srcOffset; }
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
-
-#if !defined(NDEBUG)
-    void dump(size_t pos)
-    {
-        printf("move32 ");
-        DUMP_BYTECODE_OFFSET(srcOffset);
-        DUMP_BYTECODE_OFFSET(dstOffset);
-    }
-#endif
 
 protected:
     ByteCodeStackOffset m_srcOffset;
     ByteCodeStackOffset m_dstOffset;
 };
 
-class Move64 : public ByteCode {
+class MoveI32 : public Move {
 public:
-    Move64(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
-        : ByteCode(Opcode::Move64Opcode)
-        , m_srcOffset(srcOffset)
-        , m_dstOffset(dstOffset)
+    MoveI32(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : Move(Opcode::MoveI32Opcode, srcOffset, dstOffset)
     {
     }
-
-    ByteCodeStackOffset srcOffset() const { return m_srcOffset; }
-    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
-        printf("move64 ");
+        printf("movei32 ");
         DUMP_BYTECODE_OFFSET(srcOffset);
         DUMP_BYTECODE_OFFSET(dstOffset);
     }
 #endif
-
-protected:
-    ByteCodeStackOffset m_srcOffset;
-    ByteCodeStackOffset m_dstOffset;
 };
 
-class Move128 : public ByteCode {
+class MoveF32 : public Move {
 public:
-    Move128(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
-        : ByteCode(Opcode::Move128Opcode)
-        , m_srcOffset(srcOffset)
-        , m_dstOffset(dstOffset)
+    MoveF32(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : Move(Opcode::MoveF32Opcode, srcOffset, dstOffset)
     {
     }
-
-    ByteCodeStackOffset srcOffset() const { return m_srcOffset; }
-    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
-        printf("move128 ");
+        printf("movef32 ");
         DUMP_BYTECODE_OFFSET(srcOffset);
         DUMP_BYTECODE_OFFSET(dstOffset);
     }
 #endif
+};
 
-protected:
-    ByteCodeStackOffset m_srcOffset;
-    ByteCodeStackOffset m_dstOffset;
+class MoveI64 : public Move {
+public:
+    MoveI64(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : Move(Opcode::MoveI64Opcode, srcOffset, dstOffset)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("movei64 ");
+        DUMP_BYTECODE_OFFSET(srcOffset);
+        DUMP_BYTECODE_OFFSET(dstOffset);
+    }
+#endif
+};
+
+class MoveF64 : public Move {
+public:
+    MoveF64(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : Move(Opcode::MoveF64Opcode, srcOffset, dstOffset)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("movef64 ");
+        DUMP_BYTECODE_OFFSET(srcOffset);
+        DUMP_BYTECODE_OFFSET(dstOffset);
+    }
+#endif
+};
+
+class MoveV128 : public Move {
+public:
+    MoveV128(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : Move(Opcode::MoveV128Opcode, srcOffset, dstOffset)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("movev128 ");
+        DUMP_BYTECODE_OFFSET(srcOffset);
+        DUMP_BYTECODE_OFFSET(dstOffset);
+    }
+#endif
 };
 
 class Load32 : public ByteCode {

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -743,30 +743,48 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
-    DEFINE_OPCODE(Move32)
+    DEFINE_OPCODE(MoveI32)
         :
     {
-        Move32* code = (Move32*)programCounter;
+        MoveI32* code = (MoveI32*)programCounter;
         *reinterpret_cast<uint32_t*>(bp + code->dstOffset()) = *reinterpret_cast<uint32_t*>(bp + code->srcOffset());
-        ADD_PROGRAM_COUNTER(Move32);
+        ADD_PROGRAM_COUNTER(MoveI32);
         NEXT_INSTRUCTION();
     }
 
-    DEFINE_OPCODE(Move64)
+    DEFINE_OPCODE(MoveF32)
         :
     {
-        Move64* code = (Move64*)programCounter;
+        MoveF32* code = (MoveF32*)programCounter;
+        *reinterpret_cast<float*>(bp + code->dstOffset()) = *reinterpret_cast<float*>(bp + code->srcOffset());
+        ADD_PROGRAM_COUNTER(MoveF32);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(MoveI64)
+        :
+    {
+        MoveI64* code = (MoveI64*)programCounter;
         *reinterpret_cast<uint64_t*>(bp + code->dstOffset()) = *reinterpret_cast<uint64_t*>(bp + code->srcOffset());
-        ADD_PROGRAM_COUNTER(Move64);
+        ADD_PROGRAM_COUNTER(MoveI64);
         NEXT_INSTRUCTION();
     }
 
-    DEFINE_OPCODE(Move128)
+    DEFINE_OPCODE(MoveF64)
         :
     {
-        Move128* code = (Move128*)programCounter;
+        MoveF64* code = (MoveF64*)programCounter;
+        *reinterpret_cast<double*>(bp + code->dstOffset()) = *reinterpret_cast<double*>(bp + code->srcOffset());
+        ADD_PROGRAM_COUNTER(MoveF64);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(MoveV128)
+        :
+    {
+        MoveV128* code = (MoveV128*)programCounter;
         memcpy(bp + code->dstOffset(), bp + code->srcOffset(), 16);
-        ADD_PROGRAM_COUNTER(Move128);
+        ADD_PROGRAM_COUNTER(MoveV128);
         NEXT_INSTRUCTION();
     }
 

--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -530,7 +530,7 @@ static void emitBrTable(sljit_compiler* compiler, BrTableInstruction* instr)
     context->branchTableOffset = reinterpret_cast<sljit_uw>(target);
 }
 
-static void emitMove32(sljit_compiler* compiler, Instruction* instr)
+static void emitMoveI32(sljit_compiler* compiler, Instruction* instr)
 {
     Operand* operands = instr->operands();
     JITArg src(operands);
@@ -788,18 +788,21 @@ void JITCompiler::compileFunction(JITFunction* jitFunc, bool isExternal)
         }
         case Instruction::Move: {
             switch (item->asInstruction()->opcode()) {
-            case ByteCode::Move32Opcode:
-                emitMove32(m_compiler, item->asInstruction());
+            case ByteCode::MoveI32Opcode:
+                emitMoveI32(m_compiler, item->asInstruction());
+                break;
+            case ByteCode::MoveI64Opcode:
+                emitMoveI64(m_compiler, item->asInstruction());
                 break;
 #ifdef HAS_SIMD
-            case ByteCode::Move128Opcode:
-                emitMove128(m_compiler, item->asInstruction());
+            case ByteCode::MoveV128Opcode:
+                emitMoveV128(m_compiler, item->asInstruction());
                 break;
 #endif /* HAS_SIMD */
             default:
-                ASSERT(item->asInstruction()->opcode() == ByteCode::Move64Opcode);
-                emitMove64(m_compiler, item->asInstruction());
-                break;
+                ASSERT(item->asInstruction()->opcode() == ByteCode::MoveF32Opcode
+                       || item->asInstruction()->opcode() == ByteCode::MoveF64Opcode);
+                emitMoveFloat(m_compiler, item->asInstruction());
             }
             break;
         }

--- a/src/jit/FloatMathInl.h
+++ b/src/jit/FloatMathInl.h
@@ -65,6 +65,24 @@ static void floatOperandToArg(sljit_compiler* compiler, Operand* operand, JITArg
     sljit_emit_fset64(compiler, srcReg, u.number);
 }
 
+static void emitMoveFloat(sljit_compiler* compiler, Instruction* instr)
+{
+    Operand* operands = instr->operands();
+
+    JITArg src;
+    JITArg dst(operands + 1);
+    sljit_s32 tmpReg = GET_TARGET_REG(dst.arg, SLJIT_TMP_DEST_FREG);
+
+    floatOperandToArg(compiler, operands + 0, src, tmpReg);
+
+    sljit_s32 op = (instr->opcode() == ByteCode::MoveF32Opcode) ? SLJIT_MOV_F32 : SLJIT_MOV_F64;
+
+    // Immediate to register case has already been handled.
+    if (dst.arg != src.arg || dst.argw != src.argw) {
+        sljit_emit_fop1(compiler, op, dst.arg, dst.argw, src.arg, src.argw);
+    }
+}
+
 // Float operations.
 // TODO Canonical NaN
 static sljit_f32 floatFloor(sljit_f32 operand)

--- a/src/jit/IntMath32Inl.h
+++ b/src/jit/IntMath32Inl.h
@@ -1180,7 +1180,7 @@ static void emitConvert(sljit_compiler* compiler, Instruction* instr)
     }
 }
 
-static void emitMove64(sljit_compiler* compiler, Instruction* instr)
+static void emitMoveI64(sljit_compiler* compiler, Instruction* instr)
 {
     Operand* operands = instr->operands();
     JITArgPair src(operands);

--- a/src/jit/IntMath64Inl.h
+++ b/src/jit/IntMath64Inl.h
@@ -561,7 +561,7 @@ static void emitConvert(sljit_compiler* compiler, Instruction* instr)
     }
 }
 
-static void emitMove64(sljit_compiler* compiler, Instruction* instr)
+static void emitMoveI64(sljit_compiler* compiler, Instruction* instr)
 {
     Operand* operands = instr->operands();
     JITArg src(operands);

--- a/src/jit/SimdInl.h
+++ b/src/jit/SimdInl.h
@@ -16,7 +16,7 @@
 
 /* Only included by jit-backend.cc */
 
-static void emitMove128(sljit_compiler* compiler, Instruction* instr)
+static void emitMoveV128(sljit_compiler* compiler, Instruction* instr)
 {
     Operand* operands = instr->operands();
     JITArg dst(operands + 1);

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -1592,15 +1592,32 @@ public:
 
     void generateMoveCodeIfNeeds(size_t srcPosition, size_t dstPosition, Walrus::Value::Type type)
     {
-        size_t size = Walrus::valueSize(type);
         if (srcPosition != dstPosition) {
-            if (size == 4) {
-                pushByteCode(Walrus::Move32(srcPosition, dstPosition), WASMOpcode::Move32Opcode);
-            } else if (size == 8) {
-                pushByteCode(Walrus::Move64(srcPosition, dstPosition), WASMOpcode::Move64Opcode);
-            } else {
-                ASSERT(size == 16);
-                pushByteCode(Walrus::Move128(srcPosition, dstPosition), WASMOpcode::Move128Opcode);
+            switch (type) {
+            case Walrus::Value::I32:
+                pushByteCode(Walrus::MoveI32(srcPosition, dstPosition), WASMOpcode::MoveI32Opcode);
+                break;
+            case Walrus::Value::F32:
+                pushByteCode(Walrus::MoveF32(srcPosition, dstPosition), WASMOpcode::MoveF32Opcode);
+                break;
+            case Walrus::Value::I64:
+                pushByteCode(Walrus::MoveI64(srcPosition, dstPosition), WASMOpcode::MoveI64Opcode);
+                break;
+            case Walrus::Value::F64:
+                pushByteCode(Walrus::MoveF64(srcPosition, dstPosition), WASMOpcode::MoveF64Opcode);
+                break;
+            case Walrus::Value::V128:
+                pushByteCode(Walrus::MoveV128(srcPosition, dstPosition), WASMOpcode::MoveV128Opcode);
+                break;
+            default:
+                ASSERT(type == Walrus::Value::FuncRef || type == Walrus::Value::ExternRef);
+
+                if (sizeof(size_t) == 4) {
+                    pushByteCode(Walrus::MoveI32(srcPosition, dstPosition), WASMOpcode::MoveI32Opcode);
+                } else {
+                    pushByteCode(Walrus::MoveI64(srcPosition, dstPosition), WASMOpcode::MoveI64Opcode);
+                }
+                break;
             }
         }
     }

--- a/src/parser/opcode.def
+++ b/src/parser/opcode.def
@@ -567,8 +567,10 @@ WABT_OPCODE(I64, I32, I64, I64, 2, 0xfe, 0x4d, I64AtomicRmw16CmpxchgU, "i64.atom
 WABT_OPCODE(I64, I32, I64, I64, 4, 0xfe, 0x4e, I64AtomicRmw32CmpxchgU, "i64.atomic.rmw32.cmpxchg_u", "")
 
 /* Walrus interpreter only opcodes */
-WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xe7, Move32, "move_32", "")
-WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xe8, Move64, "move_64", "")
-WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xe9, Move128, "move_128", "")
-WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xea, Const32, "const_32", "")
-WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xeb, Const64, "const_64", "")
+WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xe7, MoveI32, "move_i32", "")
+WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xe8, MoveF32, "move_f32", "")
+WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xe9, MoveI64, "move_i64", "")
+WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xea, MoveF64, "move_f64", "")
+WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xeb, MoveV128, "move_v128", "")
+WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xec, Const32, "const_32", "")
+WABT_OPCODE(___, ___, ___, ___, 0, 0, 0xed, Const64, "const_64", "")


### PR DESCRIPTION
This patch splits move32/64 to movei32/64 and movef32/64. The advantages of selecting `move` operation for this:

- Very simple implementation, the code size and speed of interpreter should not be affected. (I am not sure we can avoid code duplication because of computed goto labels)
- No need to parse move chains. E.g. `const32, move32, move32, add.f32` is difficult to track. There are still cases, such as `move32, store32`, which cannot be analyzed, but these should have minimal impact.

What do you think?