### PR TITLE
Fix BrIf optimization bug

### DIFF
--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -633,12 +633,12 @@ private:
 
     inline bool canBeInverted(size_t stackPos)
     {
-        /**
-         * m_lastI32EqzPos + sizeof(Walrus::I32Eqz) == m_currentFunction->currentByteCodeSize()
-         * checks if last byteCode is I32Eqz
-         *
-         * m_currentFunction->peekByteCode<Walrus::UnaryOperation>(m_lastI32EqzPos)->dstOffset() == stackPos
-         * checks if the output of I32Eqz is the input of JumpIfTrue/JumpIfFalse
+        /*
+          m_lastI32EqzPos + sizeof(Walrus::I32Eqz) == m_currentFunction->currentByteCodeSize()
+          checks if last byteCode is I32Eqz
+
+          m_currentFunction->peekByteCode<Walrus::UnaryOperation>(m_lastI32EqzPos)->dstOffset() == stackPos
+          checks if the output of I32Eqz is the input of JumpIfTrue/JumpIfFalse
         */
         return (m_lastI32EqzPos + sizeof(Walrus::I32Eqz) == m_currentFunction->currentByteCodeSize())
             && (m_currentFunction->peekByteCode<Walrus::UnaryOperation>(m_lastI32EqzPos)->dstOffset() == stackPos);
@@ -1801,11 +1801,12 @@ public:
         auto dropSize = dropStackValuesBeforeBrIfNeeds(depth);
         if (dropSize.second) {
             size_t pos = m_currentFunction->currentByteCodeSize();
-            if (UNLIKELY(isInverted)) {
-                pushByteCode(Walrus::JumpIfTrue(stackPos), WASMOpcode::BrIfOpcode);
-            } else {
-                pushByteCode(Walrus::JumpIfFalse(stackPos), WASMOpcode::BrIfOpcode);
-            }
+            // if (isInverted) {
+            //     pushByteCode(Walrus::JumpIfTrue(stackPos), WASMOpcode::BrIfOpcode);
+            // } else {
+            //     pushByteCode(Walrus::JumpIfFalse(stackPos), WASMOpcode::BrIfOpcode);
+            // }
+            pushByteCode(Walrus::JumpIfFalse(stackPos), WASMOpcode::BrIfOpcode);
             generateMoveValuesCodeRegardToDrop(dropSize);
 
             auto offset = (int32_t)blockInfo.m_position - (int32_t)m_currentFunction->currentByteCodeSize();


### PR DESCRIPTION
We came to notice that the BrIf and Eqz operation optimization introduced a new bug.

Take the following code for example:
```
(func (export "test10") (param i32) (result i32)
   i32.const 6
   i32.const 7
   block (result i32)
     local.get 0
     local.get 0
     i32.eqz
     br_if 0

     i32.const 5
     i32.le_s
   end
   select
)
```

Which currently generates the following bytecode:
```
0 const32 dstOffset: 8 value: 6
16 const32 dstOffset: 16 value: 7
32 const32 dstOffset: 24 value: 5
48 jump_if_true srcOffset: 0 dst: 96
64 movei32 srcOffset: 0 dstOffset: 48
80 jump dst: 112
96 I32LeS src1: 0 src2: 24 dst: 48
112 select condOffset: 48 src0Offset: 8 src1Offset: 16 dstOffset: 32
136 end resultOffsets: 32
```

The bytecode should generate `jump_if_false` instead of `jump_if_true` on offset 48. This patch aims to fix this bug.