### PR TITLE
Implement register allocator in JIT

### DIFF
--- a/src/jit/Analysis.cpp
+++ b/src/jit/Analysis.cpp
@@ -324,7 +324,7 @@ void JITCompiler::buildVariables(uint32_t requiredStackSize)
     DependencyGenContext dependencyCtx(dependencySize, requiredStackSize);
     bool updateDeps = true;
 
-    m_variableList = new VariableList(variableCount);
+    m_variableList = new VariableList(variableCount, requiredStackSize);
     nextTryBlock = m_tryBlockStart;
 
     for (uint32_t i = 0; i < requiredStackSize; i++) {
@@ -358,6 +358,8 @@ void JITCompiler::buildVariables(uint32_t requiredStackSize)
                             TagType* tagType = module()->tagType(it.tagIndex);
                             const ValueTypeVector& param = module()->functionType(tagType->sigIndex())->param();
                             Label* catchLabel = it.u.handler;
+
+                            m_variableList->pushCatchUpdate(catchLabel, param.size());
 
                             dependencyCtx.update(catchLabel->m_dependencyStart, catchLabel->id(),
                                                  STACK_OFFSET(it.stackSizeToBe), param, m_variableList);

--- a/src/jit/ByteCodeParser.cpp
+++ b/src/jit/ByteCodeParser.cpp
@@ -151,20 +151,19 @@ static bool isFloatGlobal(uint32_t globalIndex, Module* module)
     OL3(OTOp2F32, /* SSD */ F32, F32, F32 | S0 | S1)                                    \
     OL3(OTOp2F64, /* SSD */ F64, F64, F64 | S0 | S1)                                    \
     OL1(OTGetI32, /* S */ I32)                                                          \
-    OL1(OTPutI32, /* D */ I32 | TMP)                                                    \
+    OL1(OTPutI32, /* D */ I32)                                                          \
     OL1(OTPutI64, /* D */ I64)                                                          \
     OL1(OTPutV128, /* D */ V128)                                                        \
     OL1(OTPutPTR, /* D */ PTR)                                                          \
-    OL2(OTMoveI32, /* SD */ I32, I32 | S0)                                              \
     OL2(OTMoveF32, /* SD */ F32 | NOTMP, F32 | S0)                                      \
-    OL2(OTMoveI64, /* SD */ I64, I64 | S0)                                              \
     OL2(OTMoveF64, /* SD */ F64 | NOTMP, F64 | S0)                                      \
     OL2(OTMoveV128, /* SD */ V128, V128 | S0)                                           \
-    OL2(OTI32ReinterpretF32, /* SD */ I32, F32)                                         \
-    OL2(OTI64ReinterpretF64, /* SD */ I64, F64)                                         \
-    OL2(OTF32ReinterpretI32, /* SD */ F32, I32)                                         \
-    OL2(OTF64ReinterpretI64, /* SD */ F32, I32)                                         \
-    OL3(OTCompareI64, /* SSD */ I64, I64, I32 | S0 | S1)                                \
+    OL2(OTI32ReinterpretF32, /* SD */ F32, I32)                                         \
+    OL2(OTI64ReinterpretF64, /* SD */ F64, I64)                                         \
+    OL2(OTF32ReinterpretI32, /* SD */ I32, F32)                                         \
+    OL2(OTF64ReinterpretI64, /* SD */ I64, F64)                                         \
+    OL2(OTEqzI64, /* SD */ I64, I32)                                                    \
+    OL3(OTCompareI64, /* SSD */ I64, I64, I32)                                          \
     OL3(OTCompareF32, /* SSD */ F32, F32, I32)                                          \
     OL3(OTCompareF64, /* SSD */ F64, F64, I32)                                          \
     OL3(OTCopySignF32, /* SSD */ F32, F32, F32 | TMP | S0 | S1)                         \
@@ -172,14 +171,13 @@ static bool isFloatGlobal(uint32_t globalIndex, Module* module)
     OL2(OTDemoteF64, /* SD */ F64, F32 | S0)                                            \
     OL2(OTPromoteF32, /* SD */ F32, F64 | S0)                                           \
     OL4(OTLoadI32, /* SDTT */ I32, I32 | S0, PTR, I32 | S0)                             \
-    OL4(OTLoadI64, /* SDTT */ I32, I64 | S0, PTR, I32 | S0)                             \
     OL4(OTLoadF32, /* SDTT */ I32, F32, PTR, I32 | S0)                                  \
     OL4(OTLoadF64, /* SDTT */ I32, F64, PTR, I32 | S0)                                  \
     OL4(OTLoadV128, /* SDTT */ I32, V128 | TMP, PTR, I32 | S0)                          \
     OL5(OTLoadLaneV128, /* SSDTTT */ I32, V128 | NOTMP, V128 | TMP | S1, PTR, I32 | S0) \
     OL5(OTStoreI32, /* SSTTT */ I32, I32, PTR, I32 | S0, I32 | S1)                      \
-    OL5(OTStoreI64, /* SSTTT */ I32, I64, PTR, I32 | S0, PTR | S1)                      \
     OL4(OTStoreF32, /* SSTT */ I32, F32 | NOTMP, PTR, I32 | S0)                         \
+    OL5(OTStoreI64, /* SSTTT */ I32, I64, PTR, I32 | S0, PTR | S1)                      \
     OL4(OTStoreF64, /* SSTT */ I32, F64 | NOTMP, PTR, I32 | S0)                         \
     OL4(OTStoreV128, /* SSTT */ I32, V128 | TMP, PTR, I32 | S0)                         \
     OL3(OTCallback3Arg, /* SSS */ I32, I32, I32)                                        \
@@ -192,8 +190,8 @@ static bool isFloatGlobal(uint32_t globalIndex, Module* module)
     OL2(OTGlobalSetI64, /* ST */ I64, PTR)                                              \
     OL1(OTGlobalSetF32, /* S */ F32 | NOTMP)                                            \
     OL1(OTGlobalSetF64, /* S */ F64 | NOTMP)                                            \
-    OL2(OTConvertInt32FromInt64, /* SD */ I64, I32 | S0)                                \
-    OL2(OTConvertInt64FromInt32, /* SD */ I32, I64 | S0)                                \
+    OL2(OTConvertInt32FromInt64, /* SD */ I64, I32)                                     \
+    OL2(OTConvertInt64FromInt32, /* SD */ I32, I64)                                     \
     OL2(OTConvertInt32FromFloat32, /* SD */ F32 | TMP, I32 | TMP)                       \
     OL2(OTConvertInt32FromFloat64, /* SD */ F64 | TMP, I32 | TMP)                       \
     OL2(OTConvertInt64FromFloat32Callback, /* SD */ F32, I64)                           \
@@ -211,9 +209,10 @@ static bool isFloatGlobal(uint32_t globalIndex, Module* module)
 #define OPERAND_TYPE_LIST_MATH                                              \
     OL3(OTOp2I64, /* SSD */ I64, I64, I64 | TMP | S0 | S1)                  \
     OL3(OTShiftI64, /* SSD */ I64, I64 | LOW, I64 | TMP | S0)               \
-    OL4(OTMulI64, /* SSDT */ I64, I64, I64 | TMP | S0, I32 | S1)            \
+    OL3(OTMulI64, /* SSDT */ I64, I64, I64 | S0 | S1)                       \
     OL3(OTDivRemI64, /* SSD */ I64, I64, I64 | S0 | S1)                     \
     OL2(OTCountZeroesI64, /* SD */ I64, I64 | TMP | S0)                     \
+    OL4(OTLoadI64, /* SDTT */ I32, I64, PTR, I32 | S0)                      \
     OL5(OTStoreI64Low, /* SSTTT */ I32, I64 | LOW, PTR, I32 | S0, PTR | S1) \
     OL1(OTGlobalGetI64, /* D */ I64_LOW)                                    \
     OL2(OTConvertInt32FromFloat32Callback, /* SD */ F32, I32)               \
@@ -224,6 +223,7 @@ static bool isFloatGlobal(uint32_t globalIndex, Module* module)
 
 #define OPERAND_TYPE_LIST_MATH                                    \
     OL3(OTOp2I64, /* SSD */ I64, I64, I64 | S0 | S1)              \
+    OL4(OTLoadI64, /* SDTT */ I32, I64 | S0, PTR, I32 | S0)       \
     OL1(OTGlobalGetI64, /* D */ I64)                              \
     OL2(OTConvertInt64FromFloat32, /* SD */ F32 | TMP, I64 | TMP) \
     OL2(OTConvertInt64FromFloat64, /* SD */ F64 | TMP, I64 | TMP) \
@@ -238,8 +238,8 @@ static bool isFloatGlobal(uint32_t globalIndex, Module* module)
     OL1(OTGlobalSetV128, /* S */ V128 | NOTMP)                                             \
     OL2(OTSplatI32, /* SD */ I32, V128 | TMP)                                              \
     OL2(OTSplatI64, /* SD */ I64, V128 | TMP)                                              \
-    OL2(OTSplatF32, /* SD */ F32 | NOTMP, V128 | TMP | S0)                                 \
-    OL2(OTSplatF64, /* SD */ F64 | NOTMP, V128 | TMP | S0)                                 \
+    OL2(OTSplatF32, /* SD */ F32 | NOTMP, V128 | TMP)                                      \
+    OL2(OTSplatF64, /* SD */ F64 | NOTMP, V128 | TMP)                                      \
     OL2(OTV128ToI32, /* SD */ V128 | TMP, I32)                                             \
     OL4(OTBitSelectV128, /* SSSD */ V128 | TMP, V128 | TMP, V128 | NOTMP, V128 | TMP | S2) \
     OL2(OTExtractLaneI64, /* SD */ V128 | TMP, I64)                                        \
@@ -569,7 +569,7 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::I64GeUOpcode: {
             group = Instruction::Compare;
             paramCount = 2;
-            info = Instruction::kIsMergeCompare;
+            info = Instruction::kIsMergeCompare | Instruction::kFreeUnusedEarly;
             requiredInit = OTCompareI64;
             break;
         }
@@ -727,13 +727,14 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::I64EqzOpcode: {
             group = Instruction::Compare;
             paramCount = 1;
-            info = Instruction::kIsMergeCompare;
-            requiredInit = OTOp1I64;
+            info = Instruction::kIsMergeCompare | Instruction::kFreeUnusedEarly;
+            requiredInit = OTEqzI64;
             break;
         }
         case ByteCode::I32WrapI64Opcode: {
             group = Instruction::Convert;
             paramCount = 1;
+            info = Instruction::kFreeUnusedEarly;
             requiredInit = OTConvertInt32FromInt64;
             break;
         }
@@ -741,6 +742,7 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::I64ExtendI32UOpcode: {
             group = Instruction::Convert;
             paramCount = 1;
+            info = Instruction::kFreeUnusedEarly;
             requiredInit = OTConvertInt64FromInt32;
             break;
         }
@@ -938,6 +940,7 @@ static void compileFunction(JITCompiler* compiler)
             Instruction* instr = compiler->appendExtended(byteCode, Instruction::Call, opcode,
                                                           functionType->param().size() + callerCount, functionType->result().size());
             Operand* operand = instr->operands();
+            instr->addInfo(Instruction::kIsCallback | Instruction::kFreeUnusedEarly);
 
             for (auto it : functionType->param()) {
                 operand->ref = STACK_OFFSET(*stackOffset);
@@ -1210,12 +1213,14 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::F32X4SplatOpcode: {
             group = Instruction::SplatSIMD;
             paramCount = 1;
+            info = Instruction::kFreeUnusedEarly;
             requiredInit = OTSplatF32;
             break;
         }
         case ByteCode::F64X2SplatOpcode: {
             group = Instruction::SplatSIMD;
             paramCount = 1;
+            info = Instruction::kFreeUnusedEarly;
             requiredInit = OTSplatF64;
             break;
         }
@@ -1468,13 +1473,13 @@ static void compileFunction(JITCompiler* compiler)
 
             switch (opcode) {
             case ByteCode::MoveI32Opcode:
-                requiredInit = OTMoveI32;
+                requiredInit = OTOp1I32;
                 break;
             case ByteCode::MoveF32Opcode:
                 requiredInit = OTMoveF32;
                 break;
             case ByteCode::MoveI64Opcode:
-                requiredInit = OTMoveI64;
+                requiredInit = OTOp1I64;
                 break;
             case ByteCode::MoveF64Opcode:
                 requiredInit = OTMoveF64;
@@ -1513,7 +1518,6 @@ static void compileFunction(JITCompiler* compiler)
             Operand* operands = instr->operands();
 
             if (isFloatGlobal(globalGet32->index(), compiler->module())) {
-                instr->addInfo(Instruction::kIsGlobalFloatBit);
                 instr->setRequiredRegsDescriptor(OTGlobalGetF32);
             }
 
@@ -1528,7 +1532,6 @@ static void compileFunction(JITCompiler* compiler)
             Operand* operands = instr->operands();
 
             if (isFloatGlobal(globalGet64->index(), compiler->module())) {
-                instr->addInfo(Instruction::kIsGlobalFloatBit);
                 instr->setRequiredRegsDescriptor(OTGlobalGetF64);
             }
 
@@ -1553,7 +1556,6 @@ static void compileFunction(JITCompiler* compiler)
             Operand* operands = instr->operands();
 
             if (isFloatGlobal(globalSet32->index(), compiler->module())) {
-                instr->addInfo(Instruction::kIsGlobalFloatBit);
                 instr->setRequiredRegsDescriptor(OTGlobalSetF32);
             }
 
@@ -1568,7 +1570,6 @@ static void compileFunction(JITCompiler* compiler)
             Operand* operands = instr->operands();
 
             if (isFloatGlobal(globalSet64->index(), compiler->module())) {
-                instr->addInfo(Instruction::kIsGlobalFloatBit);
                 instr->setRequiredRegsDescriptor(OTGlobalSetF64);
             }
 
@@ -1920,16 +1921,55 @@ static void compileFunction(JITCompiler* compiler)
 
     compiler->buildVariables(STACK_OFFSET(function->requiredStackSize()));
 
+    if (compiler->JITFlags() & JITFlagValue::disableRegAlloc) {
+        compiler->allocateRegistersSimple();
+    } else {
+        compiler->allocateRegisters();
+    }
+
     if (compiler->JITFlags() & JITFlagValue::JITVerbose) {
         compiler->dump();
     }
 
-    compiler->allocateRegisters();
+    compiler->freeVariables();
 
     Walrus::JITFunction* jitFunc = new JITFunction();
 
     function->setJITFunction(jitFunc);
     compiler->compileFunction(jitFunc, true);
+}
+
+const uint8_t* VariableList::getOperandDescriptor(Instruction* instr)
+{
+    uint32_t requiredInit = OTNone;
+
+    switch (instr->opcode()) {
+    case ByteCode::Load32Opcode:
+        requiredInit = OTLoadF32;
+        break;
+    case ByteCode::Load64Opcode:
+        requiredInit = OTLoadF64;
+        break;
+    case ByteCode::Store32Opcode:
+        requiredInit = OTStoreF32;
+        break;
+    case ByteCode::Store64Opcode:
+        requiredInit = OTStoreF64;
+        break;
+    default:
+        break;
+    }
+
+    if (requiredInit != OTNone) {
+        ASSERT((instr->paramCount() + instr->resultCount()) == 2);
+        VariableList::Variable& variable = variables[instr->getParam(1)->ref];
+
+        if (variable.info & Instruction::FloatOperandMarker) {
+            return Instruction::getOperandDescriptorByOffset(requiredInit);
+        }
+    }
+
+    return instr->getOperandDescriptor();
 }
 
 void Module::jitCompile(ModuleFunction** functions, size_t functionsLength, uint32_t JITFlags)

--- a/src/jit/RegisterAlloc.cpp
+++ b/src/jit/RegisterAlloc.cpp
@@ -23,8 +23,880 @@
 
 namespace Walrus {
 
+class RegisterSet {
+public:
+    RegisterSet(uint32_t numberOfScratchRegs, uint32_t numberOfSavedRegs, bool isInteger);
+
+    void reserve(uint8_t reg) { m_registers[reg].rangeEnd = kReservedReg; }
+
+    void updateVariable(uint8_t reg, VariableList::Variable* variable)
+    {
+        ASSERT(m_registers[reg].rangeEnd != kUnassignedReg && m_registers[reg].variable != nullptr);
+        m_registers[reg].variable = variable;
+    }
+
+    uint8_t getSavedRegCount() { return static_cast<uint8_t>(m_usedSavedRegisters - m_savedStartIndex); }
+
+    uint8_t toCPUReg(uint8_t reg);
+    bool check(int8_t reg, uint16_t constraints);
+    void freeUnusedRegisters(size_t id);
+    uint8_t allocateRegister(VariableList::Variable* variable);
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+    uint8_t allocateRegisterPair(VariableList::Variable* variable, uint8_t* otherReg);
+
+    void setDestroysR0R1()
+    {
+        m_regStatus |= kDestroysR0R1;
+    }
+
+    void clearDestroysR0R1()
+    {
+        m_regStatus = static_cast<uint8_t>(m_regStatus & ~kDestroysR0R1);
+    }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+    uint8_t allocateQuadRegister(VariableList::Variable* variable);
+#endif /* SLJIT_CONFIG_ARM_32 */
+
+private:
+    static const uint8_t kIsInteger = 1 << 0;
+    static const uint8_t kDestroysR0R1 = 1 << 1;
+
+    static const size_t kReservedReg = 0;
+    static const size_t kUnassignedReg = ~(size_t)0;
+
+    struct RegisterInfo {
+        RegisterInfo()
+            : rangeEnd(kUnassignedReg)
+            , variable(nullptr)
+        {
+        }
+
+        size_t rangeEnd;
+        VariableList::Variable* variable;
+    };
+
+    // Free registers.
+    uint8_t m_regStatus;
+    uint8_t m_savedStartIndex;
+    uint8_t m_usedSavedRegisters;
+
+    // Allocated registers.
+    std::vector<RegisterInfo> m_registers;
+};
+
+class RegisterFile {
+public:
+    RegisterFile(uint32_t numberOfIntegerScratchRegs, uint32_t numberOfIntegerSavedRegs,
+                 uint32_t numberOfFloatScratchRegs, uint32_t numberOfFloatSavedRegs)
+        : m_integerSet(numberOfIntegerScratchRegs, numberOfIntegerSavedRegs, true)
+        , m_floatSet(numberOfFloatScratchRegs, numberOfFloatSavedRegs, false)
+    {
+    }
+
+    RegisterSet& integerSet() { return m_integerSet; }
+    RegisterSet& floatSet() { return m_floatSet; }
+
+    uint8_t toCPUIntegerReg(uint8_t reg)
+    {
+        return m_integerSet.toCPUReg(reg);
+    }
+
+    uint8_t toCPUFloatReg(uint8_t reg)
+    {
+        return m_floatSet.toCPUReg(reg);
+    }
+
+    void integerReserve(uint8_t reg)
+    {
+        m_integerSet.reserve(reg);
+    }
+
+    void floatReserve(uint8_t reg)
+    {
+        m_floatSet.reserve(reg);
+    }
+
+    void allocateVariable(VariableList::Variable* variable)
+    {
+        uint8_t type = variable->info & Instruction::TypeMask;
+        ASSERT(type > 0);
+
+        if (type & Instruction::FloatOperandMarker) {
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+            if ((variable->info & Instruction::TypeMask) == Instruction::V128Operand) {
+                m_floatSet.allocateQuadRegister(variable);
+                return;
+            }
+#endif /* SLJIT_CONFIG_ARM_32 */
+            m_floatSet.allocateRegister(variable);
+            return;
+        }
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        if (type == Instruction::Int64Operand) {
+            m_integerSet.allocateRegisterPair(variable, nullptr);
+            return;
+        }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
+        m_integerSet.allocateRegister(variable);
+    }
+
+    void freeUnusedRegisters(size_t id)
+    {
+        m_integerSet.freeUnusedRegisters(id);
+        m_floatSet.freeUnusedRegisters(id);
+    }
+
+    bool reuseResult(uint8_t type, VariableList::Variable** reusableRegs, VariableList::Variable* resultVariable);
+
+private:
+    RegisterSet m_integerSet;
+    RegisterSet m_floatSet;
+};
+
+RegisterSet::RegisterSet(uint32_t numberOfScratchRegs, uint32_t numberOfSavedRegs, bool isInteger)
+    : m_regStatus(isInteger ? kIsInteger : 0)
+    , m_savedStartIndex(numberOfScratchRegs)
+    , m_usedSavedRegisters(numberOfScratchRegs)
+{
+    m_registers.resize(numberOfScratchRegs + numberOfSavedRegs);
+}
+
+uint8_t RegisterSet::toCPUReg(uint8_t reg)
+{
+    if (reg < m_savedStartIndex) {
+        return SLJIT_R0 + reg;
+    }
+
+    uint8_t base = (m_regStatus & kIsInteger) ? SLJIT_S2 : SLJIT_FS0;
+    return base - (reg - m_savedStartIndex);
+}
+
+bool RegisterSet::check(int8_t reg, uint16_t constraints)
+{
+    if (constraints & VariableList::kIsCallback) {
+        return reg >= m_savedStartIndex;
+    }
+
+    if ((m_regStatus & kIsInteger) && (constraints & VariableList::kDestroysR0R1)) {
+        return reg >= 2;
+    }
+
+    return true;
+}
+
+void RegisterSet::freeUnusedRegisters(size_t id)
+{
+    size_t size = m_registers.size();
+
+    for (size_t i = 0; i < size; i++) {
+        RegisterInfo& info = m_registers[i];
+
+        if (info.rangeEnd == kReservedReg) {
+            if (info.variable == nullptr) {
+                info.rangeEnd = kUnassignedReg;
+                continue;
+            }
+
+            info.rangeEnd = info.variable->rangeEnd;
+        }
+
+        if (info.rangeEnd < id) {
+            info.rangeEnd = kUnassignedReg;
+            info.variable = nullptr;
+        }
+    }
+}
+
+uint8_t RegisterSet::allocateRegister(VariableList::Variable* variable)
+{
+    size_t maxRangeEnd = 0;
+    size_t maxRangeIndex = 0;
+    uint16_t constraints = variable != nullptr ? variable->info : 0;
+    size_t size = m_registers.size();
+    size_t i = 0;
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+    if (m_regStatus & kDestroysR0R1) {
+        constraints = VariableList::kDestroysR0R1;
+    }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
+    if (constraints & VariableList::kIsCallback) {
+        i = m_savedStartIndex;
+    } else if ((constraints & VariableList::kDestroysR0R1) && (m_regStatus & kIsInteger)) {
+        i = 2;
+    }
+
+    while (i < size) {
+        if (m_registers[i].rangeEnd == kUnassignedReg) {
+            break;
+        }
+
+        if (m_registers[i].rangeEnd > maxRangeEnd) {
+            maxRangeEnd = m_registers[i].rangeEnd;
+            maxRangeIndex = i;
+        }
+
+        i++;
+    }
+
+    if (i == size) {
+        ASSERT(maxRangeEnd != 0 || variable != nullptr);
+
+        if (variable != nullptr && variable->rangeEnd >= maxRangeEnd) {
+            return VariableList::kUnusedReg;
+        }
+
+        // Move variable into memory.
+        i = maxRangeIndex;
+        ASSERT(m_registers[i].variable != nullptr);
+
+        VariableList::Variable* prevVariable = m_registers[i].variable;
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        if (prevVariable->reg2 != prevVariable->reg1) {
+            size_t other = (i == prevVariable->reg1) ? prevVariable->reg2 : prevVariable->reg1;
+
+            m_registers[other].rangeEnd = kUnassignedReg;
+            m_registers[other].variable = nullptr;
+        }
+        prevVariable->reg2 = VariableList::kUnusedReg;
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+        prevVariable->reg1 = VariableList::kUnusedReg;
+    }
+
+    // Allocated registers are also reserved for the current byte code.
+    m_registers[i].rangeEnd = kReservedReg;
+    m_registers[i].variable = variable;
+
+    if (variable != nullptr) {
+        variable->reg1 = i;
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        variable->reg2 = i;
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+    }
+
+    if (i >= m_usedSavedRegisters) {
+        m_usedSavedRegisters = i + 1;
+    }
+
+    return i;
+}
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+uint8_t RegisterSet::allocateRegisterPair(VariableList::Variable* variable, uint8_t* otherReg)
+{
+    size_t maxRangeEndSingle1 = 0;
+    size_t maxRangeIndexSingle1 = 0;
+    size_t maxRangeEndSingle2 = 0;
+    size_t maxRangeIndexSingle2 = 0;
+    size_t maxRangeEndPair = 0;
+    size_t maxRangeIndexPair = 0;
+    size_t freeReg = VariableList::kUnusedReg;
+    uint16_t constraints = variable != nullptr ? variable->info : 0;
+    size_t size = m_registers.size();
+    size_t i = 0;
+
+    if (constraints & VariableList::kIsCallback) {
+        i = m_savedStartIndex;
+    } else if ((constraints & VariableList::kDestroysR0R1) && (m_regStatus & kIsInteger)) {
+        i = 2;
+    }
+
+    while (i < size) {
+        if (m_registers[i].rangeEnd == kUnassignedReg) {
+            if (freeReg != VariableList::kUnusedReg) {
+                break;
+            }
+
+            freeReg = i;
+        } else if (m_registers[i].variable != nullptr) {
+            VariableList::Variable* targetVariable = m_registers[i].variable;
+
+            if (targetVariable->reg1 != targetVariable->reg2) {
+                if (targetVariable->rangeEnd > maxRangeEndPair) {
+                    maxRangeEndPair = targetVariable->rangeEnd;
+                    maxRangeIndexPair = i;
+                }
+            } else if (targetVariable->rangeEnd > maxRangeEndSingle1) {
+                maxRangeEndSingle2 = maxRangeEndSingle1;
+                maxRangeIndexSingle2 = maxRangeIndexSingle1;
+                maxRangeEndSingle1 = targetVariable->rangeEnd;
+                maxRangeIndexSingle1 = i;
+            } else if (targetVariable->rangeEnd > maxRangeEndSingle2) {
+                maxRangeEndSingle2 = targetVariable->rangeEnd;
+                maxRangeIndexSingle2 = i;
+            }
+        }
+
+        i++;
+    }
+
+    ASSERT(maxRangeEndSingle2 <= maxRangeEndSingle1);
+
+    if (i == size) {
+        if (maxRangeEndPair == 0
+            && (maxRangeEndSingle1 == 0 || (maxRangeEndSingle2 == 0 && freeReg == VariableList::kUnusedReg))) {
+            ASSERT(variable != nullptr);
+            return VariableList::kUnusedReg;
+        }
+
+        size_t maxRangeEnd;
+
+        if (freeReg != VariableList::kUnusedReg) {
+            if (maxRangeEndSingle1 >= maxRangeEndPair) {
+                i = maxRangeIndexSingle1;
+                maxRangeEnd = maxRangeEndSingle1;
+            } else {
+                i = maxRangeEndPair;
+                maxRangeEnd = maxRangeEndPair;
+            }
+        } else if (maxRangeEndPair < maxRangeEndSingle1 && maxRangeEndPair < maxRangeEndSingle2) {
+            i = maxRangeIndexSingle1;
+            maxRangeEnd = maxRangeEndSingle2;
+            freeReg = maxRangeIndexSingle2;
+
+            VariableList::Variable* prevVariable = m_registers[freeReg].variable;
+            prevVariable->reg1 = VariableList::kUnusedReg;
+            prevVariable->reg2 = VariableList::kUnusedReg;
+        } else {
+            i = maxRangeIndexPair;
+            maxRangeEnd = maxRangeEndPair;
+
+            VariableList::Variable* targetVariable = m_registers[i].variable;
+            freeReg = (targetVariable->reg1 != i) ? targetVariable->reg1 : targetVariable->reg2;
+        }
+
+        if (variable != nullptr && variable->rangeEnd >= maxRangeEnd) {
+            return VariableList::kUnusedReg;
+        }
+
+        // Move variable into memory.
+        VariableList::Variable* prevVariable = m_registers[i].variable;
+        ASSERT(prevVariable != nullptr);
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        if (prevVariable->reg2 != prevVariable->reg1) {
+            size_t other = (i == prevVariable->reg1) ? prevVariable->reg2 : prevVariable->reg1;
+
+            ASSERT(other != VariableList::kUnusedReg);
+            m_registers[other].rangeEnd = 0;
+            m_registers[other].variable = nullptr;
+        }
+        prevVariable->reg2 = VariableList::kUnusedReg;
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+        prevVariable->reg1 = VariableList::kUnusedReg;
+    }
+
+    ASSERT(i < size && freeReg < size);
+
+    // Allocated registers are also reserved for the current byte code.
+    m_registers[i].rangeEnd = kReservedReg;
+    m_registers[i].variable = variable;
+    m_registers[freeReg].rangeEnd = kReservedReg;
+    m_registers[freeReg].variable = variable;
+
+    if (variable != nullptr) {
+        variable->reg1 = freeReg;
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        variable->reg2 = i;
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+    }
+
+    if (i >= m_usedSavedRegisters) {
+        m_usedSavedRegisters = i + 1;
+    }
+
+    if (freeReg >= m_usedSavedRegisters) {
+        m_usedSavedRegisters = freeReg + 1;
+    }
+
+    if (otherReg != nullptr) {
+        *otherReg = i;
+    }
+
+    return freeReg;
+}
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+uint8_t RegisterSet::allocateQuadRegister(VariableList::Variable* variable)
+{
+    size_t maxRangeEnd = 0;
+    size_t maxRangeIndex = 0;
+    uint16_t constraints = variable != nullptr ? variable->info : 0;
+    size_t size = m_registers.size();
+    size_t i = 0;
+
+    ASSERT(!(m_regStatus & kIsInteger) && (size & 0x1) == 0);
+
+    if (constraints & VariableList::kIsCallback) {
+        i = m_savedStartIndex;
+    }
+
+    while (i < size) {
+        if (m_registers[i].rangeEnd == kUnassignedReg) {
+            if (m_registers[i + 1].rangeEnd == kUnassignedReg) {
+                break;
+            }
+
+            if (m_registers[i + 1].rangeEnd > maxRangeEnd) {
+                maxRangeEnd = m_registers[i + 1].rangeEnd;
+                maxRangeIndex = i;
+            }
+        } else if (m_registers[i + 1].rangeEnd == kUnassignedReg) {
+            if (m_registers[i].rangeEnd > maxRangeEnd) {
+                maxRangeEnd = m_registers[i].rangeEnd;
+                maxRangeIndex = i;
+            }
+        } else {
+            size_t averageEnd = ((m_registers[i].rangeEnd + m_registers[i + 1].rangeEnd) + 1) >> 1;
+
+            if (averageEnd > maxRangeEnd) {
+                maxRangeEnd = averageEnd;
+                maxRangeIndex = i;
+            }
+        }
+
+        i += 2;
+    }
+
+    if (i == size) {
+        ASSERT(maxRangeEnd != 0 || variable != nullptr);
+
+        if (variable != nullptr && variable->rangeEnd >= maxRangeEnd) {
+            return VariableList::kUnusedReg;
+        }
+
+        // Move variable into memory.
+        i = maxRangeIndex;
+        ASSERT(m_registers[i].variable != nullptr);
+
+        VariableList::Variable* prevVariable = m_registers[i].variable;
+        ASSERT(prevVariable->reg2 == prevVariable->reg1 || prevVariable->reg2 == prevVariable->reg1 + 1);
+        prevVariable->reg1 = VariableList::kUnusedReg;
+        prevVariable->reg2 = VariableList::kUnusedReg;
+
+        prevVariable = m_registers[i + 1].variable;
+        ASSERT(prevVariable->reg2 == prevVariable->reg1 || prevVariable->reg2 == prevVariable->reg1 + 1);
+        prevVariable->reg1 = VariableList::kUnusedReg;
+        prevVariable->reg2 = VariableList::kUnusedReg;
+    }
+
+    // Allocated registers are also reserved for the current byte code.
+    m_registers[i].rangeEnd = kReservedReg;
+    m_registers[i].variable = variable;
+    m_registers[i + 1].rangeEnd = kReservedReg;
+    m_registers[i + 1].variable = variable;
+
+    if (variable != nullptr) {
+        variable->reg1 = i;
+        variable->reg2 = i + 1;
+    }
+
+    if (i + 1 >= static_cast<size_t>(m_usedSavedRegisters)) {
+        m_usedSavedRegisters = i + 2;
+    }
+
+    return i;
+}
+#endif /* SLJIT_CONFIG_ARM_32 */
+
+static inline int reuseTemporary(uint8_t type, VariableList::Variable** reusableRegs)
+{
+    if (!(type & (Instruction::Src0Allowed | Instruction::Src1Allowed | Instruction::Src2Allowed))) {
+        return -1;
+    }
+
+    for (uint32_t i = 0; i < 3; i++) {
+        if ((type & (Instruction::Src0Allowed << i)) && reusableRegs[i] != nullptr) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+bool RegisterFile::reuseResult(uint8_t type, VariableList::Variable** reusableRegs, VariableList::Variable* resultVariable)
+{
+    if (!(type & (Instruction::Src0Allowed | Instruction::Src1Allowed | Instruction::Src2Allowed))) {
+        return false;
+    }
+
+    uint16_t constraints = resultVariable->info;
+    RegisterSet& registers = (type & Instruction::FloatOperandMarker) ? m_floatSet : m_integerSet;
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+    bool isInt64 = (type & Instruction::TypeMask) == Instruction::Int64Operand;
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
+    for (uint32_t i = 0; i < 3; i++) {
+        VariableList::Variable* variable = reusableRegs[i];
+        if ((type & (Instruction::Src0Allowed << i)) && variable != nullptr && registers.check(variable->reg1, constraints)) {
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+            if (isInt64 && !registers.check(variable->reg2, constraints)) {
+                continue;
+            }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
+            reusableRegs[i] = nullptr;
+
+            resultVariable->reg1 = variable->reg1;
+            registers.updateVariable(resultVariable->reg1, resultVariable);
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+            resultVariable->reg2 = variable->reg2;
+            registers.updateVariable(resultVariable->reg2, resultVariable);
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void JITCompiler::allocateRegisters()
 {
+    if (m_variableList == nullptr) {
+        m_savedIntegerRegCount = 0;
+        m_savedFloatRegCount = 0;
+        return;
+    }
+
+#if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
+    const uint32_t numberOfscratchRegs = 3;
+    const uint32_t numberOfsavedRegs = 1;
+#else /* !SLJIT_CONFIG_X86_32 */
+    const uint32_t numberOfscratchRegs = SLJIT_NUMBER_OF_SCRATCH_REGISTERS;
+    const uint32_t numberOfsavedRegs = SLJIT_NUMBER_OF_SAVED_REGISTERS - 2;
+#endif /* SLJIT_CONFIG_X86_32 */
+
+    RegisterFile regs(numberOfscratchRegs, numberOfsavedRegs,
+                      SLJIT_NUMBER_OF_SCRATCH_FLOAT_REGISTERS, SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS);
+
+    size_t variableListParamCount = m_variableList->paramCount;
+    for (size_t i = 0; i < variableListParamCount; i++) {
+        VariableList::Variable* variable = m_variableList->variables.data() + i;
+
+        ASSERT(!(variable->info & VariableList::kIsImmediate));
+
+        if (variable->info & VariableList::kIsMerged) {
+            continue;
+        }
+
+        ASSERT(variable->u.rangeStart == 0);
+
+        if (variable->rangeEnd == 0) {
+            continue;
+        }
+
+        regs.allocateVariable(variable);
+    }
+
+    for (InstructionListItem* item = m_first; item != nullptr; item = item->next()) {
+        if (item->isLabel()) {
+            continue;
+        }
+
+        Instruction* instr = item->asInstruction();
+        Operand* operand = instr->operands();
+        const uint8_t* list = m_variableList->getOperandDescriptor(instr);
+        uint32_t paramCount = instr->paramCount();
+        size_t instrId = instr->id();
+        bool hasResult = instr->resultCount() > 0;
+
+        regs.freeUnusedRegisters(instrId + ((instr->info() & Instruction::kFreeUnusedEarly) ? 1 : 0));
+        operand = instr->operands();
+        instr->setRequiredRegsDescriptor(0);
+
+        if (*list == 0) {
+            // No register assignment required.
+            ASSERT(instr->opcode() == ByteCode::EndOpcode || instr->opcode() == ByteCode::ThrowOpcode
+                   || instr->opcode() == ByteCode::CallOpcode || instr->opcode() == ByteCode::CallIndirectOpcode
+                   || instr->opcode() == ByteCode::ElemDropOpcode || instr->opcode() == ByteCode::DataDropOpcode
+                   || instr->opcode() == ByteCode::JumpOpcode || instr->opcode() == ByteCode::UnreachableOpcode);
+
+            if (!hasResult) {
+                continue;
+            }
+
+            operand += paramCount;
+            Operand* end = operand + instr->resultCount();
+
+            while (operand < end) {
+                VariableList::Variable* resultVariable = m_variableList->variables.data() + operand->ref;
+
+                if (resultVariable->u.rangeStart == instrId && resultVariable->rangeEnd != instrId) {
+                    regs.allocateVariable(resultVariable);
+                }
+                operand++;
+            }
+            continue;
+        }
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        if (instr->opcode() == ByteCode::I64MulOpcode) {
+            regs.integerSet().setDestroysR0R1();
+            instr->setRequiredReg(0, regs.toCPUIntegerReg(regs.integerSet().allocateRegister(nullptr)));
+            regs.integerSet().clearDestroysR0R1();
+        }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
+        // Step 1: check params first. Source registers which live range ends
+        // can be reallocated if the corresponding SrcXAllowed flag is set.
+        ASSERT(paramCount <= 3 && instr->resultCount() <= 1);
+        VariableList::Variable* reusableRegs[3] = { nullptr };
+        uint32_t tmpIndex = 0;
+
+        for (uint32_t i = 0; i < paramCount; i++) {
+            ASSERT((*list & Instruction::TypeMask) >= Instruction::Int32Operand
+                   && (*list & Instruction::TypeMask) <= Instruction::Float64Operand);
+
+            VariableList::Variable* variable = m_variableList->variables.data() + operand->ref;
+
+            if (!(variable->info & VariableList::kIsImmediate)
+                && variable->rangeEnd == instrId
+                && variable->reg1 != VariableList::kUnusedReg) {
+                reusableRegs[i] = variable;
+            }
+
+            ASSERT(!(*list & Instruction::TmpRequired) || (*list & Instruction::FloatOperandMarker));
+
+            if ((*list & Instruction::FloatOperandMarker) && !(*list & Instruction::TmpNotAllowed)) {
+                // Source registers are read-only.
+                if ((*list & Instruction::TmpRequired) || (variable->info & VariableList::kIsImmediate)) {
+                    uint8_t reg = variable->reg1;
+
+                    if (reg != VariableList::kUnusedReg) {
+                        ASSERT(!(variable->info & VariableList::kIsImmediate));
+                        regs.floatReserve(reg);
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+                        if ((*list & Instruction::TypeMask) != Instruction::V128Operand) {
+                            regs.floatReserve(reg + 1);
+                        }
+#endif /* SLJIT_CONFIG_ARM_32 */
+                    } else {
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+                        if ((*list & Instruction::TypeMask) == Instruction::V128Operand) {
+                            reg = regs.floatSet().allocateQuadRegister(nullptr);
+                        } else {
+#endif /* SLJIT_CONFIG_ARM_32 */
+                            reg = regs.floatSet().allocateRegister(nullptr);
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+                        }
+#endif /* SLJIT_CONFIG_ARM_32 */
+                    }
+                    instr->setRequiredReg(tmpIndex, regs.toCPUFloatReg(reg));
+                }
+                tmpIndex++;
+            }
+
+            operand++;
+            list++;
+        }
+
+        if (instr->info() & Instruction::kIsMergeCompare) {
+            ASSERT((list[0] & Instruction::TypeMask) == Instruction::Int32Operand && list[1] == 0);
+            continue;
+        }
+
+        // Step 2: reuse as many registers as possible. Reusing
+        // has limitations, which are described in the operand list.
+        if (hasResult) {
+            VariableList::Variable* resultVariable = m_variableList->variables.data() + operand->ref;
+            uint8_t type = (*list & Instruction::TypeMask);
+
+            if (resultVariable->u.rangeStart == instrId && resultVariable->rangeEnd != instrId) {
+                if (!regs.reuseResult(*list, reusableRegs, resultVariable)) {
+                    regs.allocateVariable(resultVariable);
+                }
+            }
+
+            if (type & Instruction::FloatOperandMarker) {
+                if (resultVariable->reg1 != VariableList::kUnusedReg) {
+                    regs.floatReserve(resultVariable->reg1);
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+                    regs.floatReserve(resultVariable->reg2);
+#endif /* SLJIT_CONFIG_ARM_32 */
+                }
+            } else if (resultVariable->reg1 != VariableList::kUnusedReg) {
+                regs.integerReserve(resultVariable->reg1);
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+                regs.integerReserve(resultVariable->reg2);
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+            }
+
+            if (*list & Instruction::TmpRequired) {
+                uint8_t resultReg = resultVariable->reg1;
+
+                if (resultReg == VariableList::kUnusedReg) {
+                    if (type & Instruction::FloatOperandMarker) {
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+                        if (type == Instruction::V128Operand) {
+                            resultReg = regs.floatSet().allocateQuadRegister(nullptr);
+                        } else {
+#endif /* SLJIT_CONFIG_ARM_32 */
+                            resultReg = regs.floatSet().allocateRegister(nullptr);
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+                        }
+#endif /* SLJIT_CONFIG_ARM_32 */
+                        resultReg = regs.toCPUFloatReg(resultReg);
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+                    } else if (type == Instruction::Int64Operand) {
+                        uint8_t otherReg;
+                        resultReg = regs.integerSet().allocateRegisterPair(nullptr, &otherReg);
+                        instr->setRequiredReg(tmpIndex++, regs.toCPUIntegerReg(otherReg));
+                        resultReg = regs.toCPUIntegerReg(resultReg);
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+                    } else {
+                        resultReg = regs.integerSet().allocateRegister(nullptr);
+                        resultReg = regs.toCPUIntegerReg(resultReg);
+                    }
+                } else if (type & Instruction::FloatOperandMarker) {
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+                    if (type == Instruction::V128Operand) {
+                        regs.floatReserve(resultReg + 1);
+                    }
+#endif /* SLJIT_CONFIG_ARM_32 */
+                    regs.floatReserve(resultReg);
+                    resultReg = regs.toCPUFloatReg(resultReg);
+                } else {
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+                    if (type == Instruction::Int64Operand) {
+                        instr->setRequiredReg(tmpIndex++, regs.toCPUIntegerReg(resultReg));
+                        resultReg = resultVariable->reg2;
+                        ASSERT(resultReg != VariableList::kUnusedReg);
+                    }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+                    regs.integerReserve(resultReg);
+                    resultReg = regs.toCPUIntegerReg(resultReg);
+                }
+
+                instr->setRequiredReg(tmpIndex++, resultReg);
+            }
+
+            list++;
+        }
+
+        uint32_t reuseTmpIndex = tmpIndex;
+
+        for (const uint8_t* nextType = list; *nextType != 0; nextType++) {
+            int reuseIdx = reuseTemporary(*nextType, reusableRegs);
+
+            if (reuseIdx >= 0) {
+                VariableList::Variable* variable = reusableRegs[reuseIdx];
+                // A register cannot be reused twice.
+                reusableRegs[reuseIdx] = nullptr;
+
+                uint8_t reg = variable->reg1;
+
+                if (*nextType & Instruction::FloatOperandMarker) {
+#if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
+                    if ((*nextType & Instruction::TypeMask) == Instruction::V128Operand) {
+                        regs.floatReserve(reg + 1);
+                    }
+#endif /* SLJIT_CONFIG_ARM_32 */
+
+                    regs.floatReserve(reg);
+                    instr->setRequiredReg(reuseTmpIndex, regs.toCPUFloatReg(reg));
+                } else {
+                    regs.integerReserve(reg);
+                    instr->setRequiredReg(reuseTmpIndex, regs.toCPUIntegerReg(reg));
+                }
+            }
+
+            reuseTmpIndex++;
+        }
+
+        // Step 3: initialize uninitialized temporary values.
+        for (; *list != 0; list++) {
+            // Assign temporary registers.
+            ASSERT(((*list & Instruction::TypeMask) >= Instruction::Int32Operand || (*list & Instruction::TmpRequired))
+                   && (*list & Instruction::TypeMask) <= Instruction::Float64Operand);
+
+            if (instr->requiredReg(tmpIndex) == 0) {
+                if (*list & Instruction::FloatOperandMarker) {
+                    instr->setRequiredReg(tmpIndex, regs.toCPUFloatReg(regs.floatSet().allocateRegister(nullptr)));
+                } else {
+                    instr->setRequiredReg(tmpIndex, regs.toCPUIntegerReg(regs.integerSet().allocateRegister(nullptr)));
+                }
+            }
+
+            tmpIndex++;
+        }
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        // 64 bit shifts / rotates requires special handling.
+        if ((instr->info() & (Instruction::kIsShift | Instruction::kIs32Bit)) == Instruction::kIsShift) {
+            ASSERT(operand == instr->operands() + 2);
+            VariableList::Variable* variable = m_variableList->variables.data() + operand[-1].ref;
+            bool isImmediate = (variable->info & VariableList::kIsImmediate) != 0;
+
+            if (instr->opcode() == ByteCode::I64RotlOpcode || instr->opcode() == ByteCode::I64RotrOpcode) {
+                instr->setRequiredReg(2, regs.toCPUIntegerReg(regs.integerSet().allocateRegister(nullptr)));
+
+                if (!isImmediate) {
+                    instr->setRequiredReg(3, regs.toCPUIntegerReg(regs.integerSet().allocateRegister(nullptr)));
+                }
+            } else if (!isImmediate) {
+                instr->setRequiredReg(2, regs.toCPUIntegerReg(regs.integerSet().allocateRegister(nullptr)));
+            }
+        }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+    }
+
+    m_savedIntegerRegCount = regs.integerSet().getSavedRegCount();
+    m_savedFloatRegCount = regs.floatSet().getSavedRegCount();
+
+    // Insert stack inits before the offsets are destroyed.
+    insertStackInitList(nullptr, 0, variableListParamCount);
+
+    for (auto it : m_variableList->catchUpdates) {
+        insertStackInitList(it.handler, it.variableListStart, it.variableListSize);
+    }
+
+    size_t size = m_variableList->variables.size();
+    for (size_t i = 0; i < size; i++) {
+        VariableList::Variable& variable = m_variableList->variables[i];
+
+        if (variable.reg1 != VariableList::kUnusedReg) {
+            ASSERT(!(variable.info & (VariableList::kIsMerged | VariableList::kIsImmediate)));
+            uint8_t reg1;
+
+            if (variable.info & Instruction::FloatOperandMarker) {
+                reg1 = regs.toCPUFloatReg(variable.reg1);
+            } else {
+                reg1 = regs.toCPUIntegerReg(variable.reg1);
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+                if (variable.reg2 != variable.reg1) {
+                    uint8_t reg2;
+
+                    if (variable.info & Instruction::FloatOperandMarker) {
+                        reg2 = regs.toCPUFloatReg(variable.reg2);
+                    } else {
+                        reg2 = regs.toCPUIntegerReg(variable.reg2);
+                    }
+
+                    variable.value = VARIABLE_SET(SLJIT_REG_PAIR(reg1, reg2), Operand::Register);
+                    continue;
+                }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+            }
+
+            variable.value = VARIABLE_SET(reg1, Operand::Register);
+        }
+    }
+}
+
+void JITCompiler::allocateRegistersSimple()
+{
+    m_savedIntegerRegCount = 0;
+    m_savedFloatRegCount = 0;
+
     if (m_variableList == nullptr) {
         return;
     }
@@ -38,25 +910,13 @@ void JITCompiler::allocateRegisters()
         Instruction* instr = item->asInstruction();
         Operand* operand = instr->operands();
         Operand* end = operand + instr->paramCount() + instr->resultCount();
-        const uint8_t* list = instr->getOperandDescriptor();
+        const uint8_t* list = m_variableList->getOperandDescriptor(instr);
         uint32_t paramCount = instr->paramCount();
         uint32_t resultCount = instr->resultCount();
         uint32_t tmpIndex = 0;
         uint32_t nextIntIndex = SLJIT_R0;
         uint32_t nextFloatIndex = SLJIT_FR0;
 
-        while (operand < end) {
-            VariableRef ref = operand->ref;
-
-            VariableList::Variable& variable = m_variableList->variables[ref];
-
-            ASSERT((variable.info & Instruction::TypeMask) > 0);
-            operand->ref = variable.value;
-
-            operand++;
-        }
-
-        operand = instr->operands();
         instr->setRequiredRegsDescriptor(0);
 
         if (*list == 0) {
@@ -68,15 +928,22 @@ void JITCompiler::allocateRegisters()
             continue;
         }
 
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        if (instr->opcode() == ByteCode::I64MulOpcode) {
+            instr->setRequiredReg(0, SLJIT_R2);
+        }
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
         for (uint32_t i = 0; i < paramCount; i++) {
             ASSERT((*list & Instruction::TypeMask) >= Instruction::Int32Operand
                    && (*list & Instruction::TypeMask) <= Instruction::Float64Operand);
 
-            if ((*list & Instruction::TypeMask) >= Instruction::FloatOperandStart
+            if ((*list & Instruction::TypeMask & Instruction::FloatOperandMarker)
                 && !(*list & Instruction::TmpNotAllowed)) {
+                VariableList::Variable& variable = m_variableList->variables[operand->ref];
+
                 // Source registers are read-only.
-                if ((*list & Instruction::TmpRequired)
-                    || (VARIABLE_TYPE(operand->ref) == Operand::Immediate)) {
+                if ((*list & Instruction::TmpRequired) || (variable.info & VariableList::kIsImmediate)) {
                     instr->setRequiredReg(tmpIndex, nextFloatIndex++);
 #if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
                     if ((*list & Instruction::TypeMask) == Instruction::V128Operand) {
@@ -112,9 +979,7 @@ void JITCompiler::allocateRegisters()
 #endif /* SLJIT_32BIT_ARCHITECTURE */
             }
 
-            if ((*list & Instruction::TypeMask) < Instruction::FloatOperandStart) {
-                instr->setRequiredReg(tmpIndex, nextIntIndex++);
-            } else {
+            if (*list & Instruction::FloatOperandMarker) {
                 instr->setRequiredReg(tmpIndex, nextFloatIndex++);
 #if (defined SLJIT_CONFIG_ARM_32 && SLJIT_CONFIG_ARM_32)
                 if ((*list & Instruction::TypeMask) == Instruction::V128Operand) {
@@ -122,6 +987,8 @@ void JITCompiler::allocateRegisters()
                     nextFloatIndex++;
                 }
 #endif /* SLJIT_CONFIG_ARM_32 */
+            } else {
+                instr->setRequiredReg(tmpIndex, nextIntIndex++);
             }
             tmpIndex++;
         }
@@ -130,7 +997,8 @@ void JITCompiler::allocateRegisters()
         // 64 bit shifts / rotates requires special handling.
         if ((instr->info() & (Instruction::kIsShift | Instruction::kIs32Bit)) == Instruction::kIsShift) {
             ASSERT(operand == instr->operands() + 2);
-            bool isImmediate = (VARIABLE_TYPE(operand[-1].ref) == Operand::Immediate);
+            VariableList::Variable* variable = m_variableList->variables.data() + operand[-1].ref;
+            bool isImmediate = (variable->info & VariableList::kIsImmediate) != 0;
 
             if (instr->opcode() == ByteCode::I64RotlOpcode || instr->opcode() == ByteCode::I64RotrOpcode) {
                 instr->setRequiredReg(2, SLJIT_R2);
@@ -154,6 +1022,36 @@ void JITCompiler::allocateRegisters()
 #endif /* SLJIT_32BIT_ARCHITECTURE */
 
         ASSERT(resultCount == 0);
+    }
+}
+
+void JITCompiler::freeVariables()
+{
+    for (InstructionListItem* item = m_first; item != nullptr; item = item->next()) {
+        if (item->isLabel()) {
+            continue;
+        }
+
+        Instruction* instr = item->asInstruction();
+        Operand* operand = instr->operands();
+        Operand* end = operand + instr->paramCount() + instr->resultCount();
+        uint16_t info = 0;
+
+        while (operand < end) {
+            VariableRef ref = operand->ref;
+
+            VariableList::Variable& variable = m_variableList->variables[ref];
+
+            ASSERT((variable.info & Instruction::TypeMask) > 0);
+            info |= variable.info;
+
+            operand->ref = variable.value;
+            operand++;
+        }
+
+        if (info & Instruction::FloatOperandMarker) {
+            instr->addInfo(Instruction::kHasFloatOperand);
+        }
     }
 
     delete m_variableList;

--- a/src/jit/SimdArm64Inl.h
+++ b/src/jit/SimdArm64Inl.h
@@ -1100,18 +1100,19 @@ static void emitShuffleSIMD(sljit_compiler* compiler, Instruction* instr)
     args[2].set(operands + 2);
     sljit_s32 dst = GET_TARGET_REG(args[2].arg, instr->requiredReg(0));
 
-    if (sljit_get_register_index(SLJIT_SIMD_REG_128, args[0].arg) + 1 != sljit_get_register_index(SLJIT_SIMD_REG_128, args[1].arg) || dst == args[0].arg || dst == args[1].arg) {
+    if (sljit_get_register_index(SLJIT_SIMD_REG_128, args[0].arg) + 1 != sljit_get_register_index(SLJIT_SIMD_REG_128, args[1].arg)) {
         if (args[0].arg != SLJIT_TMP_FR0) {
-            sljit_emit_simd_mov(compiler, SLJIT_SIMD_STORE | SLJIT_SIMD_REG_128 | SLJIT_SIMD_ELEM_128, SLJIT_TMP_FR0, args[0].arg, args[0].argw);
+            sljit_emit_simd_mov(compiler, SLJIT_SIMD_LOAD | SLJIT_SIMD_REG_128 | SLJIT_SIMD_ELEM_128, SLJIT_TMP_FR0, args[0].arg, args[0].argw);
             args[0].arg = SLJIT_TMP_FR0;
         }
 
         if (args[1].arg != SLJIT_TMP_FR1) {
-            sljit_emit_simd_mov(compiler, SLJIT_SIMD_STORE | SLJIT_SIMD_REG_128 | SLJIT_SIMD_ELEM_128, SLJIT_TMP_FR1, args[1].arg, args[1].argw);
+            sljit_emit_simd_mov(compiler, SLJIT_SIMD_LOAD | SLJIT_SIMD_REG_128 | SLJIT_SIMD_ELEM_128, SLJIT_TMP_FR1, args[1].arg, args[1].argw);
             args[1].arg = SLJIT_TMP_FR1;
         }
+    } else if (dst == args[0].arg || dst == args[1].arg) {
+        dst = SLJIT_TMP_FR0;
     }
-
 
     I8X16Shuffle* shuffle = reinterpret_cast<I8X16Shuffle*>(instr->byteCode());
     const sljit_s32 type = SLJIT_SIMD_LOAD | SLJIT_SIMD_REG_128 | SLJIT_SIMD_ELEM_8;
@@ -1119,7 +1120,7 @@ static void emitShuffleSIMD(sljit_compiler* compiler, Instruction* instr)
 
     simdEmitOp(compiler, SimdOp::tbl | (1 << 13), dst, args[0].arg, dst);
 
-    if (SLJIT_IS_MEM(args[2].arg)) {
+    if (args[2].arg != dst) {
         sljit_emit_simd_mov(compiler, SLJIT_SIMD_STORE | SLJIT_SIMD_REG_128 | SLJIT_SIMD_ELEM_128, dst, args[2].arg, args[2].argw);
     }
 }

--- a/src/jit/SimdInl.h
+++ b/src/jit/SimdInl.h
@@ -24,10 +24,11 @@ static void emitMoveV128(sljit_compiler* compiler, Instruction* instr)
 
     sljit_s32 dstReg = GET_TARGET_REG(dst.arg, SLJIT_TMP_DEST_FREG);
 
-    simdOperandToArg(compiler, operands + 0, src, SLJIT_SIMD_REG_128, SLJIT_TMP_DEST_FREG);
+    simdOperandToArg(compiler, operands + 0, src, SLJIT_SIMD_REG_128, dstReg);
+    ASSERT(SLJIT_IS_REG(src.arg));
 
-    if (SLJIT_IS_MEM(dst.arg)) {
-        sljit_emit_simd_mov(compiler, SLJIT_SIMD_STORE | SLJIT_SIMD_REG_128, SLJIT_TMP_DEST_FREG, dst.arg, dst.argw);
+    if (dst.arg != src.arg) {
+        sljit_emit_simd_mov(compiler, SLJIT_SIMD_STORE | SLJIT_SIMD_REG_128, src.arg, dst.arg, dst.argw);
     }
 }
 

--- a/src/jit/SimdX86Inl.h
+++ b/src/jit/SimdX86Inl.h
@@ -332,7 +332,7 @@ static void simdEmitVexOp(sljit_compiler* compiler, uint32_t opcode, sljit_s32 r
 
 static void simdEmitOp(sljit_compiler* compiler, uint32_t opcode, sljit_s32 rd, sljit_s32 rn, sljit_s32 rm)
 {
-    ASSERT(rd != rm && !(opcode & SimdOp::opcodeHasArg));
+    ASSERT(!(opcode & SimdOp::opcodeHasArg));
 
     if (rd == rn) {
         return simdEmitSSEOp(compiler, opcode, rd, rm);
@@ -1893,7 +1893,8 @@ static void simdEmitI8X16Shl(sljit_compiler* compiler, sljit_s32 rd, sljit_s32 r
     simdEmitSSEOp(compiler, SimdOp::pcmpeqw, tmp2, tmp2);
     simdEmitOp(compiler, SimdOp::psllw, rd, rn, tmp1);
     simdEmitSSEOp(compiler, SimdOp::psllw, tmp2, tmp1);
-    sljit_emit_simd_lane_replicate(compiler, SLJIT_SIMD_REG_128 | SLJIT_SIMD_ELEM_8, tmp2, tmp2, 0);
+    simdEmitSSEOp(compiler, SimdOp::pxor, tmp1, tmp1);
+    simdEmitSSEOp(compiler, SimdOp::pshufb, tmp2, tmp1);
     simdEmitSSEOp(compiler, SimdOp::pand, rd, tmp2);
 }
 

--- a/src/runtime/JITExec.h
+++ b/src/runtime/JITExec.h
@@ -76,8 +76,8 @@ struct ExecutionContext {
     Exception* capturedException;
     Memory::TargetBuffer memory0;
     ErrorCodes error;
-    uint64_t tmp1;
-    uint64_t tmp2;
+    uint64_t tmp1[2];
+    uint64_t tmp2[2];
 };
 
 class JITModule {

--- a/src/runtime/Module.h
+++ b/src/runtime/Module.h
@@ -38,7 +38,8 @@ enum JITFlagValue : uint32_t {
     useJIT = 1 << 0,
     JITVerbose = 1 << 1,
     JITVerboseColor = 1 << 2,
-    enableJITDump = 1 << 3
+    disableRegAlloc = 1 << 3,
+    enableJITDump = 1 << 4
 };
 
 enum class SegmentMode {

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -1035,7 +1035,10 @@ static void parseArguments(int argc, char* argv[], ParseOptions& options)
                     s_JITFlags |= JITFlagValue::JITVerbose;
                     continue;
                 } else if (strcmp(argv[i], "--jit-verbose-color") == 0) {
-                    s_JITFlags |= JITFlagValue::JITVerboseColor;
+                    s_JITFlags |= JITFlagValue::JITVerbose | JITFlagValue::JITVerboseColor;
+                    continue;
+                } else if (strcmp(argv[i], "--jit-no-reg-alloc") == 0) {
+                    s_JITFlags |= JITFlagValue::disableRegAlloc;
                     continue;
                 } else if (strcmp(argv[i], "--perf") == 0) {
 #ifdef WALRUS_JITPERF

--- a/test/jit/binary-multiply.wast
+++ b/test/jit/binary-multiply.wast
@@ -57,9 +57,45 @@
   local.get 0
   i64.mul
 )
+
+(func (export "test5") (param i32 i64) (result i64)
+  local.get 0
+  i32.const 4
+  i32.add
+
+  local.get 1
+  i64.const 0x1234
+  i64.add
+  local.set 1
+
+  local.set 0
+
+  local.get 1
+  local.get 1
+  i64.mul
+)
+
+(func (export "test6") (param i32 i64) (result i64)
+  local.get 0
+  i32.const 4
+  i32.add
+
+  local.get 1
+  i64.const 0x4321
+  i64.add
+  local.set 1
+
+  local.set 0
+
+  local.get 1
+  i64.const 0x48b71cd0253
+  i64.mul
+)
 )
 
 (assert_return (invoke "test1" (i64.const 10000000)) (i64.const 100000000000000) (i64.const 18446644073709551616) (i64.const 100000000000000))
 (assert_return (invoke "test2" (i32.const 10000)) (i32.const 100000000) (i32.const 4194967296) (i32.const 100000000))
 (assert_return (invoke "test3" (i64.const 0x34b74b74b74b74b7)) (i64.const 0x5b34997a00000000) (i64.const 0x6a1d32e6b74b74b7))
 (assert_return (invoke "test4" (i64.const 0x580f80f80f80f80f)) (i64.const 0x8016016015fea16d) (i64.const 0x5635635583eb6738))
+(assert_return (invoke "test5" (i32.const 0) (i64.const 0xc48a2406a2e5)) (i64.const 0x219b6a1005485c71))
+(assert_return (invoke "test6" (i32.const 0) (i64.const 0xd4b913dfe24a)) (i64.const 0x5733424463a5f7b1))

--- a/test/jit/simd-shuffle.wast
+++ b/test/jit/simd-shuffle.wast
@@ -1,0 +1,41 @@
+(module
+
+(func (export "test1") (param v128 v128) (result v128)
+  local.get 0
+
+  local.get 1
+  local.get 1
+  i64x2.add
+
+  local.get 1
+  v128.not
+  local.set 1
+
+  i8x16.shuffle 31 15 29 13 27 11 25 9 23 7 21 5 19 3 17 1
+)
+
+(func (export "test2") (param v128 v128) (result v128) (local v128)
+  local.get 1
+  local.get 0
+
+  local.get 1
+  v128.not
+  local.set 2
+
+  i8x16.shuffle 30 14 28 12 26 10 24 8 22 6 20 4 18 2 16 0
+
+  local.get 2
+  v128.not
+  local.set 2
+)
+)
+
+(assert_return (invoke "test1"
+   (v128.const i64x2 0x0807060504030201 0x100f0e0d0c0b0a09)
+   (v128.const i64x2 0x1817161514131211 0x201f1e1d1c1b1a19))
+   (v128.const i64x2 0x0a340c380e3c1040 0x02240428062c0830))
+
+(assert_return (invoke "test2"
+   (v128.const i64x2 0x0807060504030201 0x100f0e0d0c0b0a09)
+   (v128.const i64x2 0x1817161514131211 0x201f1e1d1c1b1a19))
+   (v128.const i64x2 0x19091b0b1d0d1f0f 0x1101130315051707))


### PR DESCRIPTION
This branch contains an early version of a register allocator for Walrus. It is capable of compiling some WebAssembly code now. For example, our simple fibonacci code:

```
(module
 (func $func1 (export "func1") (param $num i32) (result i32) (local i32 i32 i32)
  i32.const 0
  local.set 0
  i32.const 1
  local.set 1

  i32.const 0
  local.set 2

  loop
    local.get 0
    local.get 1
    i32.add
    local.get 1
    local.set 0
    local.set 1

    local.get 2
    i32.const 1
    i32.add
    local.tee 2

    i32.const 100000000
    i32.lt_u
    br_if 0
  end

  local.get 2
)
)

(assert_return (invoke "func1" (i32.const 10)) (i32.const 100000000))
```

Code with register allocation (R0-R3 are scratch registers):

```
[[[[[[[  Function   0  ]]]]]]]
1: Const32 (0x5567783b3540)
  Unused
  Result[0]: 18.I32 (I:0x5567783b3540)
2: Const32 (0x5567783b2ff0)
  Unused
  Result[0]: 19.I32 (I:0x5567783b2ff0)
3: Const32 (0x5567783b3730)
  Unused
  Result[0]: 20.I32 (I:0x5567783b3730)
4: MoveI32 (0x5567783b3600)
  Param[0]: 18.I32 (I:0x5567783b3540)
  Result[0]: 21.I32 (R0) [4-14]
5: MoveI32 (0x5567783b3780)
  Param[0]: 19.I32 (I:0x5567783b2ff0)
  Result[0]: 22.I32 (R1) [5-14]
6: MoveI32 (0x5567783b37e0)
  Param[0]: 18.I32 (I:0x5567783b3540)
  Result[0]: 23.I32 (R2) [6-15]
7: Label (0x5567783b2800)
  Jump from: 14
8: I32Add (0x5567783b3840)
  Param[0]: 21.I32 (R0) [4-14]
  Param[1]: 22.I32 (R1) [5-14]
  Result[0]: 24.I32 (R3) [8-10]
9: MoveI32 (0x5567783b38a0)
  Param[0]: 22.I32 (R1) [5-14]
  Result[0]: 21.I32 (R0) [4-14]
10: MoveI32 (0x5567783b3900)
  Param[0]: 24.I32 (R3) [8-10]
  Result[0]: 22.I32 (R1) [5-14]
11: I32Add (0x5567783b3960)
  Param[0]: 23.I32 (R2) [6-15]
  Param[1]: 19.I32 (I:0x5567783b2ff0)
  Result[0]: 27.I32 (R3) [11-13]
12: MoveI32 (0x5567783b39c0)
  Param[0]: 27.I32 (R3) [11-13]
  Result[0]: 23.I32 (R2) [6-15]
13: I32LtU (0x5567783b3a20)
  MergeCompare
  Param[0]: 27.I32 (R3) [11-13]
  Param[1]: 20.I32 (I:0x5567783b3730)
  Result[0]: (flag)
14: JumpIfTrue (0x5567783b3a80)
  Jump to: 7
  Param[0]: (flag)
15: End (0x5567783b3ae0)
  Param[0]: 23.I32 (R2) [6-15]
```

Release mode runtime on an x86-64 machine:

interp: 0m0.994s
base-jit: 0m0.557s (1.78 times as fast)
reg-alloc-jit: 0m0.152s (6.53 times as fast)
