### PR TITLE
Merge Operand type into VariableRef type

### DIFF
--- a/src/jit/ByteCodeParser.cpp
+++ b/src/jit/ByteCodeParser.cpp
@@ -913,10 +913,10 @@ static void compileFunction(JITCompiler* compiler)
 
             instr->setRequiredRegsDescriptor(requiredInit);
 
-            operands[0].ref = STACK_OFFSET(select->src0Offset());
-            operands[1].ref = STACK_OFFSET(select->src1Offset());
-            operands[2].ref = STACK_OFFSET(select->condOffset());
-            operands[3].ref = STACK_OFFSET(select->dstOffset());
+            operands[0] = STACK_OFFSET(select->src0Offset());
+            operands[1] = STACK_OFFSET(select->src1Offset());
+            operands[2] = STACK_OFFSET(select->condOffset());
+            operands[3] = STACK_OFFSET(select->dstOffset());
             break;
         }
         case ByteCode::CallOpcode:
@@ -943,19 +943,16 @@ static void compileFunction(JITCompiler* compiler)
             instr->addInfo(Instruction::kIsCallback | Instruction::kFreeUnusedEarly);
 
             for (auto it : functionType->param()) {
-                operand->ref = STACK_OFFSET(*stackOffset);
-                operand++;
+                *operand++ = STACK_OFFSET(*stackOffset);
                 stackOffset += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
             }
 
             if (opcode == ByteCode::CallIndirectOpcode) {
-                operand->ref = STACK_OFFSET(reinterpret_cast<CallIndirect*>(byteCode)->calleeOffset());
-                operand++;
+                *operand++ = STACK_OFFSET(reinterpret_cast<CallIndirect*>(byteCode)->calleeOffset());
             }
 
             for (auto it : functionType->result()) {
-                operand->ref = STACK_OFFSET(*stackOffset);
-                operand++;
+                *operand++ = STACK_OFFSET(*stackOffset);
                 stackOffset += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
             }
 
@@ -973,8 +970,7 @@ static void compileFunction(JITCompiler* compiler)
             ByteCodeStackOffset* offsets = throwTag->dataOffsets();
 
             while (param < end) {
-                param->ref = STACK_OFFSET(*offsets++);
-                param++;
+                *param++ = STACK_OFFSET(*offsets++);
             }
             break;
         }
@@ -984,8 +980,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTLoadI32);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(load32->srcOffset());
-            operands[1].ref = STACK_OFFSET(load32->dstOffset());
+            operands[0] = STACK_OFFSET(load32->srcOffset());
+            operands[1] = STACK_OFFSET(load32->dstOffset());
             break;
         }
         case ByteCode::Load64Opcode: {
@@ -994,8 +990,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTLoadI64);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(load64->srcOffset());
-            operands[1].ref = STACK_OFFSET(load64->dstOffset());
+            operands[0] = STACK_OFFSET(load64->srcOffset());
+            operands[1] = STACK_OFFSET(load64->dstOffset());
             break;
         }
         case ByteCode::I32LoadOpcode:
@@ -1017,8 +1013,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(requiredInit != OTNone ? requiredInit : OTLoadI64);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(loadOperation->srcOffset());
-            operands[1].ref = STACK_OFFSET(loadOperation->dstOffset());
+            operands[0] = STACK_OFFSET(loadOperation->srcOffset());
+            operands[1] = STACK_OFFSET(loadOperation->dstOffset());
             break;
         }
         case ByteCode::F32LoadOpcode:
@@ -1049,8 +1045,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(requiredInit);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(loadOperation->srcOffset());
-            operands[1].ref = STACK_OFFSET(loadOperation->dstOffset());
+            operands[0] = STACK_OFFSET(loadOperation->srcOffset());
+            operands[1] = STACK_OFFSET(loadOperation->dstOffset());
             break;
         }
         case ByteCode::V128Load8LaneOpcode:
@@ -1062,9 +1058,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTLoadLaneV128);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(loadOperation->src0Offset());
-            operands[1].ref = STACK_OFFSET(loadOperation->src1Offset());
-            operands[2].ref = STACK_OFFSET(loadOperation->dstOffset());
+            operands[0] = STACK_OFFSET(loadOperation->src0Offset());
+            operands[1] = STACK_OFFSET(loadOperation->src1Offset());
+            operands[2] = STACK_OFFSET(loadOperation->dstOffset());
             break;
         }
         case ByteCode::Store32Opcode: {
@@ -1073,8 +1069,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTStoreI32);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(store32->src0Offset());
-            operands[1].ref = STACK_OFFSET(store32->src1Offset());
+            operands[0] = STACK_OFFSET(store32->src0Offset());
+            operands[1] = STACK_OFFSET(store32->src1Offset());
             break;
         }
         case ByteCode::Store64Opcode: {
@@ -1083,8 +1079,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTStoreI64);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(store64->src0Offset());
-            operands[1].ref = STACK_OFFSET(store64->src1Offset());
+            operands[0] = STACK_OFFSET(store64->src0Offset());
+            operands[1] = STACK_OFFSET(store64->src1Offset());
             break;
         }
         case ByteCode::I32StoreOpcode:
@@ -1106,8 +1102,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(requiredInit != OTNone ? requiredInit : OTStoreI64);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(storeOperation->src0Offset());
-            operands[1].ref = STACK_OFFSET(storeOperation->src1Offset());
+            operands[0] = STACK_OFFSET(storeOperation->src0Offset());
+            operands[1] = STACK_OFFSET(storeOperation->src1Offset());
             break;
         }
         case ByteCode::F32StoreOpcode:
@@ -1126,8 +1122,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(requiredInit);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(storeOperation->src0Offset());
-            operands[1].ref = STACK_OFFSET(storeOperation->src1Offset());
+            operands[0] = STACK_OFFSET(storeOperation->src0Offset());
+            operands[1] = STACK_OFFSET(storeOperation->src1Offset());
             break;
         }
         case ByteCode::V128Store8LaneOpcode:
@@ -1139,8 +1135,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTStoreV128);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(storeOperation->src0Offset());
-            operands[1].ref = STACK_OFFSET(storeOperation->src1Offset());
+            operands[0] = STACK_OFFSET(storeOperation->src0Offset());
+            operands[1] = STACK_OFFSET(storeOperation->src1Offset());
             break;
         }
         case ByteCode::I8X16ExtractLaneSOpcode:
@@ -1166,8 +1162,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(requiredInit == OTNone ? OTExtractLaneF64 : requiredInit);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(extractLane->srcOffset());
-            operands[1].ref = STACK_OFFSET(extractLane->dstOffset());
+            operands[0] = STACK_OFFSET(extractLane->srcOffset());
+            operands[1] = STACK_OFFSET(extractLane->dstOffset());
             break;
         }
         case ByteCode::I8X16ReplaceLaneOpcode:
@@ -1191,9 +1187,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(requiredInit == OTNone ? OTReplaceLaneF64 : requiredInit);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(replaceLane->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(replaceLane->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(replaceLane->dstOffset());
+            operands[0] = STACK_OFFSET(replaceLane->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(replaceLane->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(replaceLane->dstOffset());
             break;
         }
         case ByteCode::I8X16SplatOpcode:
@@ -1241,9 +1237,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTCallback3Arg);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(tableInit->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(tableInit->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(tableInit->srcOffsets()[2]);
+            operands[0] = STACK_OFFSET(tableInit->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(tableInit->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(tableInit->srcOffsets()[2]);
             break;
         }
         case ByteCode::TableSizeOpcode: {
@@ -1252,8 +1248,7 @@ static void compileFunction(JITCompiler* compiler)
             Instruction* instr = compiler->append(byteCode, Instruction::Table, opcode, 0, 1);
             instr->setRequiredRegsDescriptor(OTPutI32);
 
-            Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(tableSize->dstOffset());
+            *instr->operands() = STACK_OFFSET(tableSize->dstOffset());
             break;
         }
         case ByteCode::TableCopyOpcode: {
@@ -1264,9 +1259,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTCallback3Arg);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(tableCopy->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(tableCopy->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(tableCopy->srcOffsets()[2]);
+            operands[0] = STACK_OFFSET(tableCopy->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(tableCopy->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(tableCopy->srcOffsets()[2]);
             break;
         }
         case ByteCode::TableFillOpcode: {
@@ -1277,9 +1272,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTCallback3Arg);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(tableFill->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(tableFill->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(tableFill->srcOffsets()[2]);
+            operands[0] = STACK_OFFSET(tableFill->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(tableFill->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(tableFill->srcOffsets()[2]);
             break;
         }
         case ByteCode::TableGrowOpcode: {
@@ -1290,9 +1285,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTTableGrow);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(tableGrow->src0Offset());
-            operands[1].ref = STACK_OFFSET(tableGrow->src1Offset());
-            operands[2].ref = STACK_OFFSET(tableGrow->dstOffset());
+            operands[0] = STACK_OFFSET(tableGrow->src0Offset());
+            operands[1] = STACK_OFFSET(tableGrow->src1Offset());
+            operands[2] = STACK_OFFSET(tableGrow->dstOffset());
             break;
         }
         case ByteCode::TableSetOpcode: {
@@ -1302,8 +1297,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTTableSet);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(tableSet->src0Offset());
-            operands[1].ref = STACK_OFFSET(tableSet->src1Offset());
+            operands[0] = STACK_OFFSET(tableSet->src0Offset());
+            operands[1] = STACK_OFFSET(tableSet->src1Offset());
             break;
         }
         case ByteCode::TableGetOpcode: {
@@ -1313,8 +1308,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTTableGet);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(tableGet->srcOffset());
-            operands[1].ref = STACK_OFFSET(tableGet->dstOffset());
+            operands[0] = STACK_OFFSET(tableGet->srcOffset());
+            operands[1] = STACK_OFFSET(tableGet->dstOffset());
             break;
         }
         case ByteCode::MemorySizeOpcode: {
@@ -1323,8 +1318,7 @@ static void compileFunction(JITCompiler* compiler)
             Instruction* instr = compiler->append(byteCode, Instruction::Memory, opcode, 0, 1);
             instr->setRequiredRegsDescriptor(OTPutI32);
 
-            Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(memorySize->dstOffset());
+            *instr->operands() = STACK_OFFSET(memorySize->dstOffset());
             break;
         }
         case ByteCode::MemoryInitOpcode: {
@@ -1335,9 +1329,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTCallback3Arg);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(memoryInit->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(memoryInit->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(memoryInit->srcOffsets()[2]);
+            operands[0] = STACK_OFFSET(memoryInit->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(memoryInit->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(memoryInit->srcOffsets()[2]);
             break;
         }
         case ByteCode::MemoryCopyOpcode: {
@@ -1348,9 +1342,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTCallback3Arg);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(memoryCopy->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(memoryCopy->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(memoryCopy->srcOffsets()[2]);
+            operands[0] = STACK_OFFSET(memoryCopy->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(memoryCopy->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(memoryCopy->srcOffsets()[2]);
             break;
         }
         case ByteCode::MemoryFillOpcode: {
@@ -1361,9 +1355,9 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTCallback3Arg);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(memoryFill->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(memoryFill->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(memoryFill->srcOffsets()[2]);
+            operands[0] = STACK_OFFSET(memoryFill->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(memoryFill->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(memoryFill->srcOffsets()[2]);
             break;
         }
         case ByteCode::MemoryGrowOpcode: {
@@ -1374,8 +1368,8 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTOp1I32);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(memoryGrow->srcOffset());
-            operands[1].ref = STACK_OFFSET(memoryGrow->dstOffset());
+            operands[0] = STACK_OFFSET(memoryGrow->srcOffset());
+            operands[1] = STACK_OFFSET(memoryGrow->dstOffset());
             break;
         }
         case ByteCode::DataDropOpcode: {
@@ -1445,9 +1439,7 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTPutI32);
 
             Const32* const32 = reinterpret_cast<Const32*>(byteCode);
-            Operand* operands = instr->operands();
-
-            operands[0].ref = STACK_OFFSET(const32->dstOffset());
+            *instr->operands() = STACK_OFFSET(const32->dstOffset());
             break;
         }
         case ByteCode::Const64Opcode: {
@@ -1455,9 +1447,7 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTPutI64);
 
             Const64* const64 = reinterpret_cast<Const64*>(byteCode);
-            Operand* operands = instr->operands();
-
-            operands[0].ref = STACK_OFFSET(const64->dstOffset());
+            *instr->operands() = STACK_OFFSET(const64->dstOffset());
             break;
         }
         case ByteCode::MoveI32Opcode:
@@ -1506,8 +1496,8 @@ static void compileFunction(JITCompiler* compiler)
             Move* move = reinterpret_cast<Move*>(byteCode);
             Operand* operands = instr->operands();
 
-            operands[0].ref = STACK_OFFSET(move->srcOffset());
-            operands[1].ref = STACK_OFFSET(move->dstOffset());
+            operands[0] = STACK_OFFSET(move->srcOffset());
+            operands[1] = STACK_OFFSET(move->dstOffset());
             break;
         }
         case ByteCode::GlobalGet32Opcode: {
@@ -1515,13 +1505,12 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTPutI32);
 
             GlobalGet32* globalGet32 = reinterpret_cast<GlobalGet32*>(byteCode);
-            Operand* operands = instr->operands();
 
             if (isFloatGlobal(globalGet32->index(), compiler->module())) {
                 instr->setRequiredRegsDescriptor(OTGlobalGetF32);
             }
 
-            operands[0].ref = STACK_OFFSET(globalGet32->dstOffset());
+            *instr->operands() = STACK_OFFSET(globalGet32->dstOffset());
             break;
         }
         case ByteCode::GlobalGet64Opcode: {
@@ -1529,13 +1518,12 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTGlobalGetI64);
 
             GlobalGet64* globalGet64 = reinterpret_cast<GlobalGet64*>(byteCode);
-            Operand* operands = instr->operands();
 
             if (isFloatGlobal(globalGet64->index(), compiler->module())) {
                 instr->setRequiredRegsDescriptor(OTGlobalGetF64);
             }
 
-            operands[0].ref = STACK_OFFSET(globalGet64->dstOffset());
+            *instr->operands() = STACK_OFFSET(globalGet64->dstOffset());
             break;
         }
         case ByteCode::GlobalGet128Opcode: {
@@ -1543,9 +1531,7 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTGlobalGetV128);
 
             GlobalGet128* globalGet128 = reinterpret_cast<GlobalGet128*>(byteCode);
-            Operand* operands = instr->operands();
-
-            operands[0].ref = STACK_OFFSET(globalGet128->dstOffset());
+            *instr->operands() = STACK_OFFSET(globalGet128->dstOffset());
             break;
         }
         case ByteCode::GlobalSet32Opcode: {
@@ -1553,13 +1539,12 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTGlobalSetI32);
 
             GlobalSet32* globalSet32 = reinterpret_cast<GlobalSet32*>(byteCode);
-            Operand* operands = instr->operands();
 
             if (isFloatGlobal(globalSet32->index(), compiler->module())) {
                 instr->setRequiredRegsDescriptor(OTGlobalSetF32);
             }
 
-            operands[0].ref = STACK_OFFSET(globalSet32->srcOffset());
+            *instr->operands() = STACK_OFFSET(globalSet32->srcOffset());
             break;
         }
         case ByteCode::GlobalSet64Opcode: {
@@ -1567,13 +1552,12 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTGlobalSetI64);
 
             GlobalSet64* globalSet64 = reinterpret_cast<GlobalSet64*>(byteCode);
-            Operand* operands = instr->operands();
 
             if (isFloatGlobal(globalSet64->index(), compiler->module())) {
                 instr->setRequiredRegsDescriptor(OTGlobalSetF64);
             }
 
-            operands[0].ref = STACK_OFFSET(globalSet64->srcOffset());
+            *instr->operands() = STACK_OFFSET(globalSet64->srcOffset());
             break;
         }
         case ByteCode::GlobalSet128Opcode: {
@@ -1581,19 +1565,15 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTGlobalSetV128);
 
             GlobalSet128* globalSet128 = reinterpret_cast<GlobalSet128*>(byteCode);
-            Operand* operands = instr->operands();
-
-            operands[0].ref = STACK_OFFSET(globalSet128->srcOffset());
+            *instr->operands() = STACK_OFFSET(globalSet128->srcOffset());
             break;
         }
         case ByteCode::RefFuncOpcode: {
             Instruction* instr = compiler->append(byteCode, Instruction::Any, ByteCode::RefFuncOpcode, 0, 1);
             instr->setRequiredRegsDescriptor(OTPutPTR);
 
-            auto refFunc = reinterpret_cast<RefFunc*>(byteCode);
-            auto operands = instr->operands();
-
-            operands[0].ref = STACK_OFFSET(refFunc->dstOffset());
+            RefFunc* refFunc = reinterpret_cast<RefFunc*>(byteCode);
+            *instr->operands() = STACK_OFFSET(refFunc->dstOffset());
             break;
         }
         case ByteCode::EndOpcode: {
@@ -1604,8 +1584,7 @@ static void compileFunction(JITCompiler* compiler)
             ByteCodeStackOffset* offsets = reinterpret_cast<End*>(byteCode)->resultOffsets();
 
             for (auto it : result) {
-                param->ref = STACK_OFFSET(*offsets);
-                param++;
+                *param++ = STACK_OFFSET(*offsets);
                 offsets += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
             }
 
@@ -1623,9 +1602,7 @@ static void compileFunction(JITCompiler* compiler)
             instr->setRequiredRegsDescriptor(OTPutV128);
 
             Const128* const128 = reinterpret_cast<Const128*>(byteCode);
-            Operand* operands = instr->operands();
-
-            operands[0].ref = STACK_OFFSET(const128->dstOffset());
+            *instr->operands() = STACK_OFFSET(const128->dstOffset());
             break;
         }
         case ByteCode::I8X16SubOpcode:
@@ -1866,10 +1843,10 @@ static void compileFunction(JITCompiler* compiler)
             V128BitSelect* bitSelect = reinterpret_cast<V128BitSelect*>(byteCode);
             Operand* operands = instr->operands();
 
-            operands[0].ref = STACK_OFFSET(bitSelect->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(bitSelect->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(bitSelect->srcOffsets()[2]);
-            operands[3].ref = STACK_OFFSET(bitSelect->dstOffset());
+            operands[0] = STACK_OFFSET(bitSelect->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(bitSelect->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(bitSelect->srcOffsets()[2]);
+            operands[3] = STACK_OFFSET(bitSelect->dstOffset());
             break;
         }
         case ByteCode::I8X16ShuffleOpcode: {
@@ -1879,9 +1856,9 @@ static void compileFunction(JITCompiler* compiler)
             I8X16Shuffle* shuffle = reinterpret_cast<I8X16Shuffle*>(byteCode);
             Operand* operands = instr->operands();
 
-            operands[0].ref = STACK_OFFSET(shuffle->srcOffsets()[0]);
-            operands[1].ref = STACK_OFFSET(shuffle->srcOffsets()[1]);
-            operands[2].ref = STACK_OFFSET(shuffle->dstOffset());
+            operands[0] = STACK_OFFSET(shuffle->srcOffsets()[0]);
+            operands[1] = STACK_OFFSET(shuffle->srcOffsets()[1]);
+            operands[2] = STACK_OFFSET(shuffle->dstOffset());
             break;
         }
         default: {
@@ -1899,9 +1876,9 @@ static void compileFunction(JITCompiler* compiler)
             BinaryOperation* binaryOperation = reinterpret_cast<BinaryOperation*>(byteCode);
             Operand* operands = instr->operands();
 
-            operands[0].ref = STACK_OFFSET(binaryOperation->srcOffset()[0]);
-            operands[1].ref = STACK_OFFSET(binaryOperation->srcOffset()[1]);
-            operands[2].ref = STACK_OFFSET(binaryOperation->dstOffset());
+            operands[0] = STACK_OFFSET(binaryOperation->srcOffset()[0]);
+            operands[1] = STACK_OFFSET(binaryOperation->srcOffset()[1]);
+            operands[2] = STACK_OFFSET(binaryOperation->dstOffset());
         } else if (paramCount == 1) {
             ASSERT(group != Instruction::Any);
 
@@ -1912,8 +1889,8 @@ static void compileFunction(JITCompiler* compiler)
             UnaryOperation* unaryOperation = reinterpret_cast<UnaryOperation*>(byteCode);
 
             Operand* operands = instr->operands();
-            operands[0].ref = STACK_OFFSET(unaryOperation->srcOffset());
-            operands[1].ref = STACK_OFFSET(unaryOperation->dstOffset());
+            operands[0] = STACK_OFFSET(unaryOperation->srcOffset());
+            operands[1] = STACK_OFFSET(unaryOperation->dstOffset());
         }
 
         idx += byteCode->getSize();
@@ -1964,7 +1941,7 @@ const uint8_t* VariableList::getOperandDescriptor(Instruction* instr)
 
     if (requiredInit != OTNone) {
         ASSERT((instr->paramCount() + instr->resultCount()) == 2);
-        VariableList::Variable& variable = variables[instr->getParam(1)->ref];
+        VariableList::Variable& variable = variables[*instr->getParam(1)];
 
         if (variable.info & Instruction::FloatOperandMarker) {
             return Instruction::getOperandDescriptorByOffset(requiredInit);

--- a/src/jit/Compiler.h
+++ b/src/jit/Compiler.h
@@ -156,6 +156,7 @@ private:
 };
 
 typedef uintptr_t VariableRef;
+typedef VariableRef Operand;
 
 // These macros provide VariableRefs related operations.
 #define VARIABLE_SET(v, type) ((static_cast<VariableRef>(v) << 2) | (type))
@@ -164,18 +165,6 @@ typedef uintptr_t VariableRef;
 #define VARIABLE_GET_REF(v) ((v) >> 2)
 #define VARIABLE_GET_OFFSET(v) ((v) & ~(VariableRef)0x3)
 #define VARIABLE_GET_IMM(v) (reinterpret_cast<InstructionListItem*>(v)->asInstruction())
-
-struct Operand {
-    enum Type : VariableRef {
-        // Immediate type must be 0, because immediates are ByteCode pointers.
-        Immediate = 0,
-        Register = 1,
-        Offset = 2,
-    };
-
-    // Variable / immedate tracking.
-    VariableRef ref;
-};
 
 class Instruction : public InstructionListItem {
     friend class JITCompiler;
@@ -208,6 +197,13 @@ public:
         Src0Allowed = (1 << 4),
         Src1Allowed = (1 << 5),
         Src2Allowed = (1 << 6),
+    };
+
+    enum OperandType : Operand {
+        // ConstPtr type must be 0, because they are ByteCode pointers.
+        ConstPtr = 0,
+        Register = 1,
+        Offset = 2,
     };
 
     static const uint32_t TemporaryTypeShift = 4;

--- a/src/jit/FloatConvInl.h
+++ b/src/jit/FloatConvInl.h
@@ -675,7 +675,7 @@ static void emitConvertFloat(sljit_compiler* compiler, Instruction* instr)
     sljit_s32 argTypes = (flags & SourceIs64Bit) ? SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_F64, 1) : SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_F32, 1);
 
     /* Destination must not be immediate. */
-    ASSERT(VARIABLE_TYPE(operands[1].ref) != Operand::Immediate);
+    ASSERT(VARIABLE_TYPE(operands[1]) != Instruction::ConstPtr);
 
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
     arg.set(operands + 1);

--- a/src/jit/FloatMathInl.h
+++ b/src/jit/FloatMathInl.h
@@ -34,7 +34,7 @@ using f64Function1Param = std::add_pointer<sljit_f64(sljit_f64)>::type;
 
 static void floatOperandToArg(sljit_compiler* compiler, Operand* operand, JITArg& arg, sljit_s32 srcReg)
 {
-    if (VARIABLE_TYPE(operand->ref) != Operand::Immediate) {
+    if (VARIABLE_TYPE(*operand) != Instruction::ConstPtr) {
         arg.set(operand);
         return;
     }
@@ -42,7 +42,7 @@ static void floatOperandToArg(sljit_compiler* compiler, Operand* operand, JITArg
     arg.arg = srcReg;
     arg.argw = 0;
 
-    Instruction* instr = VARIABLE_GET_IMM(operand->ref);
+    Instruction* instr = VARIABLE_GET_IMM(*operand);
     ASSERT(srcReg != 0);
 
     if (instr->opcode() == ByteCode::Const32Opcode) {

--- a/src/jit/IntMath32Inl.h
+++ b/src/jit/IntMath32Inl.h
@@ -42,9 +42,9 @@ struct JITArgPair {
 
 void JITArgPair::set(Operand* operand)
 {
-    if (VARIABLE_TYPE(operand->ref) != Operand::Immediate) {
-        if (VARIABLE_TYPE(operand->ref) == Operand::Register) {
-            sljit_sw regs = VARIABLE_GET_REF(operand->ref);
+    if (VARIABLE_TYPE(*operand) != Instruction::ConstPtr) {
+        if (VARIABLE_TYPE(*operand) == Instruction::Register) {
+            sljit_sw regs = VARIABLE_GET_REF(*operand);
 
             this->arg1 = regs & 0xff;
             this->arg1w = 0;
@@ -53,7 +53,7 @@ void JITArgPair::set(Operand* operand)
             return;
         }
 
-        sljit_sw offset = static_cast<sljit_sw>(VARIABLE_GET_OFFSET(operand->ref));
+        sljit_sw offset = static_cast<sljit_sw>(VARIABLE_GET_OFFSET(*operand));
 
         this->arg1 = SLJIT_MEM1(kFrameReg);
         this->arg1w = offset + WORD_LOW_OFFSET;
@@ -64,7 +64,7 @@ void JITArgPair::set(Operand* operand)
 
     this->arg1 = SLJIT_IMM;
     this->arg2 = SLJIT_IMM;
-    Instruction* instr = VARIABLE_GET_IMM(operand->ref);
+    Instruction* instr = VARIABLE_GET_IMM(*operand);
 
     uint64_t value64 = reinterpret_cast<Const64*>(instr->byteCode())->value();
 

--- a/src/jit/MemoryInl.h
+++ b/src/jit/MemoryInl.h
@@ -686,9 +686,9 @@ static void emitStore(sljit_compiler* compiler, Instruction* instr)
         }
 #ifdef HAS_SIMD
     } else if (opcode == 0) {
-        VariableRef ref = operands[1].ref;
+        VariableRef ref = operands[1];
 
-        if (VARIABLE_TYPE(ref) != Operand::Immediate) {
+        if (VARIABLE_TYPE(ref) != Instruction::ConstPtr) {
             addr.loadArg.set(operands + 1);
         } else {
             ASSERT(VARIABLE_GET_IMM(ref)->opcode() == ByteCode::Const128Opcode);

--- a/src/jit/SimdArm32Inl.h
+++ b/src/jit/SimdArm32Inl.h
@@ -203,10 +203,10 @@ enum ExtendType : uint32_t {
 
 void setArgs(Operand* operand, JITArg& arg)
 {
-    if (VARIABLE_TYPE(operand->ref) == Operand::Immediate) {
-        ASSERT(VARIABLE_GET_IMM(operand->ref)->opcode() == ByteCode::Const128Opcode);
+    if (VARIABLE_TYPE(*operand) == Instruction::ConstPtr) {
+        ASSERT(VARIABLE_GET_IMM(*operand)->opcode() == ByteCode::Const128Opcode);
         arg.arg = SLJIT_MEM0();
-        arg.argw = (sljit_sw) reinterpret_cast<Const128*>(VARIABLE_GET_IMM(operand->ref)->asInstruction()->byteCode())->value();
+        arg.argw = (sljit_sw) reinterpret_cast<Const128*>(VARIABLE_GET_IMM(*operand)->asInstruction()->byteCode())->value();
     } else {
         arg.set(operand);
     }

--- a/src/jit/SimdX86Inl.h
+++ b/src/jit/SimdX86Inl.h
@@ -1835,7 +1835,7 @@ static void emitShuffleSIMD(sljit_compiler* compiler, Instruction* instr)
     args[2].set(operands + 2);
     sljit_s32 dst = GET_TARGET_REG(args[2].arg, instr->requiredReg(1));
 
-    if (operands[0].ref == operands[1].ref) {
+    if (operands[0] == operands[1]) {
         simdOperandToArg(compiler, operands, args[0], SLJIT_SIMD_ELEM_128, dst);
         sljit_emit_simd_mov(compiler, SLJIT_SIMD_LOAD | type, SLJIT_TMP_DEST_FREG, SLJIT_MEM0(), reinterpret_cast<sljit_sw>(shuffle->value()));
 


### PR DESCRIPTION
This is simplification of operand type. There are many cases, where `operand*` could be replaced to `operand`, but I would do it in separate patches.