### PR TITLE
Fix register pair allocation

### DIFF
--- a/src/jit/RegisterAlloc.cpp
+++ b/src/jit/RegisterAlloc.cpp
@@ -347,15 +347,10 @@ uint8_t RegisterSet::allocateRegisterPair(VariableList::Variable* variable, uint
 
         size_t maxRangeEnd;
 
-        if (freeReg != VariableList::kUnusedReg) {
-            if (maxRangeEndSingle1 >= maxRangeEndPair) {
-                i = maxRangeIndexSingle1;
-                maxRangeEnd = maxRangeEndSingle1;
-            } else {
-                i = maxRangeIndexPair;
-                maxRangeEnd = maxRangeEndPair;
-            }
-        } else if (maxRangeEndPair < maxRangeEndSingle1 && maxRangeEndPair < maxRangeEndSingle2) {
+        if (freeReg != VariableList::kUnusedReg && maxRangeEndSingle1 >= maxRangeEndPair) {
+            i = maxRangeIndexSingle1;
+            maxRangeEnd = maxRangeEndSingle1;
+        } else if (freeReg == VariableList::kUnusedReg && maxRangeEndPair < maxRangeEndSingle1 && maxRangeEndPair < maxRangeEndSingle2) {
             i = maxRangeIndexSingle1;
             maxRangeEnd = maxRangeEndSingle2;
             freeReg = maxRangeIndexSingle2;


### PR DESCRIPTION
Another hard to reproduce issue revealed by hanoi with O2 optimization level. The issue is that an extra free register is allocated when a register pair is reused on 32 bit, and this is a problem on x86-32 with very low number of registers.

The code is the same as later in the same if-else, I forgot to copy it here.
