### PR TITLE
Memory stack

### DIFF
--- a/src/jit/ByteCodeParser.cpp
+++ b/src/jit/ByteCodeParser.cpp
@@ -236,9 +236,9 @@ static bool isFloatGlobal(uint32_t globalIndex, Module* module)
     OL5(OTAtomicRmwI64, /* SSDTT */ I32, I64, I64 | TMP, PTR, I64 | S1)              \
     OL6(OTAtomicRmwCmpxchgI32, /* SSSDTT */ I32, I32, I32, I32 | TMP, PTR, I32 | S1) \
     OL6(OTAtomicRmwCmpxchgI64, /* SSSDTT */ I32, I64, I64, I64 | TMP, PTR, I64 | S1) \
-    OL6(OTAtomicWaitI32, /* SSSDTT */ I32, I32, I64, I32 | TMP, PTR, I32 | S0)       \
-    OL6(OTAtomicWaitI64, /* SSSDTT */ I32, I64, I64, I32 | TMP, PTR, I64 | S0)       \
-    OL5(OTAtomicNotify, /* SSDTT */ I32, I32, I32 | TMP, PTR, I32 | S0)
+    OL6(OTAtomicWaitI32, /* SSSDTT */ I32, I32, I64, I32, PTR, I32 | S0)             \
+    OL6(OTAtomicWaitI64, /* SSSDTT */ I32, I64, I64, I32, PTR, I64 | S0)             \
+    OL5(OTAtomicNotify, /* SSDTT */ I32, I32, I32, PTR, I32 | S0)
 #else /* !ENABLE_EXTENDED_FEATURES */
 #define OPERAND_TYPE_LIST_EXTENDED
 #endif /* ENABLE_EXTENDED_FEATURES */
@@ -1022,12 +1022,14 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::Load32Opcode: {
             group = Instruction::Load;
             paramType = ParamTypes::ParamSrcDst;
+            compiler->useMemory0();
             requiredInit = OTLoadI32;
             break;
         }
         case ByteCode::Load64Opcode: {
             group = Instruction::Load;
             paramType = ParamTypes::ParamSrcDst;
+            compiler->useMemory0();
             requiredInit = OTLoadI64;
             break;
         }
@@ -1047,6 +1049,7 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::I64Load32UOpcode: {
             group = Instruction::Load;
             paramType = ParamTypes::ParamSrcDstValue;
+            compiler->useMemory0();
             if (requiredInit == OTNone) {
                 requiredInit = OTLoadI64;
             }
@@ -1069,6 +1072,7 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::V128Load64ZeroOpcode: {
             group = Instruction::Load;
             paramType = ParamTypes::ParamSrcDstValue;
+            compiler->useMemory0();
 
             if (opcode == ByteCode::F32LoadOpcode)
                 requiredInit = OTLoadF32;
@@ -1085,6 +1089,7 @@ static void compileFunction(JITCompiler* compiler)
             SIMDMemoryLoad* loadOperation = reinterpret_cast<SIMDMemoryLoad*>(byteCode);
             Instruction* instr = compiler->append(byteCode, Instruction::LoadLaneSIMD, opcode, 2, 1);
             instr->setRequiredRegsDescriptor(OTLoadLaneV128);
+            compiler->useMemory0();
 
             Operand* operands = instr->operands();
             operands[0] = STACK_OFFSET(loadOperation->src0Offset());
@@ -1095,12 +1100,14 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::Store32Opcode: {
             group = Instruction::Store;
             paramType = ParamTypes::ParamSrc2;
+            compiler->useMemory0();
             requiredInit = OTStoreI32;
             break;
         }
         case ByteCode::Store64Opcode: {
             group = Instruction::Store;
             paramType = ParamTypes::ParamSrc2;
+            compiler->useMemory0();
             requiredInit = OTStoreI64;
             break;
         }
@@ -1120,6 +1127,7 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::I64StoreOpcode: {
             group = Instruction::Store;
             paramType = ParamTypes::ParamSrc2Value;
+            compiler->useMemory0();
             if (requiredInit == OTNone) {
                 requiredInit = OTStoreI64;
             }
@@ -1130,6 +1138,7 @@ static void compileFunction(JITCompiler* compiler)
         case ByteCode::V128StoreOpcode: {
             group = Instruction::Store;
             paramType = ParamTypes::ParamSrc2Value;
+            compiler->useMemory0();
 
             if (opcode == ByteCode::F32StoreOpcode)
                 requiredInit = OTStoreF32;
@@ -1146,6 +1155,7 @@ static void compileFunction(JITCompiler* compiler)
             SIMDMemoryStore* storeOperation = reinterpret_cast<SIMDMemoryStore*>(byteCode);
             Instruction* instr = compiler->append(byteCode, Instruction::Store, opcode, 2, 0);
             instr->setRequiredRegsDescriptor(OTStoreV128);
+            compiler->useMemory0();
 
             Operand* operands = instr->operands();
             operands[0] = STACK_OFFSET(storeOperation->src0Offset());
@@ -1320,6 +1330,7 @@ static void compileFunction(JITCompiler* compiler)
 
             Instruction* instr = compiler->append(byteCode, Instruction::Memory, opcode, 0, 1);
             instr->setRequiredRegsDescriptor(OTPutI32);
+            compiler->useMemory0();
 
             *instr->operands() = STACK_OFFSET(memorySize->dstOffset());
             break;
@@ -1863,6 +1874,7 @@ static void compileFunction(JITCompiler* compiler)
                 compiler->increaseStackTmpSize(8);
             }
 #endif /* SLJIT_32BIT_ARCHITECTURE */
+            compiler->useMemory0();
             if (requiredInit == OTNone) {
                 requiredInit = OTLoadI64;
             }
@@ -1887,6 +1899,7 @@ static void compileFunction(JITCompiler* compiler)
                 compiler->increaseStackTmpSize(8);
             }
 #endif /* SLJIT_32BIT_ARCHITECTURE */
+            compiler->useMemory0();
             if (requiredInit == OTNone) {
                 requiredInit = OTStoreI64;
             }
@@ -1952,6 +1965,7 @@ static void compileFunction(JITCompiler* compiler)
             AtomicRmw* atomicRmw = reinterpret_cast<AtomicRmw*>(byteCode);
             Operand* operands = instr->operands();
             instr->setRequiredRegsDescriptor(requiredInit != OTNone ? requiredInit : OTAtomicRmwI64);
+            compiler->useMemory0();
 
             operands[0] = STACK_OFFSET(atomicRmw->src0Offset());
             operands[1] = STACK_OFFSET(atomicRmw->src1Offset());
@@ -1983,6 +1997,7 @@ static void compileFunction(JITCompiler* compiler)
             AtomicRmwCmpxchg* atomicRmwCmpxchg = reinterpret_cast<AtomicRmwCmpxchg*>(byteCode);
             Operand* operands = instr->operands();
             instr->setRequiredRegsDescriptor(requiredInit != OTNone ? requiredInit : OTAtomicRmwCmpxchgI64);
+            compiler->useMemory0();
 
             operands[0] = STACK_OFFSET(atomicRmwCmpxchg->src0Offset());
             operands[1] = STACK_OFFSET(atomicRmwCmpxchg->src1Offset());
@@ -2002,6 +2017,7 @@ static void compileFunction(JITCompiler* compiler)
             Operand* operands = instr->operands();
             instr->setRequiredRegsDescriptor(requiredInit != OTNone ? requiredInit : OTAtomicWaitI32);
             compiler->increaseStackTmpSize(16);
+            compiler->useMemory0();
 
             operands[0] = STACK_OFFSET(memoryAtomicWait->src0Offset());
             operands[1] = STACK_OFFSET(memoryAtomicWait->src1Offset());
@@ -2016,6 +2032,7 @@ static void compileFunction(JITCompiler* compiler)
             MemoryAtomicNotify* memoryAtomicNotify = reinterpret_cast<MemoryAtomicNotify*>(byteCode);
             Operand* operands = instr->operands();
             instr->setRequiredRegsDescriptor(OTAtomicNotify);
+            compiler->useMemory0();
 
             operands[0] = STACK_OFFSET(memoryAtomicNotify->src0Offset());
             operands[1] = STACK_OFFSET(memoryAtomicNotify->src1Offset());

--- a/src/jit/Compiler.h
+++ b/src/jit/Compiler.h
@@ -589,6 +589,7 @@ struct CompileContext {
     size_t tableStart;
     size_t functionsStart;
     sljit_sw stackTmpStart;
+    sljit_sw stackMemoryStart;
     size_t nextTryBlock;
     size_t currentTryBlock;
     size_t trapBlocksStart;
@@ -760,6 +761,16 @@ public:
         }
     }
 
+    void useMemory0()
+    {
+        m_useMemory0 = true;
+    }
+
+    bool hasMemory0()
+    {
+        return m_useMemory0;
+    }
+
     void setModuleFunction(ModuleFunction* moduleFunction)
     {
         m_moduleFunction = moduleFunction;
@@ -806,6 +817,7 @@ private:
     // Backend operations.
     void emitProlog();
     void emitEpilog();
+    void emitRestoreMemories();
 
 #if !defined(NDEBUG)
     static const char* m_byteCodeNames[];
@@ -829,6 +841,7 @@ private:
     uint8_t m_savedIntegerRegCount;
     uint8_t m_savedFloatRegCount;
     uint8_t m_stackTmpSize;
+    bool m_useMemory0;
 
     std::vector<TryBlock> m_tryBlocks;
     std::vector<FunctionList> m_functionList;

--- a/src/jit/MemoryUtilInl.h
+++ b/src/jit/MemoryUtilInl.h
@@ -79,11 +79,13 @@ static void emitMemory(sljit_compiler* compiler, Instruction* instr)
     switch (opcode) {
     case ByteCode::MemorySizeOpcode: {
         ASSERT(!(instr->info() & Instruction::kIsCallback));
+        ASSERT(context->compiler->hasMemory0());
 
         JITArg dstArg(params);
 
-        sljit_emit_op2(compiler, SLJIT_LSHR32, dstArg.arg, dstArg.argw,
-                       SLJIT_MEM1(kContextReg), OffsetOfContextField(memory0) + offsetof(Memory::TargetBuffer, sizeInByte), SLJIT_IMM, 16);
+        /* The sizeInByte is always a 32 bit number on 32 bit systems. */
+        sljit_emit_op2(compiler, SLJIT_LSHR, dstArg.arg, dstArg.argw, SLJIT_MEM1(SLJIT_SP),
+                       context->stackMemoryStart + offsetof(Memory::TargetBuffer, sizeInByte) + WORD_LOW_OFFSET, SLJIT_IMM, 16);
         return;
     }
     case ByteCode::MemoryInitOpcode:

--- a/src/runtime/JITExec.cpp
+++ b/src/runtime/JITExec.cpp
@@ -31,16 +31,7 @@ ByteCodeStackOffset* JITFunction::call(ExecutionState& state, Instance* instance
     ExecutionContext context(m_module->instanceConstData(), state, instance);
     Memory* memory0 = nullptr;
 
-    if (instance->module()->numberOfMemoryTypes() > 0) {
-        memory0 = instance->memory(0);
-        memory0->push(&context.memory0);
-    }
-
     ByteCodeStackOffset* resultOffsets = m_module->exportCall()(&context, bp, m_exportEntry);
-
-    if (memory0 != nullptr) {
-        memory0->pop(&context.memory0);
-    }
 
     if (context.error != ExecutionContext::NoError) {
         switch (context.error) {

--- a/src/runtime/JITExec.h
+++ b/src/runtime/JITExec.h
@@ -66,7 +66,6 @@ struct ExecutionContext {
     ExecutionState& state;
     Instance* instance;
     Exception* capturedException;
-    Memory::TargetBuffer memory0;
     ErrorCodes error;
 };
 

--- a/src/runtime/Memory.h
+++ b/src/runtime/Memory.h
@@ -31,6 +31,8 @@ class Store;
 class DataSegment;
 
 class Memory : public Extern {
+    friend class JITCompiler;
+
 public:
     static const uint32_t s_memoryPageSize = 1024 * 64;
 
@@ -38,14 +40,14 @@ public:
     struct TargetBuffer {
         TargetBuffer()
             : prev(nullptr)
-            , sizeInByte(0)
             , buffer(nullptr)
+            , sizeInByte(0)
         {
         }
 
         TargetBuffer* prev;
-        uint64_t sizeInByte;
         uint8_t* buffer;
+        uint64_t sizeInByte;
     };
 
     static Memory* createMemory(Store* store, uint64_t initialSizeInByte, uint64_t maximumSizeInByte, bool isShared);
@@ -310,19 +312,6 @@ public:
     void init(ExecutionState& state, DataSegment* source, uint32_t dstStart, uint32_t srcStart, uint32_t srcSize);
     void copy(ExecutionState& state, uint32_t dstStart, uint32_t srcStart, uint32_t size);
     void fill(ExecutionState& state, uint32_t start, uint8_t value, uint32_t size);
-
-    inline void push(TargetBuffer* targetBuffer)
-    {
-        targetBuffer->prev = m_targetBuffers;
-        targetBuffer->sizeInByte = sizeInByte();
-        targetBuffer->buffer = buffer();
-        m_targetBuffers = targetBuffer;
-    }
-
-    inline void pop(TargetBuffer* targetBuffer)
-    {
-        m_targetBuffers = targetBuffer->prev;
-    }
 
     inline bool checkAccess(uint32_t offset, uint32_t size, uint32_t addend = 0) const
     {

--- a/test/jit/trycatch-mem.wast
+++ b/test/jit/trycatch-mem.wast
@@ -1,0 +1,39 @@
+(module
+  (memory 1)
+  (tag $except0 (param i32 i64 i32))
+
+  (func $throw1 (param i64 i32)
+     local.get 1
+     memory.grow
+
+     local.get 0
+     i64.const 0xffffffffffff
+     i64.add
+
+     memory.size
+     throw $except0
+  )
+
+  (func (export "try1") (result i32 i64 i32 i32 i32)
+    (try (result i32 i64 i32 i32 i32)
+      (do
+         i64.const 0x123456781234
+         i32.const 1
+         call $throw1
+
+         i32.const 0
+         i64.const 0
+         i32.const 0
+         i32.const 0
+         i32.const 0
+      )
+      (catch $except0
+         i32.const 2
+         memory.grow
+         memory.size
+      )
+    )
+  )
+)
+
+(assert_return (invoke "try1") (i32.const 1) (i64.const 0x1123456781233) (i32.const 2) (i32.const 2) (i32.const 4))


### PR DESCRIPTION
This is not the only option to do this. If we could store the instance in a register (my long term plan), we could cache the memory in the instance. Then saving/restoring would be unnecessary.