### PR TITLE
Support Short (8/16 bit) atomic RMW operations on RISCV

### DIFF
--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -1057,6 +1057,10 @@ void JITCompiler::compileFunction(JITFunction* jitFunc, bool isExternal)
             ASSERT(m_context.trapBlocksStart == 0);
             m_context.trapBlocksStart = 1;
         }
+
+        if (sljit_emit_atomic_load(m_compiler, SLJIT_MOV_U16 | SLJIT_ATOMIC_TEST, SLJIT_R0, SLJIT_R1) != SLJIT_ERR_UNSUPPORTED) {
+            m_options |= JITCompiler::kHasShortAtomic;
+        }
     }
 
 #ifdef WALRUS_JITPERF

--- a/src/jit/Compiler.h
+++ b/src/jit/Compiler.h
@@ -718,6 +718,7 @@ public:
 #endif
 
     static const uint32_t kHasCondMov = 1 << 0;
+    static const uint32_t kHasShortAtomic = 1 << 1;
 
     JITCompiler(Module* module, uint32_t JITFlags);
 

--- a/test/extended/threads/atomic_with_offsets.wast
+++ b/test/extended/threads/atomic_with_offsets.wast
@@ -101,6 +101,10 @@
 (assert_return (invoke "i64.atomic.rmw16.and_u" (i32.const 66) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
 (assert_return (invoke "i64.atomic.load" (i32.const 1276)) (i64.const 0x1111100111111111))
 
+(invoke "initOffset" (i64.const 0xffffffffffffffff) (i32.const 1296))
+(assert_return (invoke "i64.atomic.rmw32.and_u" (i32.const 66) (i64.const 0xbeefbeef)) (i64.const 0xffffffff))
+(assert_return (invoke "i64.atomic.load" (i32.const 1276)) (i64.const 0xbeefbeefffffffff))
+
 (invoke "initOffset" (i64.const 0x1111111111111111) (i32.const 44280))
 (assert_return (invoke "i32.atomic.rmw.or" (i32.const 757) (i32.const 0x12345678)) (i32.const 0x11111111))
 (assert_return (invoke "i64.atomic.load" (i32.const 44260)) (i64.const 0x1111111113355779))
@@ -112,6 +116,10 @@
 (invoke "initOffset" (i64.const 0x1111111111111111) (i32.const 63848))
 (assert_return (invoke "i64.atomic.rmw16.xchg_u" (i32.const 31) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
 (assert_return (invoke "i64.atomic.load" (i32.const 63828)) (i64.const 0x1111beef11111111))
+
+(invoke "initOffset" (i64.const 0x1111111111111111) (i32.const 63848))
+(assert_return (invoke "i64.atomic.rmw16.xchg_u" (i32.const 29) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 63828)) (i64.const 0x11111111beef1111))
 
 (invoke "initOffset" (i64.const 0x1111111111111111) (i32.const 2872))
 (assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 47) (i32.const 0x11111111) (i32.const 0xcafecafe)) (i32.const 0x1111))
@@ -128,3 +136,19 @@
 (invoke "initOffset" (i64.const 0x1111111111111111) (i32.const 24000))
 (assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 21169) (i64.const 0x1111) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
 (assert_return (invoke "i64.atomic.load" (i32.const 23980)) (i64.const 0x111111111111beef))
+
+(invoke "initOffset" (i64.const 0x1111111111111111) (i32.const 8216))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 5390) (i64.const 0x11) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 8196)) (i64.const 0x1111421111111111))
+
+(invoke "initOffset" (i64.const 0x1111111111111111) (i32.const 24000))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 21171) (i64.const 0x1111) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 23980)) (i64.const 0x11111111beef1111))
+
+(invoke "initOffset" (i64.const 0xffffffffffffffff) (i32.const 24000))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 21171) (i64.const 0xffff) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0xffff))
+(assert_return (invoke "i64.atomic.load" (i32.const 23980)) (i64.const 0xffffffffbeefffff))
+
+(invoke "initOffset" (i64.const 0xffffffffffffffff) (i32.const 24000))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 21169) (i64.const 0xffffffff) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0xffffffff))
+(assert_return (invoke "i64.atomic.load" (i32.const 23980)) (i64.const 0xffffffffbeefbeef))


### PR DESCRIPTION
Add support for short atomic RMW operations for RISCV

Since RISCV does not support short atomic RMW operations, only 32 and 64 bit ones, we must modify the correct values inside the 32 bit values ourselves.