### PR TITLE
Support TargetFeatures section

### DIFF
--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -712,6 +712,13 @@ public:
 
     virtual void EndModule() override {}
 
+    virtual void OnFeatureCount(Index count) override {}
+
+    virtual bool OnFeature(uint8_t prefix, std::string name) override
+    {
+        return true;
+    }
+
     virtual void OnTypeCount(Index count) override
     {
         // TODO reserve vector if possible

--- a/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
+++ b/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
@@ -43,6 +43,10 @@ public:
     virtual void BeginModule(uint32_t version) = 0;
     virtual void EndModule() = 0;
 
+    virtual void OnFeatureCount(Index count) = 0;
+    // Returns false, if the feature is not supported.
+    virtual bool OnFeature(uint8_t prefix, std::string name) = 0;
+
     virtual void OnTypeCount(Index count) = 0;
     virtual void OnFuncType(Index index, Index paramCount, Type *paramTypes, Index resultCount, Type *resultTypes) = 0;
 

--- a/third_party/wabt/src/walrus/binary-reader-walrus.cc
+++ b/third_party/wabt/src/walrus/binary-reader-walrus.cc
@@ -1259,19 +1259,16 @@ public:
 
     /* target_features section */
     Result BeginTargetFeaturesSection(Offset size) override {
-        abort();
         return Result::Ok;
     }
     Result OnFeatureCount(Index count) override {
-        abort();
+        m_externalDelegate->OnFeatureCount(count);
         return Result::Ok;
     }
     Result OnFeature(uint8_t prefix, nonstd::string_view name) override {
-        abort();
-        return Result::Ok;
+        return m_externalDelegate->OnFeature(prefix, std::string(name)) ? Result::Ok : Result::Error;
     }
     Result EndTargetFeaturesSection() override {
-        abort();
         return Result::Ok;
     }
 


### PR DESCRIPTION
Currently all features are accepted, we could add filters later.

Background: clang compiled .wasm files requires features such as bulk-memory / mutable-globals / sign-ext. These are all part of WebAssembly 2.0.

Shall I add manual checking of features?