### PR TITLE
Fix validation edge case when function end code is missing

### DIFF
--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -996,6 +996,7 @@ public:
 
     virtual void BeginFunctionBody(Index index, Offset size) override
     {
+        ASSERT(resumeGenerateByteCodeAfterNBlockEnd() == 0);
         ASSERT(m_currentFunction == nullptr);
         beginFunction(m_result.m_functions[index], false);
     }
@@ -1039,6 +1040,7 @@ public:
         m_preprocessData.m_inPreprocess = false;
         m_skipValidationUntil = *m_readerOffsetPointer - 1;
         m_shouldContinueToGenerateByteCode = true;
+        setResumeGenerateByteCodeAfterNBlockEnd(0);
 
         m_currentFunction->m_byteCode.clear();
         m_currentFunction->m_catchInfo.clear();

--- a/test/basic/missing_end.wast
+++ b/test/basic/missing_end.wast
@@ -1,0 +1,28 @@
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\09"                      ;; import section
+    "\02\60\00\00\60\01\7f\01\7f" ;; type section entry
+    "\03\02"                      ;; function section
+    "\01\00"                      ;; function section entry
+    "\07\09"                      ;; export section
+    "\01\05\6e\6f\65\6e\64\00\00" ;; export section entry (function 'noend')
+    "\0a\18"                      ;; begin code section
+    "\01\16\00"                   ;; begin function body
+    "\02\40"                      ;; block
+    "\03\40"                      ;;   loop
+    "\02\40"                      ;;     block
+    "\03\40"                      ;;       loop
+    "\0c\00"                      ;;         br 0
+    "\02\01"                      ;;         block type[1]
+    "\0b"                         ;;         end
+    "\0c\00"                      ;;         br 0
+    "\0b"                         ;;       end
+    "\00"                         ;;       unreachable
+    "\00"                         ;;       unreachable
+    "\00"                         ;;       unreachable
+    "\0b"                         ;;     end
+    "\0b"                         ;;   end
+  )
+  "function body must end with END opcode"
+)


### PR DESCRIPTION
In some cases `m_resumeGenerateByteCodeAfterNBlockEnd` could be non-zero when the preprocessing is finished on invalid wasm code.