### PR TITLE
Implement Array/Struct support for Garbage Collection

### DIFF
--- a/src/parser/WASMParser.h
+++ b/src/parser/WASMParser.h
@@ -45,7 +45,7 @@ struct WASMParsingResult {
     Vector<Data*> m_datas;
     Vector<Element*> m_elements;
 
-    Vector<FunctionType*> m_functionTypes;
+    Vector<CompositeType*> m_compositeTypes;
     Vector<GlobalType*> m_globalTypes;
     Vector<TableType*> m_tableTypes;
     Vector<MemoryType*> m_memoryTypes;

--- a/src/runtime/DefinedFunctionTypes.h
+++ b/src/runtime/DefinedFunctionTypes.h
@@ -275,11 +275,11 @@ public:
     FunctionType* operator[](const size_t idx)
     {
         ASSERT(idx < m_vector.size());
-        return m_vector[idx];
+        return m_vector[idx]->asFunction();
     }
 
 private:
-    FunctionTypeVector m_vector;
+    CompositeTypeVector m_vector;
 };
 
 } // namespace Walrus

--- a/src/runtime/Module.cpp
+++ b/src/runtime/Module.cpp
@@ -52,7 +52,7 @@ Module::Module(Store* store, WASMParsingResult& result)
     , m_functions(std::move(result.m_functions))
     , m_datas(std::move(result.m_datas))
     , m_elements(std::move(result.m_elements))
-    , m_functionTypes(std::move(result.m_functionTypes))
+    , m_compositeTypes(std::move(result.m_compositeTypes))
     , m_globalTypes(std::move(result.m_globalTypes))
     , m_tableTypes(std::move(result.m_tableTypes))
     , m_memoryTypes(std::move(result.m_memoryTypes))
@@ -235,7 +235,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
 
     // init tag
     while (tagIndex < m_tagTypes.size()) {
-        instance->m_tags[tagIndex] = Tag::createTag(m_store, m_functionTypes[m_tagTypes[tagIndex]->sigIndex()]);
+        instance->m_tags[tagIndex] = Tag::createTag(m_store, m_compositeTypes[m_tagTypes[tagIndex]->sigIndex()]->asFunction());
         tagIndex++;
     }
 

--- a/src/runtime/Module.h
+++ b/src/runtime/Module.h
@@ -376,10 +376,16 @@ public:
         return m_functions[index];
     }
 
+    CompositeType* compositeType(uint32_t index) const
+    {
+        ASSERT(index < m_compositeTypes.size());
+        return m_compositeTypes[index];
+    }
+
     FunctionType* functionType(uint32_t index) const
     {
-        ASSERT(index < m_functionTypes.size());
-        return m_functionTypes[index];
+        ASSERT(index < m_compositeTypes.size());
+        return m_compositeTypes[index]->asFunction();
     }
 
     size_t numberOfTableTypes()
@@ -461,7 +467,7 @@ private:
     VectorWithFixedSize<Data*, std::allocator<Data*>> m_datas;
     VectorWithFixedSize<Element*, std::allocator<Element*>> m_elements;
 
-    FunctionTypeVector m_functionTypes;
+    CompositeTypeVector m_compositeTypes;
     GlobalTypeVector m_globalTypes;
     TableTypeVector m_tableTypes;
     MemoryTypeVector m_memoryTypes;

--- a/src/runtime/ObjectType.cpp
+++ b/src/runtime/ObjectType.cpp
@@ -18,6 +18,7 @@
 
 #include "runtime/ObjectType.h"
 #include "runtime/Module.h"
+#include "runtime/TypeStore.h"
 
 namespace Walrus {
 
@@ -25,6 +26,21 @@ bool FunctionType::equals(const FunctionType* other) const
 {
     if (this == other) {
         return true;
+    }
+
+    // TODO: This should work for all types.
+    // However, functions defined by API has no type at
+    // the moment represented by a null recursive type.
+    if (getRecursiveType() != nullptr && other->getRecursiveType() != nullptr) {
+        return getRecursiveType() == other->getRecursiveType();
+    }
+
+    if (getRecursiveType() != nullptr && !getRecursiveType()->isSingleType()) {
+        return false;
+    }
+
+    if (other->getRecursiveType() != nullptr && !other->getRecursiveType()->isSingleType()) {
+        return false;
     }
 
     if (m_paramTypes->size() != other->param().size()) {

--- a/src/runtime/Store.cpp
+++ b/src/runtime/Store.cpp
@@ -35,7 +35,7 @@ Store::~Store()
     }
 
     for (size_t i = 0; i < m_modules.size(); i++) {
-        getTypeStore().releaseTypes(m_modules[i]->m_functionTypes);
+        getTypeStore().releaseTypes(m_modules[i]->m_compositeTypes);
         delete m_modules[i];
     }
 

--- a/src/runtime/Type.h
+++ b/src/runtime/Type.h
@@ -81,7 +81,37 @@ private:
     CompositeType* m_ref;
 };
 
+class MutableType : public Type {
+public:
+    MutableType()
+        : Type()
+        , m_isMutable(false)
+    {
+    }
+
+    MutableType(Value::Type kind, bool isMutable)
+        : Type(kind)
+        , m_isMutable(isMutable)
+    {
+    }
+
+    MutableType(Value::Type kind, CompositeType* ref, bool isMutable)
+        : Type(kind, ref)
+        , m_isMutable(isMutable)
+    {
+    }
+
+    bool isMutable() const
+    {
+        return m_isMutable;
+    }
+
+private:
+    bool m_isMutable;
+};
+
 typedef Vector<Type, std::allocator<Type>> TypeVector;
+typedef Vector<MutableType, std::allocator<MutableType>> MutableTypeVector;
 
 } // namespace Walrus
 

--- a/test/extended/gc/ref.wast
+++ b/test/extended/gc/ref.wast
@@ -1,0 +1,80 @@
+;; Syntax
+
+(module
+  (type $t (func))
+
+  (func
+    (param
+      funcref
+      externref
+      (ref func)
+      (ref extern)
+      (ref 0)
+      (ref $t)
+      (ref 0)
+      (ref $t)
+      (ref null func)
+      (ref null extern)
+      (ref null 0)
+      (ref null $t)
+    )
+  )
+)
+
+
+;; Undefined type index.
+
+(assert_invalid
+  (module (type $type-func-param-invalid (func (param (ref 1)))))
+  "unknown type"
+)
+(assert_invalid
+  (module (type $type-func-result-invalid (func (result (ref 1)))))
+  "unknown type"
+)
+
+(assert_invalid
+  (module (global $global-invalid (ref null 1) (ref.null 1)))
+  "unknown type"
+)
+
+(assert_invalid
+  (module (table $table-invalid 10 (ref null 1)))
+  "unknown type"
+)
+
+(assert_invalid
+  (module (elem $elem-invalid (ref 1)))
+  "unknown type"
+)
+
+(assert_invalid
+  (module (func $func-param-invalid (param (ref 1))))
+  "unknown type"
+)
+(assert_invalid
+  (module (func $func-result-invalid (result (ref 1))))
+  "unknown type"
+)
+(assert_invalid
+  (module (func $func-local-invalid (local (ref null 1))))
+  "unknown type"
+)
+
+(assert_invalid
+  (module (func $block-result-invalid (drop (block (result (ref 1)) (unreachable)))))
+  "unknown type"
+)
+(assert_invalid
+  (module (func $loop-result-invalid (drop (loop (result (ref 1)) (unreachable)))))
+  "unknown type"
+)
+(assert_invalid
+  (module (func $if-invalid (drop (if (result (ref 1)) (then) (else)))))
+  "unknown type"
+)
+
+(assert_invalid
+  (module (func $select-result-invalid (drop (select (result (ref 1)) (unreachable)))))
+  "unknown type"
+)

--- a/test/extended/gc/type-canon.wast
+++ b/test/extended/gc/type-canon.wast
@@ -1,0 +1,17 @@
+(module
+  (rec
+    (type $t1 (func (param i32 (ref $t3))))
+    (type $t2 (func (param i32 (ref $t1))))
+    (type $t3 (func (param i32 (ref $t2))))
+  )
+)
+
+(module
+  (rec
+    (type $t0 (func (param i32 (ref $t2) (ref $t3))))
+    (type $t1 (func (param i32 (ref $t0) i32 (ref $t4))))
+    (type $t2 (func (param i32 (ref $t2) (ref $t1))))
+    (type $t3 (func (param i32 (ref $t2) i32 (ref $t4))))
+    (type $t4 (func (param (ref $t0) (ref $t2))))
+  )
+)

--- a/test/extended/gc/type-rec.wast
+++ b/test/extended/gc/type-rec.wast
@@ -1,0 +1,158 @@
+;; Static matching of recursive types
+
+(module
+  (rec (type $f1 (func)) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (func)) (type (struct (field (ref $f2)))))
+  (func $f (type $f2))
+  (global (ref $f1) (ref.func $f))
+)
+
+(module
+  (rec (type $f1 (func)) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (func)) (type (struct (field (ref $f2)))))
+  (rec
+    (type $g1 (func))
+    (type (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1))))
+  )
+  (rec
+    (type $g2 (func))
+    (type (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2))))
+  )
+  (func $g (type $g2))
+  (global (ref $g1) (ref.func $g))
+)
+
+(assert_invalid
+  (module
+    (rec (type $f1 (func)) (type (struct (field (ref $f1)))))
+    (rec (type $f2 (func)) (type (struct (field (ref $f1)))))
+    (func $f (type $f2))
+    (global (ref $f1) (ref.func $f))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (rec (type $f0 (func)) (type (struct (field (ref $f0)))))
+    (rec (type $f1 (func)) (type (struct (field (ref $f0)))))
+    (rec (type $f2 (func)) (type (struct (field (ref $f1)))))
+    (func $f (type $f2))
+    (global (ref $f1) (ref.func $f))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (rec (type $f1 (func)) (type (struct)))
+    (rec (type (struct)) (type $f2 (func)))
+    (global (ref $f1) (ref.func $f))
+    (func $f (type $f2))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (rec (type $f1 (func)) (type (struct)))
+    (rec (type $f2 (func)) (type (struct)) (type (func)))
+    (global (ref $f1) (ref.func $f))
+    (func $f (type $f2))
+  )
+  "type mismatch"
+)
+
+
+;; Link-time matching of recursive function types
+
+(module $M
+  (rec (type $f1 (func)) (type (struct)))
+  (func (export "f") (type $f1))
+)
+(register "M" $M)
+
+(module
+  (rec (type $f2 (func)) (type (struct)))
+  (func (import "M" "f") (type $f2))
+)
+
+(assert_unlinkable
+  (module
+    (rec (type (struct)) (type $f2 (func)))
+    (func (import "M" "f") (type $f2))
+  )
+  "incompatible import type"
+)
+
+(assert_unlinkable
+  (module
+    (rec (type $f2 (func)))
+    (func (import "M" "f") (type $f2))
+  )
+  "incompatible import type"
+)
+
+
+;; Dynamic matching of recursive function types
+
+(module
+  (rec (type $f1 (func)) (type (struct)))
+  (rec (type $f2 (func)) (type (struct)))
+  (table funcref (elem $f1))
+  (func $f1 (type $f1))
+  (func (export "run") (call_indirect (type $f2) (i32.const 0)))
+)
+(assert_return (invoke "run"))
+
+(module
+  (rec (type $f1 (func)) (type (struct)))
+  (rec (type (struct)) (type $f2 (func)))
+  (table funcref (elem $f1))
+  (func $f1 (type $f1))
+  (func (export "run") (call_indirect (type $f2) (i32.const 0)))
+)
+(assert_trap (invoke "run") "indirect call type mismatch")
+
+(module
+  (rec (type $f1 (func)) (type (struct)))
+  (rec (type $f2 (func)))
+  (table funcref (elem $f1))
+  (func $f1 (type $f1))
+  (func (export "run") (call_indirect (type $f2) (i32.const 0)))
+)
+(assert_trap (invoke "run") "indirect call type mismatch")
+
+
+;; Implicit function types never pick up non-singleton recursive types
+
+(module
+  (rec (type $s (struct)))
+  (rec (type $t (func (param (ref $s)))))
+  (func $f (param (ref $s)))  ;; okay, type is equivalent to $t
+  (global (ref $t) (ref.func $f))
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type $s (struct))
+      (type $t (func (param (ref $s))))
+    )
+    (func $f (param (ref $s)))  ;; type is not equivalent to $t
+    (global (ref $t) (ref.func $f))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (struct))
+      (type $t (func))
+    )
+    (func $f)  ;; type is not equivalent to $t
+    (global (ref $t) (ref.func $f))
+  )
+  "type mismatch"
+)

--- a/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
+++ b/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
@@ -49,7 +49,10 @@ public:
     virtual bool OnFeature(uint8_t prefix, std::string name) = 0;
 
     virtual void OnTypeCount(Index count) = 0;
-    virtual void OnFuncType(Index index, Index paramCount, Type *paramTypes, Index resultCount, Type *resultTypes, GCTypeExtension* gc_ext) = 0;
+    virtual void OnRecursiveType(Index firstTypeIndex, Index typeCount) = 0;
+    virtual void OnFuncType(Index index, Index paramCount, Type *paramTypes, Index resultCount, Type *resultTypes, GCTypeExtension* gcExt) = 0;
+    virtual void OnStructType(Index index, Index fieldCount, TypeMut *fieldTypes, GCTypeExtension* gcExt) = 0;
+    virtual void OnArrayType(Index index, TypeMut fieldType, GCTypeExtension* gcExt) = 0;
     virtual void EndTypeSection() = 0;
 
     virtual void OnImportCount(Index count) = 0;


### PR DESCRIPTION
Second patch for Garbage Collection support. Adds a few spec tests, but there is still a long road to support linking all types. Supporting operations are even farther.