### PR TITLE
Reduce memory consumption of ArrayCopy

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -3752,8 +3752,7 @@ public:
               ByteCodeStackOffset src0Offset, ByteCodeStackOffset src1Offset, ByteCodeStackOffset src2Offset, ByteCodeStackOffset src3Offset, ByteCodeStackOffset src4Offset)
         : ByteCode(Opcode::ArrayCopyOpcode)
         , m_log2Size(log2Size)
-        , m_dstIsNullable(dstIsNullable ? 1 : 0)
-        , m_srcIsNullable(srcIsNullable ? 1 : 0)
+        , m_isNullable((dstIsNullable ? DstIsNullable : 0) | (srcIsNullable ? SrcIsNullable : 0))
         , m_src0Offset(src0Offset)
         , m_src1Offset(src1Offset)
         , m_src2Offset(src2Offset)
@@ -3768,16 +3767,14 @@ public:
     ByteCodeStackOffset src3Offset() const { return m_src3Offset; }
     ByteCodeStackOffset src4Offset() const { return m_src4Offset; }
     uint8_t log2Size() const { return m_log2Size; }
-    bool dstIsNullable() const { return m_dstIsNullable != 0; }
-    bool srcIsNullable() const { return m_srcIsNullable != 0; }
+    bool dstIsNullable() const { return (m_isNullable & DstIsNullable) != 0; }
+    bool srcIsNullable() const { return (m_isNullable & SrcIsNullable) != 0; }
 
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
         printf("ArrayCopy ");
         printf("log2Size: %" PRIu32 " ", m_log2Size);
-        printf("dstIsNullable: %" PRIu32 " ", m_dstIsNullable);
-        printf("srcIsNullable: %" PRIu32 " ", m_srcIsNullable);
         DUMP_BYTECODE_OFFSET(src0Offset);
         DUMP_BYTECODE_OFFSET(src1Offset);
         DUMP_BYTECODE_OFFSET(src2Offset);
@@ -3787,9 +3784,11 @@ public:
 #endif
 
 private:
+    static constexpr uint8_t DstIsNullable = 0x1;
+    static constexpr uint8_t SrcIsNullable = 0x2;
+
     uint8_t m_log2Size;
-    uint8_t m_dstIsNullable;
-    uint8_t m_srcIsNullable;
+    uint8_t m_isNullable;
     ByteCodeStackOffset m_src0Offset;
     ByteCodeStackOffset m_src1Offset;
     ByteCodeStackOffset m_src2Offset;

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -2011,12 +2011,12 @@ NextInstruction:
             Trap::throwException(state, "out of bounds array access");
         }
 
-        const uint8_t itemSize = static_cast<uintptr_t>(1) << code->log2Size();
-        const uintptr_t mask = itemSize - 1;
-        uint8_t* dst = reinterpret_cast<uint8_t*>(dstArray) + ((sizeof(GCArray) + mask) & ~mask) + (itemSize * dst_offset);
-        uint8_t* src = reinterpret_cast<uint8_t*>(srcArray) + ((sizeof(GCArray) + mask) & ~mask) + (itemSize * src_offset);
+        const uint8_t log2Size = code->log2Size();
+        const uintptr_t mask = (static_cast<uintptr_t>(1) << log2Size) - 1;
+        uint8_t* dst = reinterpret_cast<uint8_t*>(dstArray) + ((sizeof(GCArray) + mask) & ~mask) + (static_cast<uintptr_t>(dst_offset) << log2Size);
+        uint8_t* src = reinterpret_cast<uint8_t*>(srcArray) + ((sizeof(GCArray) + mask) & ~mask) + (static_cast<uintptr_t>(src_offset) << log2Size);
 
-        memmove(dst, src, size * itemSize);
+        memmove(dst, src, static_cast<size_t>(size) << log2Size);
 
         ADD_PROGRAM_COUNTER(ArrayCopy);
         NEXT_INSTRUCTION();

--- a/src/jit/GarbageCollectorInl.h
+++ b/src/jit/GarbageCollectorInl.h
@@ -790,12 +790,12 @@ static sljit_sw copyArray(GCArray* dstArray, const uint32_t dstOffset, GCArray* 
         return ExecutionContext::OutOfBoundsArrayAccessError;
     }
 
-    const uint8_t itemSize = static_cast<uintptr_t>(1) << args->log2Size;
-    const uintptr_t mask = itemSize - 1;
-    uint8_t* dstAddr = reinterpret_cast<uint8_t*>(dstArray) + ((sizeof(GCArray) + mask) & ~mask) + (itemSize * dstOffset);
-    uint8_t* srcAddr = reinterpret_cast<uint8_t*>(srcArray) + ((sizeof(GCArray) + mask) & ~mask) + (itemSize * args->srcOffset);
+    const uint8_t log2Size = args->log2Size;
+    const uintptr_t mask = (static_cast<uintptr_t>(1) << log2Size) - 1;
+    uint8_t* dstAddr = reinterpret_cast<uint8_t*>(dstArray) + ((sizeof(GCArray) + mask) & ~mask) + (static_cast<uintptr_t>(dstOffset) << log2Size);
+    uint8_t* srcAddr = reinterpret_cast<uint8_t*>(srcArray) + ((sizeof(GCArray) + mask) & ~mask) + (static_cast<uintptr_t>(args->srcOffset) << log2Size);
 
-    memmove(dstAddr, srcAddr, args->size * itemSize);
+    memmove(dstAddr, srcAddr, static_cast<size_t>(args->size) << log2Size);
 
     return ExecutionContext::NoError;
 }


### PR DESCRIPTION
Also use left shifting instead of multiply