### PR TITLE
Reduce memory consumption of JIT instruction list

### DIFF
--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -1626,7 +1626,7 @@ void JITCompiler::clear()
             }
         }
 
-        delete item;
+        item->deleteObject();
         item = next;
     }
 

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -1310,6 +1310,9 @@ int main(int argc, const char* argv[])
     // finalize
     delete store;
     delete engine;
+    for (auto it : externalValues) {
+        delete it;
+    }
 
 #if defined(WALRUS_GOOGLE_PERF)
     ProfilerStop();


### PR DESCRIPTION
Low-level change, makes the code more complex, but saves two pointers for each instruction list item, and faster execution. Also fixed a leak in Shell.cpp.