### PR TITLE
Create a separate type vector

### DIFF
--- a/src/api/wasm.cpp
+++ b/src/api/wasm.cpp
@@ -505,7 +505,7 @@ static void FromWalrusValueTypes(const TypeVector& types, wasm_valtype_vec_t* ou
 {
     wasm_valtype_vec_new_uninitialized(out, types.size());
     for (size_t i = 0; i < types.size(); i++) {
-        out->data[i] = wasm_valtype_new(FromWalrusValueType(types[i]));
+        out->data[i] = wasm_valtype_new(FromWalrusValueType(types.types()[i]));
     }
 }
 
@@ -903,16 +903,14 @@ own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*
 // Function Instances
 static FunctionType* ToWalrusFunctionType(const wasm_functype_t* ft)
 {
-    TypeVector* params = new TypeVector();
-    TypeVector* results = new TypeVector();
-    params->reserve(ft->params.size);
-    results->reserve(ft->results.size);
+    TypeVector* params = new TypeVector(ft->params.size, 0);
+    TypeVector* results = new TypeVector(ft->results.size, 0);
 
     for (uint32_t i = 0; i < ft->params.size; i++) {
-        params->push_back(ft->params.data[i]->type);
+        params->setType(i, ft->params.data[i]->type);
     }
     for (uint32_t i = 0; i < ft->results.size; i++) {
-        results->push_back(ft->results.data[i]->type);
+        results->setType(i, ft->results.data[i]->type);
     }
 
     return new FunctionType(params, results);

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -2223,7 +2223,7 @@ NextInstruction:
         userExceptionData.resizeWithUninitializedValues(sz);
 
         uint8_t* ptr = userExceptionData.data();
-        auto& param = tag->functionType()->param();
+        auto& param = tag->functionType()->param().types();
         for (size_t i = 0; i < param.size(); i++) {
             auto sz = valueStackAllocatedSize(param[i]);
             memcpy(ptr, bp + code->dataOffsets()[i], sz);

--- a/src/jit/Analysis.cpp
+++ b/src/jit/Analysis.cpp
@@ -97,7 +97,7 @@ void DependencyGenContext::update(size_t dependencyStart, size_t id, size_t excl
            && (dependencyStart % size) == 0
            && maxDistance[dependencyStart / size] <= id);
 
-    for (auto it : param) {
+    for (auto it : param.types()) {
         if (variableList != nullptr) {
             // Construct new variables.
             VariableRef ref = variableList->variables.size();
@@ -520,7 +520,7 @@ void JITCompiler::buildVariables(uint32_t requiredStackSize)
 
         size_t id = instr->id();
 
-        for (auto it : functionType->result()) {
+        for (auto it : functionType->result().types()) {
             VariableRef ref = VARIABLE_SET(m_variableList->variables.size(), DependencyGenContext::Variable);
             uint32_t typeInfo = Instruction::valueTypeToOperandType(it);
 
@@ -700,7 +700,7 @@ void JITCompiler::buildVariables(uint32_t requiredStackSize)
             } else {
                 switch (instr->opcode()) {
                 case ByteCode::StructNewOpcode: {
-                    for (auto it : reinterpret_cast<StructNew*>(instr->byteCode())->typeInfo()->fields()) {
+                    for (auto it : reinterpret_cast<StructNew*>(instr->byteCode())->typeInfo()->fields().types()) {
                         VariableList::Variable& variable = m_variableList->variables[*param++];
                         variable.info |= Instruction::valueTypeToOperandType(Value::unpackType(it.type()));
                     }
@@ -790,7 +790,7 @@ void JITCompiler::buildVariables(uint32_t requiredStackSize)
                     }
                     }
 
-                    for (auto it : *types) {
+                    for (auto it : types->types()) {
                         VariableList::Variable& variable = m_variableList->variables[*param++];
                         variable.info |= Instruction::valueTypeToOperandType(it);
                     }

--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -703,7 +703,7 @@ static void emitImmediate(sljit_compiler* compiler, Instruction* instr)
 
 static ByteCodeStackOffset* emitStoreOntoStack(sljit_compiler* compiler, Operand* param, ByteCodeStackOffset* stackOffset, const TypeVector& types, bool isWordOffsets)
 {
-    for (auto it : types) {
+    for (auto it : types.types()) {
         Operand dst = VARIABLE_SET(STACK_OFFSET(*stackOffset), Instruction::Offset);
 
         switch (VARIABLE_TYPE(*param)) {

--- a/src/jit/ByteCodeParser.cpp
+++ b/src/jit/ByteCodeParser.cpp
@@ -93,7 +93,7 @@ static void buildCatchInfo(JITCompiler* compiler, ModuleFunction* function, std:
 
 static bool isFloatGlobal(uint32_t globalIndex, Module* module)
 {
-    Value::Type type = module->globalType(globalIndex)->type();
+    Value::Type type = module->globalType(globalIndex)->type().type();
 
     return type == Value::F32 || type == Value::F64;
 }
@@ -1146,7 +1146,7 @@ static void compileFunction(JITCompiler* compiler)
             Operand* operand = instr->operands();
             instr->addInfo(Instruction::kIsCallback | Instruction::kFreeUnusedEarly);
 
-            for (auto it : functionType->param()) {
+            for (auto it : functionType->param().types()) {
                 *operand++ = STACK_OFFSET(*stackOffset);
                 stackOffset += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
             }
@@ -1157,7 +1157,7 @@ static void compileFunction(JITCompiler* compiler)
                 *operand++ = STACK_OFFSET(reinterpret_cast<CallRef*>(byteCode)->calleeOffset());
             }
 
-            for (auto it : functionType->result()) {
+            for (auto it : functionType->result().types()) {
                 *operand++ = STACK_OFFSET(*stackOffset);
                 stackOffset += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
             }
@@ -2066,7 +2066,7 @@ static void compileFunction(JITCompiler* compiler)
             Operand* param = instr->params();
             ByteCodeStackOffset* offsets = reinterpret_cast<End*>(byteCode)->resultOffsets();
 
-            for (auto it : result) {
+            for (auto it : result.types()) {
                 *param++ = STACK_OFFSET(*offsets);
                 offsets += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
             }

--- a/src/jit/CallInl.h
+++ b/src/jit/CallInl.h
@@ -182,7 +182,7 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
 
     sljit_jump* jump = sljit_emit_cmp(compiler, SLJIT_NOT_EQUAL, SLJIT_R0, 0, SLJIT_IMM, ExecutionContext::NoError);
 
-    for (auto it : functionType->result()) {
+    for (auto it : functionType->result().types()) {
         ASSERT(VARIABLE_TYPE(*operand) != Instruction::ConstPtr);
 
         if (VARIABLE_TYPE(*operand) == Instruction::Register) {

--- a/src/jit/GarbageCollectorInl.h
+++ b/src/jit/GarbageCollectorInl.h
@@ -1022,7 +1022,7 @@ static void emitGCStructNew(sljit_compiler* compiler, Instruction* instr)
     ByteCodeStackOffset* stackOffset = structNew->dataOffsets();
     Operand* param = instr->params();
 
-    for (auto it : structNew->typeInfo()->fields()) {
+    for (auto it : structNew->typeInfo()->fields().types()) {
         emitGCStore(compiler, *stackOffset++, param++, it.type());
     }
 

--- a/src/jit/TryCatchInl.h
+++ b/src/jit/TryCatchInl.h
@@ -232,7 +232,7 @@ static void throwWithArgs(Throw* throwTag, uint8_t* bp, ExecutionContext* contex
     userExceptionData.resizeWithUninitializedValues(sz);
 
     uint8_t* ptr = userExceptionData.data();
-    auto& param = tag->functionType()->param();
+    auto& param = tag->functionType()->param().types();
     for (size_t i = 0; i < param.size(); i++) {
         auto sz = valueStackAllocatedSize(param[i]);
         memcpy(ptr, bp + throwTag->dataOffsets()[i], sz);

--- a/src/runtime/DefinedFunctionTypes.h
+++ b/src/runtime/DefinedFunctionTypes.h
@@ -61,204 +61,204 @@ public:
 
         {
             // NONE
-            param = new TypeVector();
-            result = new TypeVector();
+            param = new TypeVector(0, 0);
+            result = new TypeVector(0, 0);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32R
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
+            param = new TypeVector(1, 0);
+            result = new TypeVector(0, 0);
+            param->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(1, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(2, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I64I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(3, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I64);
+            param->setType(2, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I32I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(3, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I32);
+            param->setType(2, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I32I32I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(4, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I32);
+            param->setType(2, Value::Type::I32);
+            param->setType(3, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I64I32I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(4, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I64);
+            param->setType(2, Value::Type::I32);
+            param->setType(3, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I64I64I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(4, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I64);
+            param->setType(2, Value::Type::I64);
+            param->setType(3, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I32I32I32I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(5, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I32);
+            param->setType(2, Value::Type::I32);
+            param->setType(3, Value::Type::I32);
+            param->setType(4, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I32I32I64I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(5, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I32);
+            param->setType(2, Value::Type::I32);
+            param->setType(3, Value::Type::I64);
+            param->setType(4, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I32I32I32I32I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(6, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I32);
+            param->setType(2, Value::Type::I32);
+            param->setType(3, Value::Type::I32);
+            param->setType(4, Value::Type::I32);
+            param->setType(5, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I32I32I32I32I64I64I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(7, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I32);
+            param->setType(2, Value::Type::I32);
+            param->setType(3, Value::Type::I32);
+            param->setType(4, Value::Type::I64);
+            param->setType(5, Value::Type::I64);
+            param->setType(6, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32I32I32I32I32I64I64I32I32_RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I64);
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::I32);
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(9, 0);
+            result = new TypeVector(1, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::I32);
+            param->setType(2, Value::Type::I32);
+            param->setType(3, Value::Type::I32);
+            param->setType(4, Value::Type::I32);
+            param->setType(5, Value::Type::I64);
+            param->setType(6, Value::Type::I64);
+            param->setType(7, Value::Type::I32);
+            param->setType(8, Value::Type::I32);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // RI32
-            param = new TypeVector();
-            result = new TypeVector();
-            result->push_back(Value::Type::I32);
+            param = new TypeVector(0, 0);
+            result = new TypeVector(1, 0);
+            result->setType(0, Value::Type::I32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I64
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I64);
+            param = new TypeVector(1, 0);
+            result = new TypeVector(0, 0);
+            param->setType(0, Value::Type::I64);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // F32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::F32);
+            param = new TypeVector(1, 0);
+            result = new TypeVector(0, 0);
+            param->setType(0, Value::Type::F32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // F64
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::F64);
+            param = new TypeVector(1, 0);
+            result = new TypeVector(0, 0);
+            param->setType(0, Value::Type::F64);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // I32F32
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::I32);
-            param->push_back(Value::Type::F32);
+            param = new TypeVector(2, 0);
+            result = new TypeVector(0, 0);
+            param->setType(0, Value::Type::I32);
+            param->setType(1, Value::Type::F32);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // F64F64
-            param = new TypeVector();
-            result = new TypeVector();
-            param->push_back(Value::Type::F64);
-            param->push_back(Value::Type::F64);
+            param = new TypeVector(2, 0);
+            result = new TypeVector(0, 0);
+            param->setType(0, Value::Type::F64);
+            param->setType(1, Value::Type::F64);
             m_vector[index++] = new FunctionType(param, result);
         }
         {
             // INVALID
-            param = new TypeVector();
-            result = new TypeVector();
+            param = new TypeVector(1, 0);
+            result = new TypeVector(0, 0);
             // Temporary types cannot be used as params
-            param->push_back(Value::Type::Void);
+            param->setType(0, Value::Type::Void);
             m_vector[index++] = new FunctionType(param, result);
         }
 

--- a/src/runtime/Function.cpp
+++ b/src/runtime/Function.cpp
@@ -64,14 +64,14 @@ void DefinedFunction::call(ExecutionState& state, Value* argv, Value* result)
     uint16_t parameterOffsetSize = ft->paramStackSize() / sizeof(size_t);
     uint16_t resultOffsetSize = ft->resultStackSize() / sizeof(size_t);
     ALLOCA(uint16_t, offsetBuffer, (parameterOffsetSize + resultOffsetSize) * sizeof(uint16_t));
-    const TypeVector& paramTypeInfo = ft->param();
-    const TypeVector& resultTypeInfo = ft->result();
+    const TypeVector::Types& paramTypeInfo = ft->param().types();
+    const TypeVector::Types& resultTypeInfo = ft->result().types();
 
     size_t argc = paramTypeInfo.size();
     uint8_t* paramBuffer = valueBuffer;
     size_t offsetIndex = 0;
     for (size_t i = 0; i < argc; i++) {
-        ASSERT(paramTypeInfo[i].isRef() ? argv[i].isRef() : argv[i].type() == paramTypeInfo[i]);
+        ASSERT(Value::isRefType(paramTypeInfo[i]) ? argv[i].isRef() : argv[i].type() == paramTypeInfo[i]);
         argv[i].writeToMemory(paramBuffer);
         size_t stackAllocatedSize = valueStackAllocatedSize(paramTypeInfo[i]);
         for (size_t j = 0; j < stackAllocatedSize; j += sizeof(size_t)) {
@@ -128,8 +128,8 @@ void ImportedFunction::interpreterCall(ExecutionState& state, uint8_t* bp, ByteC
                                        uint16_t parameterOffsetCount, uint16_t resultOffsetCount)
 {
     const FunctionType* ft = functionType();
-    const TypeVector& paramTypeInfo = ft->param();
-    const TypeVector& resultTypeInfo = ft->result();
+    const TypeVector::Types& paramTypeInfo = ft->param().types();
+    const TypeVector::Types& resultTypeInfo = ft->result().types();
 
     ALLOCA(Value, paramVector, sizeof(Value) * paramTypeInfo.size());
     ALLOCA(Value, resultVector, sizeof(Value) * resultTypeInfo.size());
@@ -171,8 +171,8 @@ void WasiFunction::interpreterCall(ExecutionState& state, uint8_t* bp, ByteCodeS
                                    uint16_t parameterOffsetCount, uint16_t resultOffsetCount)
 {
     const FunctionType* ft = functionType();
-    const TypeVector& paramTypeInfo = ft->param();
-    const TypeVector& resultTypeInfo = ft->result();
+    const TypeVector::Types& paramTypeInfo = ft->param().types();
+    const TypeVector::Types& resultTypeInfo = ft->result().types();
 
     ALLOCA(Value, paramVector, sizeof(Value) * paramTypeInfo.size());
     ALLOCA(Value, resultVector, sizeof(Value) * resultTypeInfo.size());

--- a/src/runtime/GCStruct.cpp
+++ b/src/runtime/GCStruct.cpp
@@ -44,7 +44,7 @@ GCStruct* GCStruct::structNew(const StructType* type, ByteCodeStackOffset* offse
     // Placement new to initialize the common part.
     new (result) GCStruct(type);
 
-    const MutableTypeVector& fields = type->fields();
+    const MutableTypeVector::Types& fields = type->fields().types();
     const VectorWithFixedSize<uint32_t, std::allocator<uint32_t>>& fieldOffsets = type->fieldOffsets();
     size_t size = fields.size();
 

--- a/src/runtime/Module.cpp
+++ b/src/runtime/Module.cpp
@@ -534,9 +534,10 @@ void ModuleFunction::dumpByteCode()
     printf("required stack size: %u bytes\n", m_requiredStackSize);
     printf("stack: [");
     size_t pos = 0;
-    for (size_t i = 0; i < m_functionType->param().size(); i++) {
-        printf("(parameter %zu, %s, pos %zu) ", i, typeName(m_functionType->param()[i]), pos);
-        pos += valueStackAllocatedSize(m_functionType->param()[i]);
+    const TypeVector::Types& param = m_functionType->param().types();
+    for (size_t i = 0; i < param.size(); i++) {
+        printf("(parameter %zu, %s, pos %zu) ", i, typeName(param[i]), pos);
+        pos += valueStackAllocatedSize(param[i]);
     }
     for (size_t i = 0; i < m_local.size(); i++) {
         printf("(local %zu, %s, pos %zu) ", i, typeName(m_local[i]), m_localDebugData[i]);

--- a/src/runtime/ObjectType.cpp
+++ b/src/runtime/ObjectType.cpp
@@ -47,19 +47,27 @@ bool FunctionType::equals(const FunctionType* other, bool isSubType) const
         return false;
     }
 
-    if (m_paramTypes->size() != other->param().size()) {
+    size_t typesSize = m_paramTypes->size();
+    size_t refsSize = m_paramTypes->refs().size();
+    if (typesSize != other->param().size()
+        || refsSize != other->param().refs().size()) {
         return false;
     }
 
-    if (memcmp(m_paramTypes->data(), other->param().data(), sizeof(Type) * other->param().size())) {
+    if (memcmp(m_paramTypes->types().data(), other->param().types().data(), sizeof(Value::Type) * typesSize)
+        || memcmp(m_paramTypes->refs().data(), other->param().refs().data(), sizeof(CompositeType*) * refsSize)) {
         return false;
     }
 
-    if (m_resultTypes->size() != other->result().size()) {
+    typesSize = m_resultTypes->size();
+    refsSize = m_resultTypes->refs().size();
+    if (typesSize != other->result().size()
+        || refsSize != other->result().refs().size()) {
         return false;
     }
 
-    if (memcmp(m_resultTypes->data(), other->result().data(), sizeof(Type) * other->result().size())) {
+    if (memcmp(m_resultTypes->types().data(), other->result().types().data(), sizeof(Value::Type) * typesSize)
+        || memcmp(m_resultTypes->refs().data(), other->result().refs().data(), sizeof(CompositeType*) * refsSize)) {
         return false;
     }
 
@@ -74,8 +82,9 @@ bool StructType::initialize()
     uint32_t offset = sizeof(GCStruct);
     uint32_t align = sizeof(void*);
 
+    const MutableTypeVector::Types& fieldTypes = fields().types();
     for (size_t i = 0; i < fieldCount; i++) {
-        Value::Type type = fields()[i].type();
+        Value::Type type = fieldTypes[i].type();
         uint32_t size;
 
         if (type == Value::I8) {
@@ -83,7 +92,7 @@ bool StructType::initialize()
         } else if (type == Value::I16) {
             size = 2;
         } else {
-            size = static_cast<uint32_t>(valueSize(fields()[i]));
+            size = static_cast<uint32_t>(valueSize(fieldTypes[i].type()));
         }
 
         if (align < size) {

--- a/src/runtime/ObjectType.h
+++ b/src/runtime/ObjectType.h
@@ -177,9 +177,11 @@ private:
 
     static size_t computeStackSize(const TypeVector& v)
     {
+        const TypeVector::Types& types = v.types();
+
         size_t s = 0;
-        for (size_t i = 0; i < v.size(); i++) {
-            s += valueStackAllocatedSize(v[i]);
+        for (size_t i = 0; i < types.size(); i++) {
+            s += valueStackAllocatedSize(types[i]);
         }
         return s;
     }

--- a/src/runtime/Store.cpp
+++ b/src/runtime/Store.cpp
@@ -81,10 +81,13 @@ void Store::finalize()
 #endif
 }
 
-#define ALLOCATE_DEFAULT_TYPE(type)                                                                                                  \
-    case Value::Type::type:                                                                                                          \
-        g_defaultFunctionTypes[Value::Type::type] = new FunctionType(new TypeVector(), new TypeVector({ Type(Value::Type::type) })); \
-        break;
+#define ALLOCATE_DEFAULT_TYPE(type)                                                                 \
+    case Value::Type::type: {                                                                       \
+        TypeVector* result = new TypeVector(1, 0);                                                  \
+        result->setType(0, Value::Type::type);                                                      \
+        g_defaultFunctionTypes[Value::Type::type] = new FunctionType(new TypeVector(0, 0), result); \
+        break;                                                                                      \
+    }
 
 FunctionType* Store::getDefaultFunctionType(Value::Type type)
 {

--- a/src/runtime/Type.cpp
+++ b/src/runtime/Type.cpp
@@ -20,7 +20,7 @@
 
 namespace Walrus {
 
-static Value::Type toGenericType(CompositeType* ref)
+static Value::Type toGenericType(const CompositeType* ref)
 {
     switch (ref->kind()) {
     case ObjectType::FunctionKind:

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -348,12 +348,12 @@ static Trap::TrapResult executeWASM(Store* store, const std::string& filename, c
                     auto fn = instance->function(exp->itemIndex());
                     FunctionType* fnType = fn->asDefinedFunction()->moduleFunction()->functionType();
 
-                    if (!fnType->param().empty()) {
+                    if (fnType->param().size() != 0) {
                         printf("warning: function %s has params, but params are not supported\n", exp->name().c_str());
                         return;
                     }
 
-                    if (!fnType->result().empty()) {
+                    if (fnType->result().size() != 0) {
                         printf("warning: function %s has results, but results are not supported\n", exp->name().c_str());
                         return;
                     }
@@ -1080,7 +1080,7 @@ static void runExports(Store* store, const std::string& filename, const std::vec
                 auto fn = instance->function(exp->itemIndex());
                 FunctionType* fnType = fn->asDefinedFunction()->moduleFunction()->functionType();
 
-                if (!fnType->param().empty()) {
+                if (fnType->param().size() != 0) {
                     printf("warning: function %s has params, but params are not supported\n", exp->name().c_str());
                     return;
                 }


### PR DESCRIPTION
This patch goes back to the original concept, where type vectors only used one byte for each argument. Since type pointers are still needed for ref/refnull types, they are stored in a secondary array. This array is often empty. So the memory consumption is reduced by 15 bytes (64 bit systems) for generic, and by 7 bytes for ref/refnull types. The secondary array is rarely used, except some type comparisons, hash computing.
