### PR TITLE
Change build scripts after move bdwgc files to gcutil repository root

### DIFF
--- a/build/walrus.cmake
+++ b/build/walrus.cmake
@@ -2,8 +2,7 @@ SET (WALRUS_INCDIRS
     ${WALRUS_INCDIRS}
     ${WALRUS_ROOT}/src/
     ${SLJIT_ROOT}/sljit_src/
-    ${GCUTIL_ROOT}/
-    ${GCUTIL_ROOT}/bdwgc/include/
+    ${GCUTIL_ROOT}/include/
 )
 
 IF (${WALRUS_MODE} STREQUAL "debug")


### PR DESCRIPTION
This is a follow up of https://github.com/Samsung/gcutil/pull/34

Remove include dir ${GCUTIL_ROOT}.
Change include dir ${GCUTIL_ROOT}/bdwgc/include to ${GCUTIL_ROOT}/include.