### PR TITLE
Use a vector with fixed size to store the byte code

### DIFF
--- a/src/jit/ByteCodeParser.cpp
+++ b/src/jit/ByteCodeParser.cpp
@@ -544,7 +544,7 @@ static void compileFunction(JITCompiler* compiler)
 {
     size_t idx = 0;
     ModuleFunction* function = compiler->moduleFunction();
-    size_t endIdx = function->currentByteCodeSize();
+    size_t endIdx = function->byteCodeSize();
 
     if (endIdx == 0) {
         // If a function has no End opcode, it is an imported function.
@@ -555,7 +555,7 @@ static void compileFunction(JITCompiler* compiler)
 
     // Construct labels first
     while (idx < endIdx) {
-        ByteCode* byteCode = function->peekByteCode<ByteCode>(idx);
+        ByteCode* byteCode = function->getByteCode<ByteCode>(idx);
         ByteCode::Opcode opcode = byteCode->opcode();
 
         switch (opcode) {
@@ -630,7 +630,7 @@ static void compileFunction(JITCompiler* compiler)
             }
         }
 
-        ByteCode* byteCode = function->peekByteCode<ByteCode>(idx);
+        ByteCode* byteCode = function->getByteCode<ByteCode>(idx);
         ByteCode::Opcode opcode = byteCode->opcode();
         Instruction::Group group = Instruction::Any;
         uint8_t paramType = ParamTypes::NoParam;

--- a/src/runtime/Module.cpp
+++ b/src/runtime/Module.cpp
@@ -382,7 +382,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
         Walrus::Trap trap;
         auto result = trap.run([](Walrus::ExecutionState& state, void* d) {
             RunData* data = reinterpret_cast<RunData*>(d);
-            if (data->init->moduleFunction()->currentByteCodeSize()) {
+            if (data->init->moduleFunction()->byteCodeSize()) {
                 DefinedFunctionWithTryCatch fakeFunction(data->instance,
                                                          data->init->moduleFunction());
                 Value offset;
@@ -528,7 +528,7 @@ static void dumpValue(Value v)
     printf(", %s", typeName(v.type()));
 }
 
-void ModuleFunction::dumpByteCode()
+void ModuleFunction::dumpByteCode(Walrus::Vector<uint8_t, std::allocator<uint8_t>>& byteCode)
 {
     printf("\n");
     printf("required stack size: %u bytes\n", m_requiredStackSize);
@@ -549,12 +549,12 @@ void ModuleFunction::dumpByteCode()
     }
     printf("....]\n");
 
-    printf("bytecode size: %zu bytes\n", m_byteCode.size());
+    printf("bytecode size: %zu bytes\n", byteCode.size());
     printf("\n");
 
     size_t idx = 0;
-    while (idx < m_byteCode.size()) {
-        ByteCode* code = reinterpret_cast<ByteCode*>(&m_byteCode[idx]);
+    while (idx < byteCode.size()) {
+        ByteCode* code = reinterpret_cast<ByteCode*>(&byteCode[idx]);
         printf("%6zu ", idx);
 
         switch (code->opcode()) {

--- a/src/runtime/Module.h
+++ b/src/runtime/Module.h
@@ -212,43 +212,21 @@ public:
     uint16_t requiredStackSize() const { return m_requiredStackSize; }
     FunctionType* functionType() const { return m_functionType; }
 
-    template <typename CodeType>
-    void pushByteCode(const CodeType& code)
-    {
-        char* first = (char*)&code;
-        size_t start = m_byteCode.size();
+    const uint8_t* byteCode() const { return m_byteCode.data(); }
 
-        m_byteCode.resizeWithUninitializedValues(m_byteCode.size() + sizeof(CodeType));
-        for (size_t i = 0; i < sizeof(CodeType); i++) {
-            m_byteCode[start++] = *first;
-            first++;
-        }
-    }
-
-    template <typename CodeType>
-    CodeType* peekByteCode(size_t position)
-    {
-        return reinterpret_cast<CodeType*>(&m_byteCode[position]);
-    }
-
-    void expandByteCode(size_t s)
-    {
-        m_byteCode.resizeWithUninitializedValues(m_byteCode.size() + s);
-    }
-
-    void resizeByteCode(size_t newSize)
-    {
-        m_byteCode.resizeWithUninitializedValues(newSize);
-    }
-
-    size_t currentByteCodeSize() const
+    size_t byteCodeSize() const
     {
         return m_byteCode.size();
     }
 
-    const uint8_t* byteCode() const { return m_byteCode.data(); }
+    template <typename CodeType>
+    CodeType* getByteCode(size_t position)
+    {
+        return reinterpret_cast<CodeType*>(&m_byteCode[position]);
+    }
+
 #if !defined(NDEBUG)
-    void dumpByteCode();
+    void dumpByteCode(Walrus::Vector<uint8_t, std::allocator<uint8_t>>& byteCode);
 #endif
 
     const Vector<CatchInfo, std::allocator<CatchInfo>>& catchInfo() const
@@ -274,7 +252,7 @@ private:
     uint16_t m_requiredStackSize;
     FunctionType* m_functionType;
     ValueTypeVector m_local;
-    Vector<uint8_t, std::allocator<uint8_t>> m_byteCode;
+    VectorWithFixedSize<uint8_t, std::allocator<uint8_t>> m_byteCode;
 #if !defined(NDEBUG)
     Vector<size_t, std::allocator<size_t>> m_localDebugData;
     Vector<std::pair<Value, size_t>, std::allocator<std::pair<Value, size_t>>> m_constantDebugData;


### PR DESCRIPTION
The idea is that VectorWithFixed size does not have capacity (reduces structure size) and there is no byte-code buffer overallocation, since the byte code is copied after the parsing is completed.