### PR TITLE
Rework FunctionType to use less memory

### DIFF
--- a/src/api/wasm.cpp
+++ b/src/api/wasm.cpp
@@ -903,8 +903,9 @@ own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*
 // Function Instances
 static FunctionType* ToWalrusFunctionType(const wasm_functype_t* ft)
 {
-    TypeVector* params = new TypeVector(ft->params.size, 0);
-    TypeVector* results = new TypeVector(ft->results.size, 0);
+    FunctionType* functionType = new FunctionType(ft->params.size, 0, ft->results.size, 0);
+    TypeVector* params = functionType->initParam();
+    TypeVector* results = functionType->initResult();
 
     for (uint32_t i = 0; i < ft->params.size; i++) {
         params->setType(i, ft->params.data[i]->type);
@@ -913,7 +914,8 @@ static FunctionType* ToWalrusFunctionType(const wasm_functype_t* ft)
         results->setType(i, ft->results.data[i]->type);
     }
 
-    return new FunctionType(params, results);
+    functionType->initDone();
+    return functionType;
 }
 
 own wasm_func_t* wasm_func_new(

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -927,7 +927,11 @@ public:
                             Type* resultTypes,
                             GCTypeExtension* gcExt) override
     {
-        Walrus::TypeVector* param = new Walrus::TypeVector(paramCount, getRefCountOfTypes(paramTypes, paramCount));
+        Walrus::FunctionType* functionType = new Walrus::FunctionType(paramCount, getRefCountOfTypes(paramTypes, paramCount),
+                                                                      resultCount, getRefCountOfTypes(resultTypes, resultCount),
+                                                                      gcExt->is_final_sub_type, toSubType(gcExt));
+
+        Walrus::TypeVector* param = functionType->initParam();
         size_t refIdx = 0;
         for (size_t i = 0; i < paramCount; i++) {
             Walrus::Type type = toValueKind(paramTypes[i], nullptr);
@@ -936,7 +940,7 @@ public:
                 param->setRef(refIdx++, type.ref());
             }
         }
-        Walrus::TypeVector* result = new Walrus::TypeVector(resultCount, getRefCountOfTypes(resultTypes, resultCount));
+        Walrus::TypeVector* result = functionType->initResult();
         refIdx = 0;
         for (size_t i = 0; i < resultCount; i++) {
             Walrus::Type type = toValueKind(resultTypes[i], nullptr);
@@ -946,7 +950,9 @@ public:
             }
         }
         ASSERT(index == m_result.m_compositeTypes.size());
-        m_result.m_compositeTypes.push_back(new Walrus::FunctionType(param, result, gcExt->is_final_sub_type, toSubType(gcExt)));
+
+        functionType->initDone();
+        m_result.m_compositeTypes.push_back(functionType);
         if (index < m_recursiveTypeEnd && index > m_recursiveTypeStart) {
             Walrus::TypeStore::ConnectTypes(m_result.m_compositeTypes, index);
         }

--- a/src/runtime/DefinedFunctionTypes.h
+++ b/src/runtime/DefinedFunctionTypes.h
@@ -56,120 +56,141 @@ public:
         m_vector.reserve(INDEX_NUM);
         size_t index = 0;
 
+        FunctionType* functionType;
         TypeVector* param;
         TypeVector* result;
 
         {
             // NONE
-            param = new TypeVector(0, 0);
-            result = new TypeVector(0, 0);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType = new FunctionType(0, 0, 0, 0);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32R
-            param = new TypeVector(1, 0);
-            result = new TypeVector(0, 0);
+            functionType = new FunctionType(1, 0, 0, 0);
+            param = functionType->initParam();
             param->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32_RI32
-            param = new TypeVector(1, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(1, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I32_RI32
-            param = new TypeVector(2, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(2, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I64I32_RI32
-            param = new TypeVector(3, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(3, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I64);
             param->setType(2, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I32I32_RI32
-            param = new TypeVector(3, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(3, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I32);
             param->setType(2, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I32I32I32_RI32
-            param = new TypeVector(4, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(4, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I32);
             param->setType(2, Value::Type::I32);
             param->setType(3, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I64I32I32_RI32
-            param = new TypeVector(4, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(4, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I64);
             param->setType(2, Value::Type::I32);
             param->setType(3, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I64I64I32_RI32
-            param = new TypeVector(4, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(4, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I64);
             param->setType(2, Value::Type::I64);
             param->setType(3, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I32I32I32I32_RI32
-            param = new TypeVector(5, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(5, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I32);
             param->setType(2, Value::Type::I32);
             param->setType(3, Value::Type::I32);
             param->setType(4, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I32I32I64I32_RI32
-            param = new TypeVector(5, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(5, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I32);
             param->setType(2, Value::Type::I32);
             param->setType(3, Value::Type::I64);
             param->setType(4, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I32I32I32I32I32_RI32
-            param = new TypeVector(6, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(6, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I32);
             param->setType(2, Value::Type::I32);
@@ -177,12 +198,14 @@ public:
             param->setType(4, Value::Type::I32);
             param->setType(5, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I32I32I32I32I64I64I32_RI32
-            param = new TypeVector(7, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(7, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I32);
             param->setType(2, Value::Type::I32);
@@ -191,12 +214,14 @@ public:
             param->setType(5, Value::Type::I64);
             param->setType(6, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32I32I32I32I32I64I64I32I32_RI32
-            param = new TypeVector(9, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(9, 0, 1, 0);
+            param = functionType->initParam();
+            result = functionType->initResult();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::I32);
             param->setType(2, Value::Type::I32);
@@ -207,59 +232,67 @@ public:
             param->setType(7, Value::Type::I32);
             param->setType(8, Value::Type::I32);
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // RI32
-            param = new TypeVector(0, 0);
-            result = new TypeVector(1, 0);
+            functionType = new FunctionType(0, 0, 1, 0);
+            result = functionType->initResult();
             result->setType(0, Value::Type::I32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I64
-            param = new TypeVector(1, 0);
-            result = new TypeVector(0, 0);
+            functionType = new FunctionType(1, 0, 0, 0);
+            param = functionType->initParam();
             param->setType(0, Value::Type::I64);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // F32
-            param = new TypeVector(1, 0);
-            result = new TypeVector(0, 0);
+            functionType = new FunctionType(1, 0, 0, 0);
+            param = functionType->initParam();
             param->setType(0, Value::Type::F32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // F64
-            param = new TypeVector(1, 0);
-            result = new TypeVector(0, 0);
+            functionType = new FunctionType(1, 0, 0, 0);
+            param = functionType->initParam();
             param->setType(0, Value::Type::F64);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // I32F32
-            param = new TypeVector(2, 0);
-            result = new TypeVector(0, 0);
+            functionType = new FunctionType(2, 0, 0, 0);
+            param = functionType->initParam();
             param->setType(0, Value::Type::I32);
             param->setType(1, Value::Type::F32);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // F64F64
-            param = new TypeVector(2, 0);
-            result = new TypeVector(0, 0);
+            functionType = new FunctionType(2, 0, 0, 0);
+            param = functionType->initParam();
             param->setType(0, Value::Type::F64);
             param->setType(1, Value::Type::F64);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
         {
             // INVALID
-            param = new TypeVector(1, 0);
-            result = new TypeVector(0, 0);
+            functionType = new FunctionType(1, 0, 0, 0);
+            param = functionType->initParam();
             // Temporary types cannot be used as params
             param->setType(0, Value::Type::Void);
-            m_vector[index++] = new FunctionType(param, result);
+            functionType->initDone();
+            m_vector[index++] = functionType;
         }
 
         ASSERT(index == INDEX_NUM);

--- a/src/runtime/ObjectType.cpp
+++ b/src/runtime/ObjectType.cpp
@@ -47,27 +47,27 @@ bool FunctionType::equals(const FunctionType* other, bool isSubType) const
         return false;
     }
 
-    size_t typesSize = m_paramTypes->size();
-    size_t refsSize = m_paramTypes->refs().size();
+    size_t typesSize = m_paramTypes.size();
+    size_t refsSize = m_paramTypes.refs().size();
     if (typesSize != other->param().size()
         || refsSize != other->param().refs().size()) {
         return false;
     }
 
-    if (memcmp(m_paramTypes->types().data(), other->param().types().data(), sizeof(Value::Type) * typesSize)
-        || memcmp(m_paramTypes->refs().data(), other->param().refs().data(), sizeof(CompositeType*) * refsSize)) {
+    if (memcmp(m_paramTypes.types().data(), other->param().types().data(), sizeof(Value::Type) * typesSize)
+        || memcmp(m_paramTypes.refs().data(), other->param().refs().data(), sizeof(CompositeType*) * refsSize)) {
         return false;
     }
 
-    typesSize = m_resultTypes->size();
-    refsSize = m_resultTypes->refs().size();
+    typesSize = m_resultTypes.size();
+    refsSize = m_resultTypes.refs().size();
     if (typesSize != other->result().size()
         || refsSize != other->result().refs().size()) {
         return false;
     }
 
-    if (memcmp(m_resultTypes->types().data(), other->result().types().data(), sizeof(Value::Type) * typesSize)
-        || memcmp(m_resultTypes->refs().data(), other->result().refs().data(), sizeof(CompositeType*) * refsSize)) {
+    if (memcmp(m_resultTypes.types().data(), other->result().types().data(), sizeof(Value::Type) * typesSize)
+        || memcmp(m_resultTypes.refs().data(), other->result().refs().data(), sizeof(CompositeType*) * refsSize)) {
         return false;
     }
 

--- a/src/runtime/ObjectType.h
+++ b/src/runtime/ObjectType.h
@@ -134,44 +134,60 @@ class FunctionType : public CompositeType {
 public:
     friend class TypeStore;
 
-    FunctionType(TypeVector* param,
-                 TypeVector* result,
+    FunctionType(size_t paramTypesCount, size_t paramRefsCount,
+                 size_t resultTypesCount, size_t resultRefsCount,
                  bool isFinal,
                  const CompositeType** subTypeList)
         : CompositeType(ObjectType::FunctionKind, isFinal, subTypeList)
-        , m_paramTypes(param)
-        , m_resultTypes(result)
-        , m_paramStackSize(computeStackSize(*m_paramTypes))
-        , m_resultStackSize(computeStackSize(*m_resultTypes))
+        , m_paramTypes(paramTypesCount, paramRefsCount)
+        , m_resultTypes(resultTypesCount, resultRefsCount)
+        , m_paramStackSize(0)
+        , m_resultStackSize(0)
     {
     }
 
-    FunctionType(TypeVector* param,
-                 TypeVector* result)
+    FunctionType(size_t paramTypesCount, size_t paramRefsCount,
+                 size_t resultTypesCount, size_t resultRefsCount)
         : CompositeType(ObjectType::FunctionKind, false, nullptr)
-        , m_paramTypes(param)
-        , m_resultTypes(result)
-        , m_paramStackSize(computeStackSize(*m_paramTypes))
-        , m_resultStackSize(computeStackSize(*m_resultTypes))
+        , m_paramTypes(paramTypesCount, paramRefsCount)
+        , m_resultTypes(resultTypesCount, resultRefsCount)
+        , m_paramStackSize(0)
+        , m_resultStackSize(0)
     {
+    }
+
+    FunctionType(Value::Type type)
+        : CompositeType(ObjectType::FunctionKind, false, nullptr)
+        , m_paramTypes(0, 0)
+        , m_resultTypes(1, 0)
+        , m_paramStackSize(0)
+        , m_resultStackSize(valueStackAllocatedSize(type))
+    {
+        m_resultTypes.setType(0, type);
     }
 
     ~FunctionType()
     {
-        delete m_paramTypes;
-        delete m_resultTypes;
     }
 
-    const TypeVector& param() const { return *m_paramTypes; }
-    const TypeVector& result() const { return *m_resultTypes; }
+    const TypeVector& param() const { return m_paramTypes; }
+    const TypeVector& result() const { return m_resultTypes; }
     size_t paramStackSize() const { return m_paramStackSize; }
     size_t resultStackSize() const { return m_resultStackSize; }
+    TypeVector* initParam() { return &m_paramTypes; }
+    TypeVector* initResult() { return &m_resultTypes; }
+
+    void initDone()
+    {
+        m_paramStackSize = computeStackSize(m_paramTypes);
+        m_resultStackSize = computeStackSize(m_resultTypes);
+    }
 
     bool equals(const FunctionType* other, bool isSubType = false) const;
 
 private:
-    TypeVector* m_paramTypes;
-    TypeVector* m_resultTypes;
+    TypeVector m_paramTypes;
+    TypeVector m_resultTypes;
     size_t m_paramStackSize;
     size_t m_resultStackSize;
 

--- a/src/runtime/Store.h
+++ b/src/runtime/Store.h
@@ -97,8 +97,6 @@ private:
     Vector<Instance*> m_instances;
     Vector<Extern*> m_externs;
 
-    // default FunctionTypes used for initialization of Data, Element and Global
-    static FunctionType* g_defaultFunctionTypes[Value::Type::NUM];
     std::mutex m_waiterListLock;
     std::vector<Waiter*> m_waiterList;
 };

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -89,6 +89,50 @@ size_t stackAllocatedSize()
     }
 }
 
+// Notes:
+// - The any, extern, and eq groups represent the same objects in Walrus.
+//   WebAssembly allows defining internal (so called host) types, and
+//   these types might need special handling, but in Walrus, the internal
+//   types follows the same rules as WebAssembly defined types. This
+//   model simplifies operations, improves performance, and has no
+//   disadvantages. For example, any.convert_extern and extern.convert_any
+//   are no operations.
+
+// - The order of references are important. They are grouped together to
+//   improve type comparison speed.
+//   See: isRefType / isTaggedRefType / isNullableRefType.
+
+// - NoAnyRef is (ref none), but this name follows the other No... naming conventions
+
+#define FOR_EACH_VALUE_TYPE(F) \
+    F(I32)                     \
+    F(I64)                     \
+    F(F32)                     \
+    F(F64)                     \
+    F(V128)                    \
+    F(ExternRef)               \
+    F(NoExternRef)             \
+    F(AnyRef)                  \
+    F(NoAnyRef)                \
+    F(EqRef)                   \
+    F(I31Ref)                  \
+    F(StructRef)               \
+    F(ArrayRef)                \
+    F(FuncRef)                 \
+    F(NoFuncRef)               \
+    F(DefinedRef)              \
+    F(NullExternRef)           \
+    F(NullNoExternRef)         \
+    F(NullAnyRef)              \
+    F(NullNoAnyRef)            \
+    F(NullEqRef)               \
+    F(NullI31Ref)              \
+    F(NullStructRef)           \
+    F(NullArrayRef)            \
+    F(NullFuncRef)             \
+    F(NullNoFuncRef)           \
+    F(NullDefinedRef)
+
 class Value {
     friend class JITFieldAccessor;
 
@@ -104,48 +148,13 @@ public:
 
     // Some tpyes (such as Void, GenericRef) are pseudo types, not used by WebAssembly
     enum Type : uint8_t {
-        I32,
-        I64,
-        F32,
-        F64,
-        V128,
+#define DEFINE_VALUE_TYPE(name) name,
+        FOR_EACH_VALUE_TYPE(DEFINE_VALUE_TYPE)
+#undef DEFINE_VALUE_TYPE
+
         // I8/I16 packed types are only used by structs/arrays
         I8,
         I16,
-        // The any, extern, and eq groups represent the same objects in Walrus.
-        // WebAssembly allows defining internal (so called host) types, and
-        // these types might need special handling, but in Walrus, the internal
-        // types follows the same rules as WebAssembly defined types. This
-        // model simplifies operations, improves performance, and has no
-        // disadvantages. For example, any.convert_extern and extern.convert_any
-        // are no operations.
-
-        // The order of references are important. They are grouped together to
-        // improve type comparison speed.
-        // See: isRefType / isTaggedRefType / isNullableRefType.
-        ExternRef,
-        NoExternRef,
-        AnyRef,
-        // NoAnyRef is (ref none), but this name follows the other No... naming conventions
-        NoAnyRef,
-        EqRef,
-        I31Ref,
-        StructRef,
-        ArrayRef,
-        FuncRef,
-        NoFuncRef,
-        DefinedRef,
-        NullExternRef,
-        NullNoExternRef,
-        NullAnyRef,
-        NullNoAnyRef,
-        NullEqRef,
-        NullI31Ref,
-        NullStructRef,
-        NullArrayRef,
-        NullFuncRef,
-        NullNoFuncRef,
-        NullDefinedRef,
         Void, // Void type should be located at end
         NUM = Void
     };


### PR DESCRIPTION
- FunctionType directly contains its params/result
- Short type vectors use inline buffer, instead of allocating memory

This patch was reworked several times. It removes some extra pointers, and small allocations. Default function types does not require any allocation anymore.
