### PR TITLE
Implement 64 bit memory support in the interpreter

### DIFF
--- a/src/Walrus.h
+++ b/src/Walrus.h
@@ -399,7 +399,7 @@ if (f.type == Type::B) { puts("failed in msvc."); }
 
 #ifndef STACK_LIMIT_FROM_BASE
 // FIXME reduce stack limit to 3MB
-#define STACK_LIMIT_FROM_BASE (1024 * 1024 * 5) // 5MB
+#define STACK_LIMIT_FROM_BASE (1024 * 1024 * 7) // 7MB
 #endif
 
 #include "util/Optional.h"

--- a/src/api/wasm.cpp
+++ b/src/api/wasm.cpp
@@ -1146,13 +1146,13 @@ bool wasm_table_grow(wasm_table_t* table, wasm_table_size_t delta, wasm_ref_t* i
 // Memory Instances
 own wasm_memory_t* wasm_memory_new(wasm_store_t* store, const wasm_memorytype_t* mt)
 {
-    Memory* mem = Memory::createMemory(store->get(), mt->limits.min * MEMORY_PAGE_SIZE, mt->limits.max * MEMORY_PAGE_SIZE, false);
+    Memory* mem = Memory::createMemory(store->get(), mt->limits.min * MEMORY_PAGE_SIZE, mt->limits.max * MEMORY_PAGE_SIZE, false, false);
     return new wasm_memory_t(mem, mt->clone());
 }
 
 own wasm_memory_t* wasm_shared_memory_new(wasm_store_t* store, const wasm_memorytype_t* mt)
 {
-    Memory* mem = Memory::createMemory(store->get(), mt->limits.min * MEMORY_PAGE_SIZE, mt->limits.max * MEMORY_PAGE_SIZE, true);
+    Memory* mem = Memory::createMemory(store->get(), mt->limits.min * MEMORY_PAGE_SIZE, mt->limits.max * MEMORY_PAGE_SIZE, true, false);
     return new wasm_memory_t(mem, mt->clone());
 }
 

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -83,9 +83,13 @@ class FunctionType;
     F(Const64)                  \
     F(Const128)                 \
     F(Load32)                   \
+    F(Load32M64)                \
     F(Load64)                   \
+    F(Load64M64)                \
     F(Store32)                  \
+    F(Store32M64)               \
     F(Store64)                  \
+    F(Store64M64)               \
     F(RefAsNonNull)             \
     F(RefCastGeneric)           \
     F(RefCastDefined)           \
@@ -222,6 +226,117 @@ class FunctionType;
     F(I64AtomicRmw8CmpxchgUMemIdx)     \
     F(I64AtomicRmw16CmpxchgUMemIdx)    \
     F(I64AtomicRmw32CmpxchgUMemIdx)
+
+#define FOR_EACH_BYTECODE_MEMIDX_M64_OP(F) \
+    F(I32LoadMemIdxM64)                    \
+    F(I64LoadMemIdxM64)                    \
+    F(F32LoadMemIdxM64)                    \
+    F(F64LoadMemIdxM64)                    \
+    F(I32Load8SMemIdxM64)                  \
+    F(I32Load8UMemIdxM64)                  \
+    F(I32Load16SMemIdxM64)                 \
+    F(I32Load16UMemIdxM64)                 \
+    F(I64Load8SMemIdxM64)                  \
+    F(I64Load8UMemIdxM64)                  \
+    F(I64Load16UMemIdxM64)                 \
+    F(I64Load16SMemIdxM64)                 \
+    F(I64Load32SMemIdxM64)                 \
+    F(I64Load32UMemIdxM64)                 \
+    F(I32StoreMemIdxM64)                   \
+    F(I64StoreMemIdxM64)                   \
+    F(I32Store8MemIdxM64)                  \
+    F(I32Store16MemIdxM64)                 \
+    F(I64Store8MemIdxM64)                  \
+    F(I64Store16MemIdxM64)                 \
+    F(I64Store32MemIdxM64)                 \
+    F(V128LoadMemIdxM64)                   \
+    F(V128StoreMemIdxM64)                  \
+    F(V128Load8X8SMemIdxM64)               \
+    F(V128Load8X8UMemIdxM64)               \
+    F(V128Load16X4SMemIdxM64)              \
+    F(V128Load16X4UMemIdxM64)              \
+    F(V128Load32X2SMemIdxM64)              \
+    F(V128Load32X2UMemIdxM64)              \
+    F(V128Load8SplatMemIdxM64)             \
+    F(V128Load16SplatMemIdxM64)            \
+    F(V128Load32SplatMemIdxM64)            \
+    F(V128Load64SplatMemIdxM64)            \
+    F(V128Load64LaneMemIdxM64)             \
+    F(V128Load32LaneMemIdxM64)             \
+    F(V128Load16LaneMemIdxM64)             \
+    F(V128Load8LaneMemIdxM64)              \
+    F(V128Store8LaneMemIdxM64)             \
+    F(V128Store16LaneMemIdxM64)            \
+    F(V128Store32LaneMemIdxM64)            \
+    F(V128Store64LaneMemIdxM64)            \
+    F(V128Load32ZeroMemIdxM64)             \
+    F(V128Load64ZeroMemIdxM64)             \
+    F(MemoryAtomicNotifyMemIdxM64)         \
+    F(MemoryAtomicWait32MemIdxM64)         \
+    F(MemoryAtomicWait64MemIdxM64)         \
+    F(I32AtomicLoadMemIdxM64)              \
+    F(I64AtomicLoadMemIdxM64)              \
+    F(I32AtomicLoad8UMemIdxM64)            \
+    F(I32AtomicLoad16UMemIdxM64)           \
+    F(I64AtomicLoad8UMemIdxM64)            \
+    F(I64AtomicLoad16UMemIdxM64)           \
+    F(I64AtomicLoad32UMemIdxM64)           \
+    F(I32AtomicStoreMemIdxM64)             \
+    F(I64AtomicStoreMemIdxM64)             \
+    F(I32AtomicStore8MemIdxM64)            \
+    F(I32AtomicStore16MemIdxM64)           \
+    F(I64AtomicStore8MemIdxM64)            \
+    F(I64AtomicStore16MemIdxM64)           \
+    F(I64AtomicStore32MemIdxM64)           \
+    F(I32AtomicRmwAddMemIdxM64)            \
+    F(I64AtomicRmwAddMemIdxM64)            \
+    F(I32AtomicRmw8AddUMemIdxM64)          \
+    F(I32AtomicRmw16AddUMemIdxM64)         \
+    F(I64AtomicRmw8AddUMemIdxM64)          \
+    F(I64AtomicRmw16AddUMemIdxM64)         \
+    F(I64AtomicRmw32AddUMemIdxM64)         \
+    F(I32AtomicRmwSubMemIdxM64)            \
+    F(I64AtomicRmwSubMemIdxM64)            \
+    F(I32AtomicRmw8SubUMemIdxM64)          \
+    F(I32AtomicRmw16SubUMemIdxM64)         \
+    F(I64AtomicRmw8SubUMemIdxM64)          \
+    F(I64AtomicRmw16SubUMemIdxM64)         \
+    F(I64AtomicRmw32SubUMemIdxM64)         \
+    F(I32AtomicRmwAndMemIdxM64)            \
+    F(I64AtomicRmwAndMemIdxM64)            \
+    F(I32AtomicRmw8AndUMemIdxM64)          \
+    F(I32AtomicRmw16AndUMemIdxM64)         \
+    F(I64AtomicRmw8AndUMemIdxM64)          \
+    F(I64AtomicRmw16AndUMemIdxM64)         \
+    F(I64AtomicRmw32AndUMemIdxM64)         \
+    F(I32AtomicRmwOrMemIdxM64)             \
+    F(I64AtomicRmwOrMemIdxM64)             \
+    F(I32AtomicRmw8OrUMemIdxM64)           \
+    F(I32AtomicRmw16OrUMemIdxM64)          \
+    F(I64AtomicRmw8OrUMemIdxM64)           \
+    F(I64AtomicRmw16OrUMemIdxM64)          \
+    F(I64AtomicRmw32OrUMemIdxM64)          \
+    F(I32AtomicRmwXorMemIdxM64)            \
+    F(I64AtomicRmwXorMemIdxM64)            \
+    F(I32AtomicRmw8XorUMemIdxM64)          \
+    F(I32AtomicRmw16XorUMemIdxM64)         \
+    F(I64AtomicRmw8XorUMemIdxM64)          \
+    F(I64AtomicRmw16XorUMemIdxM64)         \
+    F(I64AtomicRmw32XorUMemIdxM64)         \
+    F(I32AtomicRmwXchgMemIdxM64)           \
+    F(I64AtomicRmwXchgMemIdxM64)           \
+    F(I32AtomicRmw8XchgUMemIdxM64)         \
+    F(I32AtomicRmw16XchgUMemIdxM64)        \
+    F(I64AtomicRmw8XchgUMemIdxM64)         \
+    F(I64AtomicRmw16XchgUMemIdxM64)        \
+    F(I64AtomicRmw32XchgUMemIdxM64)        \
+    F(I32AtomicRmwCmpxchgMemIdxM64)        \
+    F(I64AtomicRmwCmpxchgMemIdxM64)        \
+    F(I32AtomicRmw8CmpxchgUMemIdxM64)      \
+    F(I32AtomicRmw16CmpxchgUMemIdxM64)     \
+    F(I64AtomicRmw8CmpxchgUMemIdxM64)      \
+    F(I64AtomicRmw16CmpxchgUMemIdxM64)     \
+    F(I64AtomicRmw32CmpxchgUMemIdxM64)
 
 #define FOR_EACH_BYTECODE_BINARY_OP(F)            \
     F(I32Add, add, int32_t, int32_t)              \
@@ -382,13 +497,36 @@ class FunctionType;
     F(I64Load32U, uint32_t, int64_t)     \
     F(V128Load, Vec128, Vec128)
 
+#define FOR_EACH_BYTECODE_LOAD_INT_M64_OP(F) \
+    F(I32LoadM64, int32_t, int32_t)          \
+    F(I32Load8SM64, int8_t, int32_t)         \
+    F(I32Load8UM64, uint8_t, int32_t)        \
+    F(I32Load16SM64, int16_t, int32_t)       \
+    F(I32Load16UM64, uint16_t, int32_t)      \
+    F(I64LoadM64, int64_t, int64_t)          \
+    F(I64Load8SM64, int8_t, int64_t)         \
+    F(I64Load8UM64, uint8_t, int64_t)        \
+    F(I64Load16SM64, int16_t, int64_t)       \
+    F(I64Load16UM64, uint16_t, int64_t)      \
+    F(I64Load32SM64, int32_t, int64_t)       \
+    F(I64Load32UM64, uint32_t, int64_t)      \
+    F(V128LoadM64, Vec128, Vec128)
+
 #define FOR_EACH_BYTECODE_LOAD_FLOAT_OP(F) \
     F(F32Load, float, float)               \
     F(F64Load, double, double)
 
+#define FOR_EACH_BYTECODE_LOAD_FLOAT_M64_OP(F) \
+    F(F32LoadM64, float, float)                \
+    F(F64LoadM64, double, double)
+
 #define FOR_EACH_BYTECODE_LOAD_OP(F) \
     FOR_EACH_BYTECODE_LOAD_INT_OP(F) \
     FOR_EACH_BYTECODE_LOAD_FLOAT_OP(F)
+
+#define FOR_EACH_BYTECODE_LOAD_M64_OP(F) \
+    FOR_EACH_BYTECODE_LOAD_INT_M64_OP(F) \
+    FOR_EACH_BYTECODE_LOAD_FLOAT_M64_OP(F)
 
 #define FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_OP(F) \
     F(I32LoadMemIdx, int32_t, int32_t)          \
@@ -405,13 +543,34 @@ class FunctionType;
     F(I64Load32UMemIdx, uint32_t, int64_t)      \
     F(V128LoadMemIdx, Vec128, Vec128)
 
+#define FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_M64_OP(F) \
+    F(I32LoadMemIdxM64, int32_t, int32_t)           \
+    F(I32Load8SMemIdxM64, int8_t, int32_t)          \
+    F(I32Load8UMemIdxM64, uint8_t, int32_t)         \
+    F(I32Load16SMemIdxM64, int16_t, int32_t)        \
+    F(I32Load16UMemIdxM64, uint16_t, int32_t)       \
+    F(I64LoadMemIdxM64, int64_t, int64_t)           \
+    F(I64Load8SMemIdxM64, int8_t, int64_t)          \
+    F(I64Load8UMemIdxM64, uint8_t, int64_t)         \
+    F(I64Load16SMemIdxM64, int16_t, int64_t)        \
+    F(I64Load16UMemIdxM64, uint16_t, int64_t)       \
+    F(I64Load32SMemIdxM64, int32_t, int64_t)        \
+    F(I64Load32UMemIdxM64, uint32_t, int64_t)       \
+    F(V128LoadMemIdxM64, Vec128, Vec128)
+
 #define FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_OP(F) \
     F(F32LoadMemIdx, float, float)                \
     F(F64LoadMemIdx, double, double)
 
-#define FOR_EACH_BYTECODE_LOAD_MEMIDX_OP(F) \
-    FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_OP(F) \
-    FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_OP(F)
+#define FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_M64_OP(F) \
+    F(F32LoadMemIdxM64, float, float)                 \
+    F(F64LoadMemIdxM64, double, double)
+
+#define FOR_EACH_BYTECODE_LOAD_MEMIDX_OP(F)     \
+    FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_OP(F)     \
+    FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_M64_OP(F) \
+    FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_OP(F)   \
+    FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_M64_OP(F)
 
 #define FOR_EACH_BYTECODE_STORE_32_OP(F) \
     F(I32Store, int32_t, int32_t)        \
@@ -419,15 +578,31 @@ class FunctionType;
     F(I32Store8, int32_t, int8_t)        \
     F(V128Store, Vec128, Vec128)
 
+#define FOR_EACH_BYTECODE_STORE_32_M64_OP(F) \
+    F(I32StoreM64, int32_t, int32_t)         \
+    F(I32Store16M64, int32_t, int16_t)       \
+    F(I32Store8M64, int32_t, int8_t)         \
+    F(V128StoreM64, Vec128, Vec128)
+
 #define FOR_EACH_BYTECODE_STORE_64_OP(F) \
     F(I64Store, int64_t, int64_t)        \
     F(I64Store32, int64_t, int32_t)      \
     F(I64Store16, int64_t, int16_t)      \
     F(I64Store8, int64_t, int8_t)
 
+#define FOR_EACH_BYTECODE_STORE_64_M64_OP(F) \
+    F(I64StoreM64, int64_t, int64_t)         \
+    F(I64Store32M64, int64_t, int32_t)       \
+    F(I64Store16M64, int64_t, int16_t)       \
+    F(I64Store8M64, int64_t, int8_t)
+
 #define FOR_EACH_BYTECODE_STORE_OP(F) \
     FOR_EACH_BYTECODE_STORE_32_OP(F)  \
     FOR_EACH_BYTECODE_STORE_64_OP(F)
+
+#define FOR_EACH_BYTECODE_STORE_M64_OP(F) \
+    FOR_EACH_BYTECODE_STORE_32_M64_OP(F)  \
+    FOR_EACH_BYTECODE_STORE_64_M64_OP(F)
 
 #define FOR_EACH_BYTECODE_STORE_MEMIDX_32_OP(F) \
     F(I32StoreMemIdx, int32_t, int32_t)         \
@@ -435,15 +610,29 @@ class FunctionType;
     F(I32Store8MemIdx, int32_t, int8_t)         \
     F(V128StoreMemIdx, Vec128, Vec128)
 
+#define FOR_EACH_BYTECODE_STORE_MEMIDX_32_M64_OP(F) \
+    F(I32StoreMemIdxM64, int32_t, int32_t)          \
+    F(I32Store16MemIdxM64, int32_t, int16_t)        \
+    F(I32Store8MemIdxM64, int32_t, int8_t)          \
+    F(V128StoreMemIdxM64, Vec128, Vec128)
+
 #define FOR_EACH_BYTECODE_STORE_MEMIDX_64_OP(F) \
     F(I64StoreMemIdx, int64_t, int64_t)         \
     F(I64Store32MemIdx, int64_t, int32_t)       \
     F(I64Store16MemIdx, int64_t, int16_t)       \
     F(I64Store8MemIdx, int64_t, int8_t)
 
-#define FOR_EACH_BYTECODE_STORE_MEMIDX_OP(F) \
-    FOR_EACH_BYTECODE_STORE_MEMIDX_32_OP(F)  \
-    FOR_EACH_BYTECODE_STORE_MEMIDX_64_OP(F)
+#define FOR_EACH_BYTECODE_STORE_MEMIDX_64_M64_OP(F) \
+    F(I64StoreMemIdxM64, int64_t, int64_t)          \
+    F(I64Store32MemIdxM64, int64_t, int32_t)        \
+    F(I64Store16MemIdxM64, int64_t, int16_t)        \
+    F(I64Store8MemIdxM64, int64_t, int8_t)
+
+#define FOR_EACH_BYTECODE_STORE_MEMIDX_OP(F)    \
+    FOR_EACH_BYTECODE_STORE_MEMIDX_32_OP(F)     \
+    FOR_EACH_BYTECODE_STORE_MEMIDX_32_M64_OP(F) \
+    FOR_EACH_BYTECODE_STORE_MEMIDX_64_OP(F)     \
+    FOR_EACH_BYTECODE_STORE_MEMIDX_64_M64_OP(F)
 
 #define FOR_EACH_BYTECODE_SIMD_BINARY_OP(F)                       \
     F(I8X16Add, add, uint8_t, uint8_t)                            \
@@ -660,11 +849,23 @@ class FunctionType;
     F(V128Load32Splat, uint32_t)                \
     F(V128Load64Splat, uint64_t)
 
+#define FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_M64_OP(F) \
+    F(V128Load8SplatM64, uint8_t)                   \
+    F(V128Load16SplatM64, uint16_t)                 \
+    F(V128Load32SplatM64, uint32_t)                 \
+    F(V128Load64SplatM64, uint64_t)
+
 #define FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_MEMIDX_OP(F) \
     F(V128Load8SplatMemIdx, uint8_t)                   \
     F(V128Load16SplatMemIdx, uint16_t)                 \
     F(V128Load32SplatMemIdx, uint32_t)                 \
     F(V128Load64SplatMemIdx, uint64_t)
+
+#define FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_MEMIDX_M64_OP(F) \
+    F(V128Load8SplatMemIdxM64, uint8_t)                    \
+    F(V128Load16SplatMemIdxM64, uint16_t)                  \
+    F(V128Load32SplatMemIdxM64, uint32_t)                  \
+    F(V128Load64SplatMemIdxM64, uint64_t)
 
 #define FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_OP(F) \
     F(V128Load8X8S, S8x8, int16_t)               \
@@ -674,6 +875,14 @@ class FunctionType;
     F(V128Load32X2S, S32x2, int64_t)             \
     F(V128Load32X2U, U32x2, uint64_t)
 
+#define FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_M64_OP(F) \
+    F(V128Load8X8SM64, S8x8, int16_t)                \
+    F(V128Load8X8UM64, U8x8, uint16_t)               \
+    F(V128Load16X4SM64, S16x4, int32_t)              \
+    F(V128Load16X4UM64, U16x4, uint32_t)             \
+    F(V128Load32X2SM64, S32x2, int64_t)              \
+    F(V128Load32X2UM64, U32x2, uint64_t)
+
 #define FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_MEMIDX_OP(F) \
     F(V128Load8X8SMemIdx, S8x8, int16_t)                \
     F(V128Load8X8UMemIdx, U8x8, uint16_t)               \
@@ -682,11 +891,25 @@ class FunctionType;
     F(V128Load32X2SMemIdx, S32x2, int64_t)              \
     F(V128Load32X2UMemIdx, U32x2, uint64_t)
 
+#define FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_MEMIDX_M64_OP(F) \
+    F(V128Load8X8SMemIdxM64, S8x8, int16_t)                 \
+    F(V128Load8X8UMemIdxM64, U8x8, uint16_t)                \
+    F(V128Load16X4SMemIdxM64, S16x4, int32_t)               \
+    F(V128Load16X4UMemIdxM64, U16x4, uint32_t)              \
+    F(V128Load32X2SMemIdxM64, S32x2, int64_t)               \
+    F(V128Load32X2UMemIdxM64, U32x2, uint64_t)
+
 #define FOR_EACH_BYTECODE_SIMD_LOAD_LANE_OP(F) \
     F(V128Load8Lane, uint8_t)                  \
     F(V128Load16Lane, uint16_t)                \
     F(V128Load32Lane, uint32_t)                \
     F(V128Load64Lane, uint64_t)
+
+#define FOR_EACH_BYTECODE_SIMD_LOAD_LANE_M64_OP(F) \
+    F(V128Load8LaneM64, uint8_t)                   \
+    F(V128Load16LaneM64, uint16_t)                 \
+    F(V128Load32LaneM64, uint32_t)                 \
+    F(V128Load64LaneM64, uint64_t)
 
 #define FOR_EACH_BYTECODE_SIMD_LOAD_LANE_MEMIDX_OP(F) \
     F(V128Load8LaneMemIdx, uint8_t)                   \
@@ -694,17 +917,35 @@ class FunctionType;
     F(V128Load32LaneMemIdx, uint32_t)                 \
     F(V128Load64LaneMemIdx, uint64_t)
 
+#define FOR_EACH_BYTECODE_SIMD_LOAD_LANE_MEMIDX_M64_OP(F) \
+    F(V128Load8LaneMemIdxM64, uint8_t)                    \
+    F(V128Load16LaneMemIdxM64, uint16_t)                  \
+    F(V128Load32LaneMemIdxM64, uint32_t)                  \
+    F(V128Load64LaneMemIdxM64, uint64_t)
+
 #define FOR_EACH_BYTECODE_SIMD_STORE_LANE_OP(F) \
     F(V128Store8Lane, uint8_t)                  \
     F(V128Store16Lane, uint16_t)                \
     F(V128Store32Lane, uint32_t)                \
     F(V128Store64Lane, uint64_t)
 
+#define FOR_EACH_BYTECODE_SIMD_STORE_LANE_M64_OP(F) \
+    F(V128Store8LaneM64, uint8_t)                   \
+    F(V128Store16LaneM64, uint16_t)                 \
+    F(V128Store32LaneM64, uint32_t)                 \
+    F(V128Store64LaneM64, uint64_t)
+
 #define FOR_EACH_BYTECODE_SIMD_STORE_LANE_MEMIDX_OP(F) \
     F(V128Store8LaneMemIdx, uint8_t)                   \
     F(V128Store16LaneMemIdx, uint16_t)                 \
     F(V128Store32LaneMemIdx, uint32_t)                 \
     F(V128Store64LaneMemIdx, uint64_t)
+
+#define FOR_EACH_BYTECODE_SIMD_STORE_LANE_MEMIDX_M64_OP(F) \
+    F(V128Store8LaneMemIdxM64, uint8_t)                    \
+    F(V128Store16LaneMemIdxM64, uint16_t)                  \
+    F(V128Store32LaneMemIdxM64, uint32_t)                  \
+    F(V128Store64LaneMemIdxM64, uint64_t)
 
 #define FOR_EACH_BYTECODE_SIMD_EXTRACT_LANE_OP(F) \
     F(I8X16ExtractLaneS, int8_t, int32_t)         \
@@ -730,9 +971,17 @@ class FunctionType;
     F(V128Load64Zero)                    \
     F(I8X16Shuffle)
 
+#define FOR_EACH_BYTECODE_SIMD_ETC_M64_OP(F) \
+    F(V128Load32ZeroM64)                     \
+    F(V128Load64ZeroM64)
+
 #define FOR_EACH_BYTECODE_SIMD_ETC_MEMIDX_OP(F) \
     F(V128Load32ZeroMemIdx)                     \
     F(V128Load64ZeroMemIdx)
+
+#define FOR_EACH_BYTECODE_SIMD_ETC_MEMIDX_M64_OP(F) \
+    F(V128Load32ZeroMemIdxM64)                      \
+    F(V128Load64ZeroMemIdxM64)
 
 // Extended Features
 #define FOR_EACH_BYTECODE_ATOMIC_LOAD_OP(F) \
@@ -744,6 +993,15 @@ class FunctionType;
     F(I64AtomicLoad16U, uint16_t, uint64_t) \
     F(I64AtomicLoad32U, uint32_t, uint64_t)
 
+#define FOR_EACH_BYTECODE_ATOMIC_LOAD_M64_OP(F) \
+    F(I32AtomicLoadM64, uint32_t, uint32_t)     \
+    F(I64AtomicLoadM64, uint64_t, uint64_t)     \
+    F(I32AtomicLoad8UM64, uint8_t, uint32_t)    \
+    F(I32AtomicLoad16UM64, uint16_t, uint32_t)  \
+    F(I64AtomicLoad8UM64, uint8_t, uint64_t)    \
+    F(I64AtomicLoad16UM64, uint16_t, uint64_t)  \
+    F(I64AtomicLoad32UM64, uint32_t, uint64_t)
+
 #define FOR_EACH_BYTECODE_ATOMIC_LOAD_MEMIDX_OP(F) \
     F(I32AtomicLoadMemIdx, uint32_t, uint32_t)     \
     F(I64AtomicLoadMemIdx, uint64_t, uint64_t)     \
@@ -753,10 +1011,24 @@ class FunctionType;
     F(I64AtomicLoad16UMemIdx, uint16_t, uint64_t)  \
     F(I64AtomicLoad32UMemIdx, uint32_t, uint64_t)
 
+#define FOR_EACH_BYTECODE_ATOMIC_LOAD_MEMIDX_M64_OP(F) \
+    F(I32AtomicLoadMemIdxM64, uint32_t, uint32_t)      \
+    F(I64AtomicLoadMemIdxM64, uint64_t, uint64_t)      \
+    F(I32AtomicLoad8UMemIdxM64, uint8_t, uint32_t)     \
+    F(I32AtomicLoad16UMemIdxM64, uint16_t, uint32_t)   \
+    F(I64AtomicLoad8UMemIdxM64, uint8_t, uint64_t)     \
+    F(I64AtomicLoad16UMemIdxM64, uint16_t, uint64_t)   \
+    F(I64AtomicLoad32UMemIdxM64, uint32_t, uint64_t)
+
 #define FOR_EACH_BYTECODE_ATOMIC_STORE_32_OP(F) \
     F(I32AtomicStore, uint32_t, uint32_t)       \
     F(I32AtomicStore8, uint32_t, uint8_t)       \
     F(I32AtomicStore16, uint32_t, uint16_t)
+
+#define FOR_EACH_BYTECODE_ATOMIC_STORE_32_M64_OP(F) \
+    F(I32AtomicStoreM64, uint32_t, uint32_t)        \
+    F(I32AtomicStore8M64, uint32_t, uint8_t)        \
+    F(I32AtomicStore16M64, uint32_t, uint16_t)
 
 #define FOR_EACH_BYTECODE_ATOMIC_STORE_64_OP(F) \
     F(I64AtomicStore, uint64_t, uint64_t)       \
@@ -764,14 +1036,29 @@ class FunctionType;
     F(I64AtomicStore16, uint64_t, uint16_t)     \
     F(I64AtomicStore32, uint64_t, uint32_t)
 
+#define FOR_EACH_BYTECODE_ATOMIC_STORE_64_M64_OP(F) \
+    F(I64AtomicStoreM64, uint64_t, uint64_t)        \
+    F(I64AtomicStore8M64, uint64_t, uint8_t)        \
+    F(I64AtomicStore16M64, uint64_t, uint16_t)      \
+    F(I64AtomicStore32M64, uint64_t, uint32_t)
+
 #define FOR_EACH_BYTECODE_ATOMIC_STORE_OP(F) \
     FOR_EACH_BYTECODE_ATOMIC_STORE_32_OP(F)  \
     FOR_EACH_BYTECODE_ATOMIC_STORE_64_OP(F)
+
+#define FOR_EACH_BYTECODE_ATOMIC_STORE_M64_OP(F) \
+    FOR_EACH_BYTECODE_ATOMIC_STORE_32_M64_OP(F)  \
+    FOR_EACH_BYTECODE_ATOMIC_STORE_64_M64_OP(F)
 
 #define FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_OP(F) \
     F(I32AtomicStoreMemIdx, uint32_t, uint32_t)        \
     F(I32AtomicStore8MemIdx, uint32_t, uint8_t)        \
     F(I32AtomicStore16MemIdx, uint32_t, uint16_t)
+
+#define FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_M64_OP(F) \
+    F(I32AtomicStoreMemIdxM64, uint32_t, uint32_t)         \
+    F(I32AtomicStore8MemIdxM64, uint32_t, uint8_t)         \
+    F(I32AtomicStore16MemIdxM64, uint32_t, uint16_t)
 
 #define FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_OP(F) \
     F(I64AtomicStoreMemIdx, uint64_t, uint64_t)        \
@@ -779,9 +1066,17 @@ class FunctionType;
     F(I64AtomicStore16MemIdx, uint64_t, uint16_t)      \
     F(I64AtomicStore32MemIdx, uint64_t, uint32_t)
 
-#define FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_OP(F) \
-    FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_OP(F)  \
-    FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_OP(F)
+#define FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_M64_OP(F) \
+    F(I64AtomicStoreMemIdxM64, uint64_t, uint64_t)         \
+    F(I64AtomicStore8MemIdxM64, uint64_t, uint8_t)         \
+    F(I64AtomicStore16MemIdxM64, uint64_t, uint16_t)       \
+    F(I64AtomicStore32MemIdxM64, uint64_t, uint32_t)
+
+#define FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_OP(F)    \
+    FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_OP(F)     \
+    FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_M64_OP(F) \
+    FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_OP(F)     \
+    FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_M64_OP(F)
 
 #define FOR_EACH_BYTECODE_ATOMIC_RMW_OP(F)                                \
     F(I64AtomicRmwAdd, uint64_t, uint64_t, Memory::AtomicRmwOp::Add)      \
@@ -832,6 +1127,55 @@ class FunctionType;
     F(I32AtomicRmw8XchgU, uint32_t, uint8_t, Memory::AtomicRmwOp::Xchg)   \
     F(I32AtomicRmw16XchgU, uint32_t, uint16_t, Memory::AtomicRmwOp::Xchg)
 
+#define FOR_EACH_BYTECODE_ATOMIC_RMW_M64_OP(F)                               \
+    F(I64AtomicRmwAddM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Add)      \
+    F(I64AtomicRmw8AddUM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Add)     \
+    F(I64AtomicRmw16AddUM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Add)   \
+    F(I64AtomicRmw32AddUM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Add)   \
+    F(I32AtomicRmwAddM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Add)      \
+    F(I32AtomicRmw8AddUM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Add)     \
+    F(I32AtomicRmw16AddUM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Add)   \
+                                                                             \
+    F(I64AtomicRmwSubM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Sub)      \
+    F(I64AtomicRmw8SubUM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Sub)     \
+    F(I64AtomicRmw16SubUM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Sub)   \
+    F(I64AtomicRmw32SubUM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Sub)   \
+    F(I32AtomicRmwSubM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Sub)      \
+    F(I32AtomicRmw8SubUM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Sub)     \
+    F(I32AtomicRmw16SubUM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Sub)   \
+                                                                             \
+    F(I64AtomicRmwAndM64, uint64_t, uint64_t, Memory::AtomicRmwOp::And)      \
+    F(I64AtomicRmw8AndUM64, uint64_t, uint8_t, Memory::AtomicRmwOp::And)     \
+    F(I64AtomicRmw16AndUM64, uint64_t, uint16_t, Memory::AtomicRmwOp::And)   \
+    F(I64AtomicRmw32AndUM64, uint64_t, uint32_t, Memory::AtomicRmwOp::And)   \
+    F(I32AtomicRmwAndM64, uint32_t, uint32_t, Memory::AtomicRmwOp::And)      \
+    F(I32AtomicRmw8AndUM64, uint32_t, uint8_t, Memory::AtomicRmwOp::And)     \
+    F(I32AtomicRmw16AndUM64, uint32_t, uint16_t, Memory::AtomicRmwOp::And)   \
+                                                                             \
+    F(I64AtomicRmwOrM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Or)        \
+    F(I64AtomicRmw8OrUM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Or)       \
+    F(I64AtomicRmw16OrUM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Or)     \
+    F(I64AtomicRmw32OrUM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Or)     \
+    F(I32AtomicRmwOrM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Or)        \
+    F(I32AtomicRmw8OrUM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Or)       \
+    F(I32AtomicRmw16OrUM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Or)     \
+                                                                             \
+    F(I64AtomicRmwXorM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Xor)      \
+    F(I64AtomicRmw8XorUM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Xor)     \
+    F(I64AtomicRmw16XorUM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Xor)   \
+    F(I64AtomicRmw32XorUM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Xor)   \
+    F(I32AtomicRmwXorM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Xor)      \
+    F(I32AtomicRmw8XorUM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Xor)     \
+    F(I32AtomicRmw16XorUM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Xor)   \
+                                                                             \
+    F(I64AtomicRmwXchgM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Xchg)    \
+    F(I64AtomicRmw8XchgUM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Xchg)   \
+    F(I64AtomicRmw16XchgUM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Xchg) \
+    F(I64AtomicRmw32XchgUM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Xchg) \
+    F(I32AtomicRmwXchgM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Xchg)    \
+    F(I32AtomicRmw8XchgUM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Xchg)   \
+    F(I32AtomicRmw16XchgUM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Xchg)
+
 #define FOR_EACH_BYTECODE_ATOMIC_RMW_MEMIDX_OP(F)                               \
     F(I64AtomicRmwAddMemIdx, uint64_t, uint64_t, Memory::AtomicRmwOp::Add)      \
     F(I64AtomicRmw8AddUMemIdx, uint64_t, uint8_t, Memory::AtomicRmwOp::Add)     \
@@ -881,6 +1225,55 @@ class FunctionType;
     F(I32AtomicRmw8XchgUMemIdx, uint32_t, uint8_t, Memory::AtomicRmwOp::Xchg)   \
     F(I32AtomicRmw16XchgUMemIdx, uint32_t, uint16_t, Memory::AtomicRmwOp::Xchg)
 
+#define FOR_EACH_BYTECODE_ATOMIC_RMW_MEMIDX_M64_OP(F)                              \
+    F(I64AtomicRmwAddMemIdxM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Add)      \
+    F(I64AtomicRmw8AddUMemIdxM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Add)     \
+    F(I64AtomicRmw16AddUMemIdxM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Add)   \
+    F(I64AtomicRmw32AddUMemIdxM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Add)   \
+    F(I32AtomicRmwAddMemIdxM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Add)      \
+    F(I32AtomicRmw8AddUMemIdxM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Add)     \
+    F(I32AtomicRmw16AddUMemIdxM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Add)   \
+                                                                                   \
+    F(I64AtomicRmwSubMemIdxM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Sub)      \
+    F(I64AtomicRmw8SubUMemIdxM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Sub)     \
+    F(I64AtomicRmw16SubUMemIdxM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Sub)   \
+    F(I64AtomicRmw32SubUMemIdxM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Sub)   \
+    F(I32AtomicRmwSubMemIdxM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Sub)      \
+    F(I32AtomicRmw8SubUMemIdxM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Sub)     \
+    F(I32AtomicRmw16SubUMemIdxM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Sub)   \
+                                                                                   \
+    F(I64AtomicRmwAndMemIdxM64, uint64_t, uint64_t, Memory::AtomicRmwOp::And)      \
+    F(I64AtomicRmw8AndUMemIdxM64, uint64_t, uint8_t, Memory::AtomicRmwOp::And)     \
+    F(I64AtomicRmw16AndUMemIdxM64, uint64_t, uint16_t, Memory::AtomicRmwOp::And)   \
+    F(I64AtomicRmw32AndUMemIdxM64, uint64_t, uint32_t, Memory::AtomicRmwOp::And)   \
+    F(I32AtomicRmwAndMemIdxM64, uint32_t, uint32_t, Memory::AtomicRmwOp::And)      \
+    F(I32AtomicRmw8AndUMemIdxM64, uint32_t, uint8_t, Memory::AtomicRmwOp::And)     \
+    F(I32AtomicRmw16AndUMemIdxM64, uint32_t, uint16_t, Memory::AtomicRmwOp::And)   \
+                                                                                   \
+    F(I64AtomicRmwOrMemIdxM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Or)        \
+    F(I64AtomicRmw8OrUMemIdxM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Or)       \
+    F(I64AtomicRmw16OrUMemIdxM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Or)     \
+    F(I64AtomicRmw32OrUMemIdxM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Or)     \
+    F(I32AtomicRmwOrMemIdxM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Or)        \
+    F(I32AtomicRmw8OrUMemIdxM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Or)       \
+    F(I32AtomicRmw16OrUMemIdxM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Or)     \
+                                                                                   \
+    F(I64AtomicRmwXorMemIdxM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Xor)      \
+    F(I64AtomicRmw8XorUMemIdxM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Xor)     \
+    F(I64AtomicRmw16XorUMemIdxM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Xor)   \
+    F(I64AtomicRmw32XorUMemIdxM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Xor)   \
+    F(I32AtomicRmwXorMemIdxM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Xor)      \
+    F(I32AtomicRmw8XorUMemIdxM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Xor)     \
+    F(I32AtomicRmw16XorUMemIdxM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Xor)   \
+                                                                                   \
+    F(I64AtomicRmwXchgMemIdxM64, uint64_t, uint64_t, Memory::AtomicRmwOp::Xchg)    \
+    F(I64AtomicRmw8XchgUMemIdxM64, uint64_t, uint8_t, Memory::AtomicRmwOp::Xchg)   \
+    F(I64AtomicRmw16XchgUMemIdxM64, uint64_t, uint16_t, Memory::AtomicRmwOp::Xchg) \
+    F(I64AtomicRmw32XchgUMemIdxM64, uint64_t, uint32_t, Memory::AtomicRmwOp::Xchg) \
+    F(I32AtomicRmwXchgMemIdxM64, uint32_t, uint32_t, Memory::AtomicRmwOp::Xchg)    \
+    F(I32AtomicRmw8XchgUMemIdxM64, uint32_t, uint8_t, Memory::AtomicRmwOp::Xchg)   \
+    F(I32AtomicRmw16XchgUMemIdxM64, uint32_t, uint16_t, Memory::AtomicRmwOp::Xchg)
+
 #define FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_OP(F) \
     F(I32AtomicRmwCmpxchg, uint32_t, uint32_t)     \
     F(I64AtomicRmwCmpxchg, uint64_t, uint64_t)     \
@@ -889,6 +1282,15 @@ class FunctionType;
     F(I64AtomicRmw8CmpxchgU, uint64_t, uint8_t)    \
     F(I64AtomicRmw16CmpxchgU, uint64_t, uint16_t)  \
     F(I64AtomicRmw32CmpxchgU, uint64_t, uint32_t)
+
+#define FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_M64_OP(F) \
+    F(I32AtomicRmwCmpxchgM64, uint32_t, uint32_t)      \
+    F(I64AtomicRmwCmpxchgM64, uint64_t, uint64_t)      \
+    F(I32AtomicRmw8CmpxchgUM64, uint32_t, uint8_t)     \
+    F(I32AtomicRmw16CmpxchgUM64, uint32_t, uint16_t)   \
+    F(I64AtomicRmw8CmpxchgUM64, uint64_t, uint8_t)     \
+    F(I64AtomicRmw16CmpxchgUM64, uint64_t, uint16_t)   \
+    F(I64AtomicRmw32CmpxchgUM64, uint64_t, uint32_t)
 
 #define FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_MEMIDX_OP(F) \
     F(I32AtomicRmwCmpxchgMemIdx, uint32_t, uint32_t)      \
@@ -899,16 +1301,35 @@ class FunctionType;
     F(I64AtomicRmw16CmpxchgUMemIdx, uint64_t, uint16_t)   \
     F(I64AtomicRmw32CmpxchgUMemIdx, uint64_t, uint32_t)
 
+#define FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_MEMIDX_M64_OP(F) \
+    F(I32AtomicRmwCmpxchgMemIdxM64, uint32_t, uint32_t)       \
+    F(I64AtomicRmwCmpxchgMemIdxM64, uint64_t, uint64_t)       \
+    F(I32AtomicRmw8CmpxchgUMemIdxM64, uint32_t, uint8_t)      \
+    F(I32AtomicRmw16CmpxchgUMemIdxM64, uint32_t, uint16_t)    \
+    F(I64AtomicRmw8CmpxchgUMemIdxM64, uint64_t, uint8_t)      \
+    F(I64AtomicRmw16CmpxchgUMemIdxM64, uint64_t, uint16_t)    \
+    F(I64AtomicRmw32CmpxchgUMemIdxM64, uint64_t, uint32_t)
+
 #define FOR_EACH_BYTECODE_ATOMIC_OTHER(F) \
     F(MemoryAtomicNotify)                 \
     F(MemoryAtomicWait32)                 \
     F(MemoryAtomicWait64)                 \
     F(AtomicFence)
 
+#define FOR_EACH_BYTECODE_ATOMIC_OTHER_M64(F) \
+    F(MemoryAtomicNotifyM64)                  \
+    F(MemoryAtomicWait32M64)                  \
+    F(MemoryAtomicWait64M64)
+
 #define FOR_EACH_BYTECODE_ATOMIC_OTHER_MEMIDX(F) \
     F(MemoryAtomicNotifyMemIdx)                  \
     F(MemoryAtomicWait32MemIdx)                  \
     F(MemoryAtomicWait64MemIdx)
+
+#define FOR_EACH_BYTECODE_ATOMIC_OTHER_MEMIDX_M64(F) \
+    F(MemoryAtomicNotifyMemIdxM64)                   \
+    F(MemoryAtomicWait32MemIdxM64)                   \
+    F(MemoryAtomicWait64MemIdxM64)
 
 #define FOR_EACH_BYTECODE_RELAXED_SIMD_UNARY_OTHER(F)                            \
     F(I32X4RelaxedTruncF32X4S, (simdTruncSatOperation<float, int32_t>))          \
@@ -942,12 +1363,15 @@ class FunctionType;
 
 #define FOR_EACH_BYTECODE(F)                        \
     FOR_EACH_BYTECODE_OP(F)                         \
-    FOR_EACH_BYTECODE_MEMIDX_OP(F)                  \
     FOR_EACH_BYTECODE_BINARY_OP(F)                  \
     FOR_EACH_BYTECODE_UNARY_OP(F)                   \
     FOR_EACH_BYTECODE_UNARY_OP_2(F)                 \
+    FOR_EACH_BYTECODE_MEMIDX_OP(F)                  \
+    FOR_EACH_BYTECODE_MEMIDX_M64_OP(F)              \
     FOR_EACH_BYTECODE_LOAD_OP(F)                    \
+    FOR_EACH_BYTECODE_LOAD_M64_OP(F)                \
     FOR_EACH_BYTECODE_STORE_OP(F)                   \
+    FOR_EACH_BYTECODE_STORE_M64_OP(F)               \
     FOR_EACH_BYTECODE_SIMD_BINARY_OP(F)             \
     FOR_EACH_BYTECODE_SIMD_BINARY_SHIFT_OP(F)       \
     FOR_EACH_BYTECODE_SIMD_BINARY_OTHER(F)          \
@@ -960,17 +1384,27 @@ class FunctionType;
     FOR_EACH_BYTECODE_RELAXED_SIMD_TERNARY_OTHER(F) \
     FOR_EACH_BYTECODE_SIMD_UNARY_OTHER(F)           \
     FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_OP(F)         \
+    FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_M64_OP(F)     \
     FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_OP(F)        \
+    FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_M64_OP(F)    \
     FOR_EACH_BYTECODE_SIMD_LOAD_LANE_OP(F)          \
+    FOR_EACH_BYTECODE_SIMD_LOAD_LANE_M64_OP(F)      \
     FOR_EACH_BYTECODE_SIMD_STORE_LANE_OP(F)         \
+    FOR_EACH_BYTECODE_SIMD_STORE_LANE_M64_OP(F)     \
     FOR_EACH_BYTECODE_SIMD_EXTRACT_LANE_OP(F)       \
     FOR_EACH_BYTECODE_SIMD_REPLACE_LANE_OP(F)       \
     FOR_EACH_BYTECODE_SIMD_ETC_OP(F)                \
+    FOR_EACH_BYTECODE_SIMD_ETC_M64_OP(F)            \
     FOR_EACH_BYTECODE_ATOMIC_LOAD_OP(F)             \
+    FOR_EACH_BYTECODE_ATOMIC_LOAD_M64_OP(F)         \
     FOR_EACH_BYTECODE_ATOMIC_STORE_OP(F)            \
+    FOR_EACH_BYTECODE_ATOMIC_STORE_M64_OP(F)        \
     FOR_EACH_BYTECODE_ATOMIC_RMW_OP(F)              \
+    FOR_EACH_BYTECODE_ATOMIC_RMW_M64_OP(F)          \
     FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_OP(F)      \
-    FOR_EACH_BYTECODE_ATOMIC_OTHER(F)
+    FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_M64_OP(F)  \
+    FOR_EACH_BYTECODE_ATOMIC_OTHER(F)               \
+    FOR_EACH_BYTECODE_ATOMIC_OTHER_M64(F)
 
 class ByteCode {
 public:
@@ -1084,6 +1518,27 @@ protected:
     uint32_t m_value;
 };
 
+class ByteCodeOffset2Value64 : public ByteCode {
+public:
+    ByteCodeOffset2Value64(Opcode opcode, ByteCodeStackOffset stackOffset1, ByteCodeStackOffset stackOffset2, uint64_t value)
+        : ByteCode(opcode)
+        , m_stackOffset1(stackOffset1)
+        , m_stackOffset2(stackOffset2)
+        , m_value(value)
+    {
+    }
+
+    ByteCodeStackOffset stackOffset1() const { return m_stackOffset1; }
+    ByteCodeStackOffset stackOffset2() const { return m_stackOffset2; }
+    uint64_t uint64Value() const { return m_value; }
+    int64_t int64Value() const { return static_cast<int64_t>(m_value); }
+
+protected:
+    ByteCodeStackOffset m_stackOffset1;
+    ByteCodeStackOffset m_stackOffset2;
+    uint64_t m_value;
+};
+
 class ByteCodeOffset2ValueMemIdx : public ByteCode {
 public:
     ByteCodeOffset2ValueMemIdx(uint32_t index, uint32_t alignment, Opcode opcode, ByteCodeStackOffset stackOffset1, ByteCodeStackOffset stackOffset2, uint32_t value)
@@ -1109,6 +1564,33 @@ protected:
     ByteCodeStackOffset m_stackOffset1;
     ByteCodeStackOffset m_stackOffset2;
     uint32_t m_value;
+};
+
+class ByteCodeOffset2Value64MemIdx : public ByteCode {
+public:
+    ByteCodeOffset2Value64MemIdx(uint32_t index, uint32_t alignment, Opcode opcode, ByteCodeStackOffset stackOffset1, ByteCodeStackOffset stackOffset2, uint64_t value)
+        : ByteCode(opcode)
+        , m_memIndex(index)
+        , m_alignment(alignment)
+        , m_stackOffset1(stackOffset1)
+        , m_stackOffset2(stackOffset2)
+        , m_value(value)
+    {
+    }
+
+    uint16_t memIndex() const { return m_memIndex; }
+    uint16_t alignment() const { return m_alignment; }
+    ByteCodeStackOffset stackOffset1() const { return m_stackOffset1; }
+    ByteCodeStackOffset stackOffset2() const { return m_stackOffset2; }
+    uint64_t uint64Value() const { return m_value; }
+    int64_t int64Value() const { return static_cast<int64_t>(m_value); }
+
+protected:
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+    ByteCodeStackOffset m_stackOffset1;
+    ByteCodeStackOffset m_stackOffset2;
+    uint64_t m_value;
 };
 
 class ByteCodeOffset4 : public ByteCode {
@@ -1155,6 +1637,32 @@ protected:
     uint32_t m_value;
 };
 
+class ByteCodeOffset4Value64 : public ByteCode {
+public:
+    ByteCodeOffset4Value64(Opcode opcode, ByteCodeStackOffset src0Offset, ByteCodeStackOffset src1Offset, ByteCodeStackOffset src2Offset, ByteCodeStackOffset dstOffset, uint64_t value)
+        : ByteCode(opcode)
+        , m_stackOffset1(src0Offset)
+        , m_stackOffset2(src1Offset)
+        , m_stackOffset3(src2Offset)
+        , m_stackOffset4(dstOffset)
+        , m_value(value)
+    {
+    }
+
+    ByteCodeStackOffset src0Offset() const { return m_stackOffset1; }
+    ByteCodeStackOffset src1Offset() const { return m_stackOffset2; }
+    ByteCodeStackOffset src2Offset() const { return m_stackOffset3; }
+    ByteCodeStackOffset dstOffset() const { return m_stackOffset4; }
+    uint64_t offset() const { return m_value; }
+
+protected:
+    ByteCodeStackOffset m_stackOffset1;
+    ByteCodeStackOffset m_stackOffset2;
+    ByteCodeStackOffset m_stackOffset3;
+    ByteCodeStackOffset m_stackOffset4;
+    uint64_t m_value;
+};
+
 class ByteCodeOffset4ValueMemIdx : public ByteCode {
 public:
     ByteCodeOffset4ValueMemIdx(uint32_t index, uint32_t alignment, Opcode opcode, ByteCodeStackOffset src0Offset, ByteCodeStackOffset src1Offset, ByteCodeStackOffset src2Offset, ByteCodeStackOffset dstOffset, uint32_t value)
@@ -1187,6 +1695,37 @@ protected:
     uint32_t m_value;
 };
 
+class ByteCodeOffset4Value64MemIdx : public ByteCode {
+public:
+    ByteCodeOffset4Value64MemIdx(uint32_t index, uint32_t alignment, Opcode opcode, ByteCodeStackOffset src0Offset, ByteCodeStackOffset src1Offset, ByteCodeStackOffset src2Offset, ByteCodeStackOffset dstOffset, uint64_t value)
+        : ByteCode(opcode)
+        , m_memIndex(index)
+        , m_alignment(alignment)
+        , m_stackOffset1(src0Offset)
+        , m_stackOffset2(src1Offset)
+        , m_stackOffset3(src2Offset)
+        , m_stackOffset4(dstOffset)
+        , m_value(value)
+    {
+    }
+
+    uint16_t memIndex() const { return m_memIndex; }
+    uint16_t alignment() const { return m_alignment; }
+    ByteCodeStackOffset src0Offset() const { return m_stackOffset1; }
+    ByteCodeStackOffset src1Offset() const { return m_stackOffset2; }
+    ByteCodeStackOffset src2Offset() const { return m_stackOffset3; }
+    ByteCodeStackOffset dstOffset() const { return m_stackOffset4; }
+    uint64_t offset() const { return m_value; }
+
+protected:
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+    ByteCodeStackOffset m_stackOffset1;
+    ByteCodeStackOffset m_stackOffset2;
+    ByteCodeStackOffset m_stackOffset3;
+    ByteCodeStackOffset m_stackOffset4;
+    uint64_t m_value;
+};
 
 class ByteCodeTable {
 public:
@@ -1690,6 +2229,26 @@ public:
 #endif
 };
 
+class Load32M64 : public ByteCodeOffset2 {
+public:
+    Load32M64(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : ByteCodeOffset2(Load32M64Opcode, srcOffset, dstOffset)
+    {
+    }
+
+    ByteCodeStackOffset srcOffset() const { return stackOffset1(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset2(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("load32M64 ");
+        DUMP_BYTECODE_OFFSET(stackOffset1);
+        DUMP_BYTECODE_OFFSET(stackOffset2);
+    }
+#endif
+};
+
 class Load64 : public ByteCodeOffset2 {
 public:
     Load64(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
@@ -1704,6 +2263,26 @@ public:
     void dump(size_t pos)
     {
         printf("load64 ");
+        DUMP_BYTECODE_OFFSET(stackOffset1);
+        DUMP_BYTECODE_OFFSET(stackOffset2);
+    }
+#endif
+};
+
+class Load64M64 : public ByteCodeOffset2 {
+public:
+    Load64M64(ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : ByteCodeOffset2(Load64M64Opcode, srcOffset, dstOffset)
+    {
+    }
+
+    ByteCodeStackOffset srcOffset() const { return stackOffset1(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset2(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("load64M64 ");
         DUMP_BYTECODE_OFFSET(stackOffset1);
         DUMP_BYTECODE_OFFSET(stackOffset2);
     }
@@ -1730,6 +2309,26 @@ public:
 #endif
 };
 
+class Store32M64 : public ByteCodeOffset2 {
+public:
+    Store32M64(ByteCodeStackOffset src0Offset, ByteCodeStackOffset src1Offset)
+        : ByteCodeOffset2(Store32M64Opcode, src0Offset, src1Offset)
+    {
+    }
+
+    ByteCodeStackOffset src0Offset() const { return stackOffset1(); }
+    ByteCodeStackOffset src1Offset() const { return stackOffset2(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("store32M64 ");
+        DUMP_BYTECODE_OFFSET(stackOffset1);
+        DUMP_BYTECODE_OFFSET(stackOffset2);
+    }
+#endif
+};
+
 class Store64 : public ByteCodeOffset2 {
 public:
     Store64(ByteCodeStackOffset src0Offset, ByteCodeStackOffset src1Offset)
@@ -1744,6 +2343,26 @@ public:
     void dump(size_t pos)
     {
         printf("store64 ");
+        DUMP_BYTECODE_OFFSET(stackOffset1);
+        DUMP_BYTECODE_OFFSET(stackOffset2);
+    }
+#endif
+};
+
+class Store64M64 : public ByteCodeOffset2 {
+public:
+    Store64M64(ByteCodeStackOffset src0Offset, ByteCodeStackOffset src1Offset)
+        : ByteCodeOffset2(Store64M64Opcode, src0Offset, src1Offset)
+    {
+    }
+
+    ByteCodeStackOffset src0Offset() const { return stackOffset1(); }
+    ByteCodeStackOffset src1Offset() const { return stackOffset2(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("store64M64 ");
         DUMP_BYTECODE_OFFSET(stackOffset1);
         DUMP_BYTECODE_OFFSET(stackOffset2);
     }
@@ -2239,6 +2858,24 @@ public:
 #endif
 };
 
+class MemoryLoadM64 : public ByteCodeOffset2Value64 {
+public:
+    MemoryLoadM64(Opcode code, uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : ByteCodeOffset2Value64(code, srcOffset, dstOffset, offset)
+    {
+    }
+
+    uint64_t offset() const { return uint64Value(); }
+    ByteCodeStackOffset srcOffset() const { return stackOffset1(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset2(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
 class MemoryLoadFloat : public ByteCodeOffset2Value {
 public:
     MemoryLoadFloat(Opcode code, uint32_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
@@ -2247,6 +2884,24 @@ public:
     }
 
     uint32_t offset() const { return uint32Value(); }
+    ByteCodeStackOffset srcOffset() const { return stackOffset2(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset1(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
+class MemoryLoadFloatM64 : public ByteCodeOffset2Value64 {
+public:
+    MemoryLoadFloatM64(Opcode code, uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : ByteCodeOffset2Value64(code, dstOffset, srcOffset, offset)
+    {
+    }
+
+    uint64_t offset() const { return uint64Value(); }
     ByteCodeStackOffset srcOffset() const { return stackOffset2(); }
     ByteCodeStackOffset dstOffset() const { return stackOffset1(); }
 
@@ -2276,6 +2931,24 @@ public:
 #endif
 };
 
+class MemoryLoadMemIdxM64 : public ByteCodeOffset2Value64MemIdx {
+public:
+    MemoryLoadMemIdxM64(uint32_t index, uint32_t alignment, Opcode code, uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : ByteCodeOffset2Value64MemIdx(index, alignment, code, srcOffset, dstOffset, offset)
+    {
+    }
+
+    uint64_t offset() const { return uint64Value(); }
+    ByteCodeStackOffset srcOffset() const { return stackOffset1(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset2(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
 class MemoryLoadFloatMemIdx : public ByteCodeOffset2ValueMemIdx {
 public:
     MemoryLoadFloatMemIdx(uint32_t index, uint32_t alignment, Opcode code, uint32_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
@@ -2284,6 +2957,24 @@ public:
     }
 
     uint32_t offset() const { return uint32Value(); }
+    ByteCodeStackOffset srcOffset() const { return stackOffset2(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset1(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
+class MemoryLoadFloatMemIdxM64 : public ByteCodeOffset2Value64MemIdx {
+public:
+    MemoryLoadFloatMemIdxM64(uint32_t index, uint32_t alignment, Opcode code, uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : ByteCodeOffset2Value64MemIdx(index, alignment, code, dstOffset, srcOffset, offset)
+    {
+    }
+
+    uint64_t offset() const { return uint64Value(); }
     ByteCodeStackOffset srcOffset() const { return stackOffset2(); }
     ByteCodeStackOffset dstOffset() const { return stackOffset1(); }
 
@@ -2320,6 +3011,37 @@ public:
 #endif
 protected:
     uint32_t m_offset;
+    ByteCodeStackOffset m_src0Offset;
+    ByteCodeStackOffset m_src1Offset;
+    ByteCodeStackOffset m_index;
+    ByteCodeStackOffset m_dstOffset;
+};
+
+class SIMDMemoryLoadM64 : public ByteCode {
+public:
+    SIMDMemoryLoadM64(Opcode code, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset index, ByteCodeStackOffset dst)
+        : ByteCode(code)
+        , m_offset(offset)
+        , m_src0Offset(src0)
+        , m_src1Offset(src1)
+        , m_index(index)
+        , m_dstOffset(dst)
+    {
+    }
+
+    uint64_t offset() const { return m_offset; }
+    ByteCodeStackOffset index() const { return m_index; }
+    ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
+    ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
+    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+protected:
+    uint64_t m_offset;
     ByteCodeStackOffset m_src0Offset;
     ByteCodeStackOffset m_src1Offset;
     ByteCodeStackOffset m_index;
@@ -2364,6 +3086,43 @@ protected:
     uint16_t m_alignment;
 };
 
+class SIMDMemoryLoadMemIdxM64 : public ByteCode {
+public:
+    SIMDMemoryLoadMemIdxM64(uint32_t memIndex, uint32_t alignment, Opcode code, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset index, ByteCodeStackOffset dst)
+        : ByteCode(code)
+        , m_offset(offset)
+        , m_src0Offset(src0)
+        , m_src1Offset(src1)
+        , m_index(index)
+        , m_dstOffset(dst)
+        , m_memIndex(memIndex)
+        , m_alignment(alignment)
+    {
+    }
+
+    uint64_t offset() const { return m_offset; }
+    ByteCodeStackOffset index() const { return m_index; }
+    ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
+    ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
+    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+    uint16_t memIndex() const { return m_memIndex; }
+    uint16_t alignment() const { return m_alignment; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+protected:
+    uint64_t m_offset;
+    ByteCodeStackOffset m_src0Offset;
+    ByteCodeStackOffset m_src1Offset;
+    ByteCodeStackOffset m_index;
+    ByteCodeStackOffset m_dstOffset;
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
 #if !defined(NDEBUG)
 #define DEFINE_LOAD_BYTECODE_DUMP(name)                                                                                              \
     void dump(size_t pos)                                                                                                            \
@@ -2392,6 +3151,36 @@ protected:
         {                                                                                   \
         }                                                                                   \
         DEFINE_LOAD_BYTECODE_DUMP(name)                                                     \
+    };
+
+#if !defined(NDEBUG)
+#define DEFINE_LOAD_BYTECODE_M64_DUMP(name)                                                                                          \
+    void dump(size_t pos)                                                                                                            \
+    {                                                                                                                                \
+        printf(#name " src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset()); \
+    }
+#else
+#define DEFINE_LOAD_BYTECODE_M64_DUMP(name)
+#endif
+
+#define DEFINE_LOAD_M64_BYTECODE(name, ...)                                                 \
+    class name : public MemoryLoadM64 {                                                     \
+    public:                                                                                 \
+        name(uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset) \
+            : MemoryLoadM64(Opcode::name##Opcode, offset, srcOffset, dstOffset)             \
+        {                                                                                   \
+        }                                                                                   \
+        DEFINE_LOAD_BYTECODE_M64_DUMP(name)                                                 \
+    };
+
+#define DEFINE_LOAD_FLOAT_M64_BYTECODE(name, ...)                                           \
+    class name : public MemoryLoadFloatM64 {                                                \
+    public:                                                                                 \
+        name(uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset) \
+            : MemoryLoadFloatM64(Opcode::name##Opcode, offset, srcOffset, dstOffset)        \
+        {                                                                                   \
+        }                                                                                   \
+        DEFINE_LOAD_BYTECODE_M64_DUMP(name)                                                 \
     };
 
 #if !defined(NDEBUG)
@@ -2426,6 +3215,37 @@ protected:
     };
 
 #if !defined(NDEBUG)
+#define DEFINE_LOAD_MEMIDX_M64_BYTECODE_DUMP(name)                                                                       \
+    void dump(size_t pos)                                                                                                \
+    {                                                                                                                    \
+        printf(#name " src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16, \
+               (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset(), (uint16_t)m_memIndex, (uint16_t)m_alignment);     \
+    }
+#else
+#define DEFINE_LOAD_MEMIDX_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_LOAD_MEMIDX_M64_BYTECODE(name, ...)                                                                              \
+    class name : public MemoryLoadMemIdxM64 {                                                                                   \
+    public:                                                                                                                     \
+        name(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset) \
+            : MemoryLoadMemIdxM64(index, alignment, Opcode::name##Opcode, offset, srcOffset, dstOffset)                         \
+        {                                                                                                                       \
+        }                                                                                                                       \
+        DEFINE_LOAD_MEMIDX_M64_BYTECODE_DUMP(name)                                                                              \
+    };
+
+#define DEFINE_LOAD_FLOAT_MEMIDX_M64_BYTECODE(name, ...)                                                                        \
+    class name : public MemoryLoadFloatMemIdxM64 {                                                                              \
+    public:                                                                                                                     \
+        name(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset) \
+            : MemoryLoadFloatMemIdxM64(index, alignment, Opcode::name##Opcode, offset, srcOffset, dstOffset)                    \
+        {                                                                                                                       \
+        }                                                                                                                       \
+        DEFINE_LOAD_MEMIDX_M64_BYTECODE_DUMP(name)                                                                              \
+    };
+
+#if !defined(NDEBUG)
 #define DEFINE_SIMD_LOAD_LANE_BYTECODE_DUMP(name)                                                                                                                                                                              \
     void dump(size_t pos)                                                                                                                                                                                                      \
     {                                                                                                                                                                                                                          \
@@ -2443,6 +3263,26 @@ protected:
         {                                                                                                                             \
         }                                                                                                                             \
         DEFINE_SIMD_LOAD_LANE_BYTECODE_DUMP(name)                                                                                     \
+    };
+
+#if !defined(NDEBUG)
+#define DEFINE_SIMD_LOAD_LANE_M64_BYTECODE_DUMP(name)                                                                                                                                                                          \
+    void dump(size_t pos)                                                                                                                                                                                                      \
+    {                                                                                                                                                                                                                          \
+        printf(#name " idx: %" PRIu32 " src0: %" PRIu32 " src1: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)m_index, (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_dstOffset, (uint64_t)m_offset); \
+    }
+#else
+#define DEFINE_SIMD_LOAD_LANE_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_SIMD_LOAD_LANE_M64_BYTECODE(name, opType)                                                                              \
+    class name : public SIMDMemoryLoadM64 {                                                                                           \
+    public:                                                                                                                           \
+        name(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset index, ByteCodeStackOffset dst) \
+            : SIMDMemoryLoadM64(Opcode::name##Opcode, offset, src0, src1, index, dst)                                                 \
+        {                                                                                                                             \
+        }                                                                                                                             \
+        DEFINE_SIMD_LOAD_LANE_M64_BYTECODE_DUMP(name)                                                                                 \
     };
 
 #if !defined(NDEBUG)
@@ -2464,6 +3304,27 @@ protected:
         {                                                                                                                                                                    \
         }                                                                                                                                                                    \
         DEFINE_SIMD_LOAD_LANE_BYTECODE_DUMP(name)                                                                                                                            \
+    };
+
+#if !defined(NDEBUG)
+#define DEFINE_SIMD_LOAD_LANE_MEMIDX_M64_BYTECODE_DUMP(name)                                                                                                               \
+    void dump(size_t pos)                                                                                                                                                  \
+    {                                                                                                                                                                      \
+        printf(#name " idx: %" PRIu32 " src0: %" PRIu32 " src1: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16,               \
+               (uint32_t)m_index, (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_dstOffset, (uint64_t)m_offset, (uint16_t)m_memIndex, (uint16_t)m_alignment); \
+    }
+#else
+#define DEFINE_SIMD_LOAD_LANE_MEMIDX_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_SIMD_LOAD_LANE_MEMIDX_M64_BYTECODE(name, opType)                                                                                                              \
+    class name : public SIMDMemoryLoadMemIdxM64 {                                                                                                                            \
+    public:                                                                                                                                                                  \
+        name(uint32_t memIndex, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset index, ByteCodeStackOffset dst) \
+            : SIMDMemoryLoadMemIdxM64(memIndex, alignment, Opcode::name##Opcode, offset, src0, src1, index, dst)                                                             \
+        {                                                                                                                                                                    \
+        }                                                                                                                                                                    \
+        DEFINE_SIMD_LOAD_LANE_M64_BYTECODE_DUMP(name)                                                                                                                        \
     };
 
 // dummy ByteCode for memory store operations
@@ -2493,6 +3354,42 @@ public:
     }
 
     uint32_t offset() const { return uint32Value(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset2(); }
+    ByteCodeStackOffset valueOffset() const { return stackOffset1(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
+class MemoryStore32M64 : public ByteCodeOffset2Value64 {
+public:
+    MemoryStore32M64(Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1)
+        : ByteCodeOffset2Value64(opcode, src0, src1, offset)
+    {
+    }
+
+    uint64_t offset() const { return uint64Value(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset1(); }
+    ByteCodeStackOffset valueOffset() const { return stackOffset2(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
+class MemoryStore64M64 : public ByteCodeOffset2Value64 {
+public:
+    MemoryStore64M64(Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1)
+        : ByteCodeOffset2Value64(opcode, src1, src0, offset)
+    {
+    }
+
+    uint64_t offset() const { return uint64Value(); }
     ByteCodeStackOffset dstOffset() const { return stackOffset2(); }
     ByteCodeStackOffset valueOffset() const { return stackOffset1(); }
 
@@ -2540,6 +3437,42 @@ public:
 #endif
 };
 
+class MemoryStoreMemIdx32M64 : public ByteCodeOffset2Value64MemIdx {
+public:
+    MemoryStoreMemIdx32M64(uint32_t memIndex, uint32_t alignment, Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1)
+        : ByteCodeOffset2Value64MemIdx(memIndex, alignment, opcode, src0, src1, offset)
+    {
+    }
+
+    uint64_t offset() const { return uint64Value(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset1(); }
+    ByteCodeStackOffset valueOffset() const { return stackOffset2(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
+class MemoryStoreMemIdx64M64 : public ByteCodeOffset2Value64MemIdx {
+public:
+    MemoryStoreMemIdx64M64(uint32_t memIndex, uint32_t alignment, Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1)
+        : ByteCodeOffset2Value64MemIdx(memIndex, alignment, opcode, src1, src0, offset)
+    {
+    }
+
+    uint64_t offset() const { return uint64Value(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset2(); }
+    ByteCodeStackOffset valueOffset() const { return stackOffset1(); }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
 // dummy ByteCode for simd memory store operation
 class SIMDMemoryStore : public ByteCode {
 public:
@@ -2564,6 +3497,34 @@ public:
 #endif
 protected:
     uint32_t m_offset;
+    ByteCodeStackOffset m_src0Offset;
+    ByteCodeStackOffset m_src1Offset;
+    ByteCodeStackOffset m_index;
+};
+
+class SIMDMemoryStoreM64 : public ByteCode {
+public:
+    SIMDMemoryStoreM64(Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset index)
+        : ByteCode(opcode)
+        , m_offset(offset)
+        , m_src0Offset(src0)
+        , m_src1Offset(src1)
+        , m_index(index)
+    {
+    }
+
+    uint64_t offset() const { return m_offset; }
+    ByteCodeStackOffset index() const { return m_index; }
+    ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
+    ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+protected:
+    uint64_t m_offset;
     ByteCodeStackOffset m_src0Offset;
     ByteCodeStackOffset m_src1Offset;
     ByteCodeStackOffset m_index;
@@ -2597,6 +3558,40 @@ public:
 #endif
 protected:
     uint32_t m_offset;
+    ByteCodeStackOffset m_src0Offset;
+    ByteCodeStackOffset m_src1Offset;
+    ByteCodeStackOffset m_index;
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
+class SIMDMemoryStoreMemIdxM64 : public ByteCode {
+public:
+    SIMDMemoryStoreMemIdxM64(uint32_t memIndex, uint32_t alignment, Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset index)
+        : ByteCode(opcode)
+        , m_offset(offset)
+        , m_src0Offset(src0)
+        , m_src1Offset(src1)
+        , m_index(index)
+        , m_memIndex(memIndex)
+        , m_alignment(alignment)
+    {
+    }
+
+    uint64_t offset() const { return m_offset; }
+    ByteCodeStackOffset index() const { return m_index; }
+    ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
+    ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
+    uint16_t memIndex() const { return m_memIndex; }
+    uint16_t alignment() const { return m_alignment; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+protected:
+    uint64_t m_offset;
     ByteCodeStackOffset m_src0Offset;
     ByteCodeStackOffset m_src1Offset;
     ByteCodeStackOffset m_index;
@@ -2687,6 +3682,36 @@ protected:
     };
 
 #if !defined(NDEBUG)
+#define DEFINE_STORE_M64_BYTECODE_DUMP(name)                                                                                             \
+    void dump(size_t pos)                                                                                                                \
+    {                                                                                                                                    \
+        printf(#name " dst: %" PRIu32 " value: %" PRIu32 " offset: %" PRIu64, (uint32_t)dstOffset(), (uint32_t)valueOffset(), offset()); \
+    }
+#else
+#define DEFINE_STORE_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_STORE_32_M64_BYTECODE(name, readType, writeType)                   \
+    class name : public MemoryStore32M64 {                                        \
+    public:                                                                       \
+        name(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1) \
+            : MemoryStore32M64(Opcode::name##Opcode, offset, src0, src1)          \
+        {                                                                         \
+        }                                                                         \
+        DEFINE_STORE_M64_BYTECODE_DUMP(name)                                      \
+    };
+
+#define DEFINE_STORE_64_M64_BYTECODE(name, readType, writeType)                   \
+    class name : public MemoryStore64M64 {                                        \
+    public:                                                                       \
+        name(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1) \
+            : MemoryStore64M64(Opcode::name##Opcode, offset, src0, src1)          \
+        {                                                                         \
+        }                                                                         \
+        DEFINE_STORE_M64_BYTECODE_DUMP(name)                                      \
+    };
+
+#if !defined(NDEBUG)
 #define DEFINE_STORE_MEMIDX_BYTECODE_DUMP(name)                                                                            \
     void dump(size_t pos)                                                                                                  \
     {                                                                                                                      \
@@ -2718,6 +3743,37 @@ protected:
     };
 
 #if !defined(NDEBUG)
+#define DEFINE_STORE_MEMIDX_M64_BYTECODE_DUMP(name)                                                                        \
+    void dump(size_t pos)                                                                                                  \
+    {                                                                                                                      \
+        printf(#name " dst: %" PRIu32 " value: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16, \
+               (uint32_t)dstOffset(), (uint32_t)valueOffset(), offset(), (uint16_t)m_memIndex, (uint16_t)m_alignment);     \
+    }
+#else
+#define DEFINE_STORE_MEMIDX_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_STORE_MEMIDX_32_M64_BYTECODE(name, readType, writeType)                                                \
+    class name : public MemoryStoreMemIdx32M64 {                                                                      \
+    public:                                                                                                           \
+        name(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1) \
+            : MemoryStoreMemIdx32M64(index, alignment, Opcode::name##Opcode, offset, src0, src1)                      \
+        {                                                                                                             \
+        }                                                                                                             \
+        DEFINE_STORE_MEMIDX_M64_BYTECODE_DUMP(name)                                                                   \
+    };
+
+#define DEFINE_STORE_MEMIDX_64_M64_BYTECODE(name, readType, writeType)                                                \
+    class name : public MemoryStoreMemIdx64M64 {                                                                      \
+    public:                                                                                                           \
+        name(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1) \
+            : MemoryStoreMemIdx64M64(index, alignment, Opcode::name##Opcode, offset, src0, src1)                      \
+        {                                                                                                             \
+        }                                                                                                             \
+        DEFINE_STORE_MEMIDX_M64_BYTECODE_DUMP(name)                                                                   \
+    };
+
+#if !defined(NDEBUG)
 #define DEFINE_SIMD_STORE_LANE_BYTECODE_DUMP(name)                                                                                                                                     \
     void dump(size_t pos)                                                                                                                                                              \
     {                                                                                                                                                                                  \
@@ -2735,6 +3791,26 @@ protected:
         {                                                                                                    \
         }                                                                                                    \
         DEFINE_SIMD_STORE_LANE_BYTECODE_DUMP(name)                                                           \
+    };
+
+#if !defined(NDEBUG)
+#define DEFINE_SIMD_STORE_LANE_M64_BYTECODE_DUMP(name)                                                                                                                                 \
+    void dump(size_t pos)                                                                                                                                                              \
+    {                                                                                                                                                                                  \
+        printf(#name " idx: %" PRIu32 " src0: %" PRIu32 " src1: %" PRIu32 " offset: %" PRIu64, (uint32_t)m_index, (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint64_t)m_offset); \
+    }
+#else
+#define DEFINE_SIMD_STORE_LANE_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_SIMD_STORE_LANE_M64_BYTECODE(name, opType)                                                    \
+    class name : public SIMDMemoryStoreM64 {                                                                 \
+    public:                                                                                                  \
+        name(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset index) \
+            : SIMDMemoryStoreM64(Opcode::name##Opcode, offset, src0, src1, index)                            \
+        {                                                                                                    \
+        }                                                                                                    \
+        DEFINE_SIMD_STORE_LANE_M64_BYTECODE_DUMP(name)                                                       \
     };
 
 #if !defined(NDEBUG)
@@ -2759,6 +3835,27 @@ protected:
         DEFINE_SIMD_STORE_LANE_BYTECODE_DUMP(name)                                                                                                  \
     };
 
+#if !defined(NDEBUG)
+#define DEFINE_SIMD_STORE_LANE_MEMIDX_M64_BYTECODE_DUMP(name)                                                                               \
+    void dump(size_t pos)                                                                                                                   \
+    {                                                                                                                                       \
+        printf(#name " idx: %" PRIu32 " src0: %" PRIu32 " src1: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16, \
+               (uint32_t)m_index,                                                                                                           \
+               (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint64_t)m_offset, (uint16_t)m_memIndex, (uint16_t)m_alignment);            \
+    }
+#else
+#define DEFINE_SIMD_STORE_LANE_MEMIDX_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_SIMD_STORE_LANE_MEMIDX_M64_BYTECODE(name, opType)                                                                                    \
+    class name : public SIMDMemoryStoreMemIdxM64 {                                                                                                  \
+    public:                                                                                                                                         \
+        name(uint32_t memIndex, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset index) \
+            : SIMDMemoryStoreMemIdxM64(memIndex, alignment, Opcode::name##Opcode, offset, src0, src1, index)                                        \
+        {                                                                                                                                           \
+        }                                                                                                                                           \
+        DEFINE_SIMD_STORE_LANE_M64_BYTECODE_DUMP(name)                                                                                              \
+    };
 
 #if !defined(NDEBUG)
 #define DEFINE_SIMD_EXTRACT_LANE_BYTECODE_DUMP(name)                                                                                       \
@@ -2829,6 +3926,34 @@ protected:
     ByteCodeStackOffset m_dstOffset;
 };
 
+class AtomicRmwM64 : public ByteCode {
+public:
+    AtomicRmwM64(Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst)
+        : ByteCode(opcode)
+        , m_offset(offset)
+        , m_src0Offset(src0)
+        , m_src1Offset(src1)
+        , m_dstOffset(dst)
+    {
+    }
+
+    uint64_t offset() const { return m_offset; }
+    ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
+    ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
+    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+protected:
+    uint64_t m_offset;
+    ByteCodeStackOffset m_src0Offset;
+    ByteCodeStackOffset m_src1Offset;
+    ByteCodeStackOffset m_dstOffset;
+};
+
 class AtomicRmwMemIdx : public ByteCode {
 public:
     AtomicRmwMemIdx(uint32_t memIndex, uint32_t alignment, Opcode opcode, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst)
@@ -2864,11 +3989,59 @@ protected:
     uint16_t m_alignment;
 };
 
+class AtomicRmwMemIdxM64 : public ByteCode {
+public:
+    AtomicRmwMemIdxM64(uint32_t memIndex, uint32_t alignment, Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst)
+        : ByteCode(opcode)
+        , m_offset(offset)
+        , m_src0Offset(src0)
+        , m_src1Offset(src1)
+        , m_dstOffset(dst)
+        , m_memIndex(memIndex)
+        , m_alignment(alignment)
+    {
+    }
+
+    uint64_t offset() const { return m_offset; }
+    ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
+    ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
+    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+    uint16_t memIndex() const { return m_memIndex; }
+    uint16_t alignment() const { return m_alignment; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+
+protected:
+    uint64_t m_offset;
+    ByteCodeStackOffset m_src0Offset;
+    ByteCodeStackOffset m_src1Offset;
+    ByteCodeStackOffset m_dstOffset;
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
 class AtomicRmwCmpxchg : public ByteCodeOffset4Value {
 public:
     AtomicRmwCmpxchg(Opcode opcode, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
         : ByteCodeOffset4Value(opcode, src0, src1, src2, dst, offset)
+    {
+    }
 
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+};
+
+class AtomicRmwCmpxchgM64 : public ByteCodeOffset4Value64 {
+public:
+    AtomicRmwCmpxchgM64(Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
+        : ByteCodeOffset4Value64(opcode, src0, src1, src2, dst, offset)
     {
     }
 
@@ -2885,7 +4058,29 @@ public:
         : ByteCodeOffset4Value(opcode, src0, src1, src2, dst, offset)
         , m_memIndex(memIndex)
         , m_alignment(alignment)
+    {
+    }
 
+    uint16_t memIndex() const { return m_memIndex; }
+    uint16_t alignment() const { return m_alignment; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+    }
+#endif
+
+protected:
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
+class AtomicRmwCmpxchgMemIdxM64 : public ByteCodeOffset4Value64 {
+public:
+    AtomicRmwCmpxchgMemIdxM64(uint32_t memIndex, uint32_t alignment, Opcode opcode, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
+        : ByteCodeOffset4Value64(opcode, src0, src1, src2, dst, offset)
+        , m_memIndex(memIndex)
+        , m_alignment(alignment)
     {
     }
 
@@ -2917,10 +4112,24 @@ public:
 #endif
 };
 
+class MemoryAtomicWait32M64 : public ByteCodeOffset4Value64 {
+public:
+    MemoryAtomicWait32M64(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
+        : ByteCodeOffset4Value64(Opcode::MemoryAtomicWait32M64Opcode, src0, src1, src2, dst, offset)
+    {
+    }
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("MemoryAtomicWait32M64 src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)m_stackOffset1, (uint32_t)m_stackOffset2, (uint32_t)m_stackOffset3, (uint32_t)m_stackOffset4, (uint64_t)m_value);
+    }
+#endif
+};
+
 class MemoryAtomicWait32MemIdx : public ByteCodeOffset4Value {
 public:
     MemoryAtomicWait32MemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
-        : ByteCodeOffset4Value(Opcode::MemoryAtomicWait32Opcode, src0, src1, src2, dst, offset)
+        : ByteCodeOffset4Value(Opcode::MemoryAtomicWait32MemIdxOpcode, src0, src1, src2, dst, offset)
         , m_memIndex(index)
         , m_alignment(alignment)
     {
@@ -2928,8 +4137,35 @@ public:
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
-        printf("MemoryAtomicWait32 src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16,
+        printf("MemoryAtomicWait32MemIdx src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16,
                (uint32_t)m_stackOffset1, (uint32_t)m_stackOffset2, (uint32_t)m_stackOffset3, (uint32_t)m_stackOffset4, (uint32_t)m_value, (uint16_t)m_memIndex, (uint16_t)m_alignment);
+    }
+#endif
+
+    uint16_t memIndex() const
+    {
+        return m_memIndex;
+    }
+    uint16_t alignment() const { return m_alignment; }
+
+protected:
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
+class MemoryAtomicWait32MemIdxM64 : public ByteCodeOffset4Value64 {
+public:
+    MemoryAtomicWait32MemIdxM64(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
+        : ByteCodeOffset4Value64(Opcode::MemoryAtomicWait32MemIdxM64Opcode, src0, src1, src2, dst, offset)
+        , m_memIndex(index)
+        , m_alignment(alignment)
+    {
+    }
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("MemoryAtomicWait32MemIdxM64 src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16,
+               (uint32_t)m_stackOffset1, (uint32_t)m_stackOffset2, (uint32_t)m_stackOffset3, (uint32_t)m_stackOffset4, (uint64_t)m_value, (uint16_t)m_memIndex, (uint16_t)m_alignment);
     }
 #endif
 
@@ -2959,10 +4195,25 @@ public:
 #endif
 };
 
+class MemoryAtomicWait64M64 : public ByteCodeOffset4Value64 {
+public:
+    MemoryAtomicWait64M64(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
+        : ByteCodeOffset4Value64(Opcode::MemoryAtomicWait64M64Opcode, src0, src1, src2, dst, offset)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("MemoryAtomicWait64M64 src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)m_stackOffset1, (uint32_t)m_stackOffset2, (uint32_t)m_stackOffset3, (uint32_t)m_stackOffset4, (uint64_t)m_value);
+    }
+#endif
+};
+
 class MemoryAtomicWait64MemIdx : public ByteCodeOffset4Value {
 public:
     MemoryAtomicWait64MemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
-        : ByteCodeOffset4Value(Opcode::MemoryAtomicWait64Opcode, src0, src1, src2, dst, offset)
+        : ByteCodeOffset4Value(Opcode::MemoryAtomicWait64MemIdxOpcode, src0, src1, src2, dst, offset)
         , m_memIndex(index)
         , m_alignment(alignment)
     {
@@ -2971,8 +4222,36 @@ public:
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
-        printf("MemoryAtomicWait64 src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16,
+        printf("MemoryAtomicWait64MemIdx src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16,
                (uint32_t)m_stackOffset1, (uint32_t)m_stackOffset2, (uint32_t)m_stackOffset3, (uint32_t)m_stackOffset4, (uint32_t)m_value, (uint16_t)m_memIndex, (uint16_t)m_alignment);
+    }
+#endif
+
+    uint16_t memIndex() const
+    {
+        return m_memIndex;
+    }
+    uint16_t alignment() const { return m_alignment; }
+
+protected:
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
+class MemoryAtomicWait64MemIdxM64 : public ByteCodeOffset4Value64 {
+public:
+    MemoryAtomicWait64MemIdxM64(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
+        : ByteCodeOffset4Value64(Opcode::MemoryAtomicWait64MemIdxM64Opcode, src0, src1, src2, dst, offset)
+        , m_memIndex(index)
+        , m_alignment(alignment)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("MemoryAtomicWait64MemIdxM64 src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16,
+               (uint32_t)m_stackOffset1, (uint32_t)m_stackOffset2, (uint32_t)m_stackOffset3, (uint32_t)m_stackOffset4, (uint64_t)m_value, (uint16_t)m_memIndex, (uint16_t)m_alignment);
     }
 #endif
 
@@ -3016,10 +4295,39 @@ protected:
     ByteCodeStackOffset m_dstOffset;
 };
 
+class MemoryAtomicNotifyM64 : public ByteCode {
+public:
+    MemoryAtomicNotifyM64(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst)
+        : ByteCode(Opcode::MemoryAtomicNotifyM64Opcode)
+        , m_offset(offset)
+        , m_src0Offset(src0)
+        , m_src1Offset(src1)
+        , m_dstOffset(dst)
+    {
+    }
+
+    uint64_t offset() const { return m_offset; }
+    ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
+    ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
+    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("MemoryAtomicNotifyM64 src0: %" PRIu32 " src1: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_dstOffset, (uint64_t)m_offset);
+    }
+#endif
+protected:
+    uint64_t m_offset;
+    ByteCodeStackOffset m_src0Offset;
+    ByteCodeStackOffset m_src1Offset;
+    ByteCodeStackOffset m_dstOffset;
+};
+
 class MemoryAtomicNotifyMemIdx : public ByteCode {
 public:
     MemoryAtomicNotifyMemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst)
-        : ByteCode(Opcode::MemoryAtomicNotifyOpcode)
+        : ByteCode(Opcode::MemoryAtomicNotifyMemIdxOpcode)
         , m_offset(offset)
         , m_src0Offset(src0)
         , m_src1Offset(src1)
@@ -3039,12 +4347,48 @@ public:
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
-        printf("MemoryAtomicNotify src0: %" PRIu32 " src1: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16,
+        printf("MemoryAtomicNotifyMemIdx src0: %" PRIu32 " src1: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16,
                (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_dstOffset, (uint32_t)m_offset, (uint16_t)m_memIndex, (uint16_t)m_alignment);
     }
 #endif
 protected:
     uint32_t m_offset;
+    ByteCodeStackOffset m_src0Offset;
+    ByteCodeStackOffset m_src1Offset;
+    ByteCodeStackOffset m_dstOffset;
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
+class MemoryAtomicNotifyMemIdxM64 : public ByteCode {
+public:
+    MemoryAtomicNotifyMemIdxM64(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst)
+        : ByteCode(Opcode::MemoryAtomicNotifyMemIdxM64Opcode)
+        , m_offset(offset)
+        , m_src0Offset(src0)
+        , m_src1Offset(src1)
+        , m_dstOffset(dst)
+        , m_memIndex(index)
+        , m_alignment(alignment)
+    {
+    }
+
+    uint64_t offset() const { return m_offset; }
+    ByteCodeStackOffset src0Offset() const { return m_src0Offset; }
+    ByteCodeStackOffset src1Offset() const { return m_src1Offset; }
+    ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
+    uint16_t memIndex() const { return m_memIndex; }
+    uint16_t alignment() const { return m_alignment; }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("MemoryAtomicNotifyMemIdxM64 src0: %" PRIu32 " src1: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16,
+               (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_dstOffset, (uint64_t)m_offset, (uint16_t)m_memIndex, (uint16_t)m_alignment);
+    }
+#endif
+protected:
+    uint64_t m_offset;
     ByteCodeStackOffset m_src0Offset;
     ByteCodeStackOffset m_src1Offset;
     ByteCodeStackOffset m_dstOffset;
@@ -3089,6 +4433,26 @@ protected:
     };
 
 #if !defined(NDEBUG)
+#define DEFINE_RMW_M64_BYTECODE_DUMP(name)                                                                                                                                                 \
+    void dump(size_t pos)                                                                                                                                                                  \
+    {                                                                                                                                                                                      \
+        printf(#name " src0: %" PRIu32 " src1: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_dstOffset, (uint64_t)m_offset); \
+    }
+#else
+#define DEFINE_RMW_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_RMW_M64_BYTECODE(name, paramType, writeType, operationName)                                 \
+    class name : public AtomicRmwM64 {                                                                     \
+    public:                                                                                                \
+        name(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst) \
+            : AtomicRmwM64(Opcode::name##Opcode, offset, src0, src1, dst)                                  \
+        {                                                                                                  \
+        }                                                                                                  \
+        DEFINE_RMW_M64_BYTECODE_DUMP(name)                                                                 \
+    };
+
+#if !defined(NDEBUG)
 #define DEFINE_RMW_MEMIDX_BYTECODE_DUMP(name)                                                                                                           \
     void dump(size_t pos)                                                                                                                               \
     {                                                                                                                                                   \
@@ -3099,14 +4463,35 @@ protected:
 #define DEFINE_RMW_MEMIDX_BYTECODE_DUMP(name)
 #endif
 
-#define DEFINE_RMW_MEMIDX_BYTECODE(name, paramType, writeType, operationName)                                                                          \
-    class name##MemIdx : public AtomicRmwMemIdx {                                                                                                      \
-    public:                                                                                                                                            \
-        name##MemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst) \
-            : AtomicRmwMemIdx(index, alignment, Opcode::name##MemIdxOpcode, offset, src0, src1, dst)                                                   \
-        {                                                                                                                                              \
-        }                                                                                                                                              \
-        DEFINE_RMW_MEMIDX_BYTECODE_DUMP(name)                                                                                                          \
+#define DEFINE_RMW_MEMIDX_BYTECODE(name, paramType, writeType, operationName)                                                                  \
+    class name : public AtomicRmwMemIdx {                                                                                                      \
+    public:                                                                                                                                    \
+        name(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst) \
+            : AtomicRmwMemIdx(index, alignment, Opcode::name##Opcode, offset, src0, src1, dst)                                                 \
+        {                                                                                                                                      \
+        }                                                                                                                                      \
+        DEFINE_RMW_MEMIDX_BYTECODE_DUMP(name)                                                                                                  \
+    };
+
+#if !defined(NDEBUG)
+#define DEFINE_RMW_MEMIDX_M64_BYTECODE_DUMP(name)                                                                                                       \
+    void dump(size_t pos)                                                                                                                               \
+    {                                                                                                                                                   \
+        printf(#name " src0: %" PRIu32 " src1: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16,             \
+               (uint32_t)m_src0Offset, (uint32_t)m_src1Offset, (uint32_t)m_dstOffset, (uint64_t)m_offset, (uint16_t)m_memIndex, (uint16_t)m_alignment); \
+    }
+#else
+#define DEFINE_RMW_MEMIDX_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_RMW_MEMIDX_M64_BYTECODE(name, paramType, writeType, operationName)                                                              \
+    class name : public AtomicRmwMemIdxM64 {                                                                                                   \
+    public:                                                                                                                                    \
+        name(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset dst) \
+            : AtomicRmwMemIdxM64(index, alignment, Opcode::name##Opcode, offset, src0, src1, dst)                                              \
+        {                                                                                                                                      \
+        }                                                                                                                                      \
+        DEFINE_RMW_MEMIDX_M64_BYTECODE_DUMP(name)                                                                                              \
     };
 
 #if !defined(NDEBUG)
@@ -3130,6 +4515,26 @@ protected:
     };
 
 #if !defined(NDEBUG)
+#define DEFINE_RMW_CMPXCHG_M64_BYTECODE_DUMP(name)                                                                                                                                                                                           \
+    void dump(size_t pos)                                                                                                                                                                                                                    \
+    {                                                                                                                                                                                                                                        \
+        printf(#name " src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)m_stackOffset1, (uint32_t)m_stackOffset2, (uint32_t)m_stackOffset3, (uint32_t)m_stackOffset4, (uint64_t)m_value); \
+    }
+#else
+#define DEFINE_RMW_CMPXCHG_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_RMW_CMPXCHG_M64_BYTECODE(name, paramType, writeType)                                                                  \
+    class name : public AtomicRmwCmpxchgM64 {                                                                                        \
+    public:                                                                                                                          \
+        name(uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst) \
+            : AtomicRmwCmpxchgM64(Opcode::name##Opcode, offset, src0, src1, src2, dst)                                               \
+        {                                                                                                                            \
+        }                                                                                                                            \
+        DEFINE_RMW_CMPXCHG_M64_BYTECODE_DUMP(name)                                                                                   \
+    };
+
+#if !defined(NDEBUG)
 #define DEFINE_RMW_CMPXCHG_MEMIDX_BYTECODE_DUMP(name)                                                                                                                                   \
     void dump(size_t pos)                                                                                                                                                               \
     {                                                                                                                                                                                   \
@@ -3140,65 +4545,143 @@ protected:
 #define DEFINE_RMW_CMPXCHG_MEMIDX_BYTECODE_DUMP(name)
 #endif
 
-#define DEFINE_RMW_CMPXCHG_MEMIDX_BYTECODE(name, paramType, writeType)                                                                                                           \
-    class name##MemIdx : public AtomicRmwCmpxchgMemIdx {                                                                                                                         \
-    public:                                                                                                                                                                      \
-        name##MemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst) \
-            : AtomicRmwCmpxchgMemIdx(index, alignment, Opcode::name##MemIdxOpcode, offset, src0, src1, src2, dst)                                                                \
-        {                                                                                                                                                                        \
-        }                                                                                                                                                                        \
-        DEFINE_RMW_CMPXCHG_BYTECODE_DUMP(name)                                                                                                                                   \
+#define DEFINE_RMW_CMPXCHG_MEMIDX_BYTECODE(name, paramType, writeType)                                                                                                   \
+    class name : public AtomicRmwCmpxchgMemIdx {                                                                                                                         \
+    public:                                                                                                                                                              \
+        name(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst) \
+            : AtomicRmwCmpxchgMemIdx(index, alignment, Opcode::name##Opcode, offset, src0, src1, src2, dst)                                                              \
+        {                                                                                                                                                                \
+        }                                                                                                                                                                \
+        DEFINE_RMW_CMPXCHG_BYTECODE_DUMP(name)                                                                                                                           \
     };
 
+#if !defined(NDEBUG)
+#define DEFINE_RMW_CMPXCHG_MEMIDX_M64_BYTECODE_DUMP(name)                                                                                                                               \
+    void dump(size_t pos)                                                                                                                                                               \
+    {                                                                                                                                                                                   \
+        printf(#name " src0: %" PRIu32 " src1: %" PRIu32 " src2: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16,                           \
+               (uint32_t)m_stackOffset1, (uint32_t)m_stackOffset2, (uint32_t)m_stackOffset3, (uint32_t)m_stackOffset4, (uint64_t)m_value, (uint16_t)m_memIndex, (uint16_t)m_alignment); \
+    }
+#else
+#define DEFINE_RMW_CMPXCHG_MEMIDX_M64_BYTECODE_DUMP(name)
+#endif
+
+#define DEFINE_RMW_CMPXCHG_MEMIDX_M64_BYTECODE(name, paramType, writeType)                                                                                               \
+    class name : public AtomicRmwCmpxchgMemIdxM64 {                                                                                                                      \
+    public:                                                                                                                                                              \
+        name(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst) \
+            : AtomicRmwCmpxchgMemIdxM64(index, alignment, Opcode::name##Opcode, offset, src0, src1, src2, dst)                                                           \
+        {                                                                                                                                                                \
+        }                                                                                                                                                                \
+        DEFINE_RMW_CMPXCHG_M64_BYTECODE_DUMP(name)                                                                                                                       \
+    };
 
 FOR_EACH_BYTECODE_LOAD_INT_OP(DEFINE_LOAD_BYTECODE)
+FOR_EACH_BYTECODE_LOAD_INT_M64_OP(DEFINE_LOAD_M64_BYTECODE)
 FOR_EACH_BYTECODE_LOAD_FLOAT_OP(DEFINE_LOAD_FLOAT_BYTECODE)
+FOR_EACH_BYTECODE_LOAD_FLOAT_M64_OP(DEFINE_LOAD_FLOAT_M64_BYTECODE)
 FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_OP(DEFINE_LOAD_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_M64_OP(DEFINE_LOAD_MEMIDX_M64_BYTECODE)
 FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_OP(DEFINE_LOAD_FLOAT_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_M64_OP(DEFINE_LOAD_FLOAT_MEMIDX_M64_BYTECODE)
 FOR_EACH_BYTECODE_STORE_32_OP(DEFINE_STORE_32_BYTECODE)
+FOR_EACH_BYTECODE_STORE_32_M64_OP(DEFINE_STORE_32_M64_BYTECODE)
 FOR_EACH_BYTECODE_STORE_64_OP(DEFINE_STORE_64_BYTECODE)
+FOR_EACH_BYTECODE_STORE_64_M64_OP(DEFINE_STORE_64_M64_BYTECODE)
 FOR_EACH_BYTECODE_STORE_MEMIDX_32_OP(DEFINE_STORE_MEMIDX_32_BYTECODE)
+FOR_EACH_BYTECODE_STORE_MEMIDX_32_M64_OP(DEFINE_STORE_MEMIDX_32_M64_BYTECODE)
 FOR_EACH_BYTECODE_STORE_MEMIDX_64_OP(DEFINE_STORE_MEMIDX_64_BYTECODE)
+FOR_EACH_BYTECODE_STORE_MEMIDX_64_M64_OP(DEFINE_STORE_MEMIDX_64_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_OP(DEFINE_LOAD_BYTECODE)
+FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_M64_OP(DEFINE_LOAD_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_MEMIDX_OP(DEFINE_LOAD_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_MEMIDX_M64_OP(DEFINE_LOAD_MEMIDX_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_OP(DEFINE_LOAD_BYTECODE)
+FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_M64_OP(DEFINE_LOAD_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_MEMIDX_OP(DEFINE_LOAD_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_MEMIDX_M64_OP(DEFINE_LOAD_MEMIDX_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_LOAD_LANE_OP(DEFINE_SIMD_LOAD_LANE_BYTECODE)
+FOR_EACH_BYTECODE_SIMD_LOAD_LANE_M64_OP(DEFINE_SIMD_LOAD_LANE_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_LOAD_LANE_MEMIDX_OP(DEFINE_SIMD_LOAD_LANE_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_SIMD_LOAD_LANE_MEMIDX_M64_OP(DEFINE_SIMD_LOAD_LANE_MEMIDX_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_STORE_LANE_OP(DEFINE_SIMD_STORE_LANE_BYTECODE)
+FOR_EACH_BYTECODE_SIMD_STORE_LANE_M64_OP(DEFINE_SIMD_STORE_LANE_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_STORE_LANE_MEMIDX_OP(DEFINE_SIMD_STORE_LANE_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_SIMD_STORE_LANE_MEMIDX_M64_OP(DEFINE_SIMD_STORE_LANE_MEMIDX_M64_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_EXTRACT_LANE_OP(DEFINE_SIMD_EXTRACT_LANE_BYTECODE)
 FOR_EACH_BYTECODE_SIMD_REPLACE_LANE_OP(DEFINE_SIMD_REPLACE_LANE_BYTECODE)
 FOR_EACH_BYTECODE_ATOMIC_LOAD_OP(DEFINE_LOAD_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_LOAD_M64_OP(DEFINE_LOAD_M64_BYTECODE)
 FOR_EACH_BYTECODE_ATOMIC_LOAD_MEMIDX_OP(DEFINE_LOAD_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_LOAD_MEMIDX_M64_OP(DEFINE_LOAD_MEMIDX_M64_BYTECODE)
 FOR_EACH_BYTECODE_ATOMIC_STORE_32_OP(DEFINE_STORE_32_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_STORE_32_M64_OP(DEFINE_STORE_32_M64_BYTECODE)
 FOR_EACH_BYTECODE_ATOMIC_STORE_64_OP(DEFINE_STORE_64_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_STORE_64_M64_OP(DEFINE_STORE_64_M64_BYTECODE)
 FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_OP(DEFINE_STORE_MEMIDX_32_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_M64_OP(DEFINE_STORE_MEMIDX_32_M64_BYTECODE)
 FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_OP(DEFINE_STORE_MEMIDX_64_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_M64_OP(DEFINE_STORE_MEMIDX_64_M64_BYTECODE)
 FOR_EACH_BYTECODE_ATOMIC_RMW_OP(DEFINE_RMW_BYTECODE)
-FOR_EACH_BYTECODE_ATOMIC_RMW_OP(DEFINE_RMW_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_RMW_M64_OP(DEFINE_RMW_M64_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_RMW_MEMIDX_OP(DEFINE_RMW_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_RMW_MEMIDX_M64_OP(DEFINE_RMW_MEMIDX_M64_BYTECODE)
 FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_OP(DEFINE_RMW_CMPXCHG_BYTECODE)
-FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_OP(DEFINE_RMW_CMPXCHG_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_M64_OP(DEFINE_RMW_CMPXCHG_M64_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_MEMIDX_OP(DEFINE_RMW_CMPXCHG_MEMIDX_BYTECODE)
+FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_MEMIDX_M64_OP(DEFINE_RMW_CMPXCHG_MEMIDX_M64_BYTECODE)
 #undef DEFINE_LOAD_BYTECODE_DUMP
+#undef DEFINE_LOAD_M64_BYTECODE_DUMP
 #undef DEFINE_LOAD_MEMIDX_BYTECODE_DUMP
+#undef DEFINE_LOAD_MEMIDX_M64_BYTECODE_DUMP
 #undef DEFINE_LOAD_BYTECODE
+#undef DEFINE_LOAD_M64_BYTECODE
 #undef DEFINE_LOAD_MEMIDX_BYTECODE
+#undef DEFINE_LOAD_MEMIDX_M64_BYTECODE
 #undef DEFINE_STORE_BYTECODE_DUMP
+#undef DEFINE_STORE_M64_BYTECODE_DUMP
 #undef DEFINE_STORE_MEMIDX_BYTECODE_DUMP
-#undef DEFINE_STORE_BYTECODE
-#undef DEFINE_STORE_MEMIDX_BYTECODE
+#undef DEFINE_STORE_MEMIDX_M64_BYTECODE_DUMP
+#undef DEFINE_STORE_32_BYTECODE
+#undef DEFINE_STORE_64_BYTECODE
+#undef DEFINE_STORE_32_M64_BYTECODE
+#undef DEFINE_STORE_64_M64_BYTECODE
+#undef DEFINE_STORE_MEMIDX_32_BYTECODE
+#undef DEFINE_STORE_MEMIDX_64_BYTECODE
+#undef DEFINE_STORE_MEMIDX_32_M64_BYTECODE
+#undef DEFINE_STORE_MEMIDX_64_M64_BYTECODE
+#undef DEFINE_SIMD_LOAD_LANE_BYTECODE_DUMP
+#undef DEFINE_SIMD_LOAD_LANE_M64_BYTECODE_DUMP
+#undef DEFINE_SIMD_LOAD_LANE_MEMIDX_BYTECODE_DUMP
+#undef DEFINE_SIMD_LOAD_LANE_MEMIDX_M64_BYTECODE_DUMP
 #undef DEFINE_SIMD_LOAD_LANE_BYTECODE
 #undef DEFINE_SIMD_LOAD_LANE_MEMIDX_BYTECODE
+#undef DEFINE_SIMD_LOAD_LANE_M64_BYTECODE
+#undef DEFINE_SIMD_LOAD_LANE_MEMIDX_M64_BYTECODE
+#undef DEFINE_SIMD_STORE_LANE_BYTECODE_DUMP
+#undef DEFINE_SIMD_STORE_LANE_MEMIDX_BYTECODE_DUMP
+#undef DEFINE_SIMD_STORE_LANE_M64_BYTECODE_DUMP
+#undef DEFINE_SIMD_STORE_LANE_MEMIDX_M64_BYTECODE_DUMP
 #undef DEFINE_SIMD_STORE_LANE_BYTECODE
+#undef DEFINE_SIMD_STORE_LANE_M64_BYTECODE
 #undef DEFINE_SIMD_STORE_LANE_MEMIDX_BYTECODE
+#undef DEFINE_SIMD_STORE_LANE_MEMIDX_M64_BYTECODE
 #undef DEFINE_RMW_BYTECODE_DUMP
 #undef DEFINE_RMW_MEMIDX_BYTECODE_DUMP
+#undef DEFINE_RMW_M64_BYTECODE_DUMP
+#undef DEFINE_RMW_MEMIDX_M64_BYTECODE_DUMP
 #undef DEFINE_RMW_BYTECODE
 #undef DEFINE_RMW_MEMIDX_BYTECODE
+#undef DEFINE_RMW_M64_BYTECODE
+#undef DEFINE_RMW_MEMIDX_M64_BYTECODE
 #undef DEFINE_RMW_CMPXCHG_BYTECODE_DUMP
+#undef DEFINE_RMW_CMPXCHG_M64_BYTECODE_DUMP
 #undef DEFINE_RMW_CMPXCHG_MEMIDX_BYTECODE_DUMP
+#undef DEFINE_RMW_CMPXCHG_MEMIDX_M64_BYTECODE_DUMP
 #undef DEFINE_RMW_CMPXCHG_BYTECODE
+#undef DEFINE_RMW_CMPXCHG_M64_BYTECODE
 #undef DEFINE_RMW_CMPXCHG_MEMIDX_BYTECODE
+#undef DEFINE_RMW_CMPXCHG_MEMIDX_M64_BYTECODE
 
 // FOR_EACH_BYTECODE_SIMD_ETC_OP
 class V128BitSelect : public ByteCodeOffset4 {
@@ -3231,10 +4714,25 @@ public:
 #endif
 };
 
-class V128Load32ZeroMemIdx : public MemoryLoad {
+class V128Load32ZeroM64 : public MemoryLoadM64 {
+public:
+    V128Load32ZeroM64(uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : MemoryLoadM64(Opcode::V128Load32ZeroM64Opcode, offset, srcOffset, dstOffset)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("V128Load32ZeroM64 src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset());
+    }
+#endif
+};
+
+class V128Load32ZeroMemIdx : public MemoryLoadMemIdx {
 public:
     V128Load32ZeroMemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
-        : MemoryLoad(Opcode::V128Load32ZeroOpcode, offset, srcOffset, dstOffset)
+        : MemoryLoadMemIdx(index, alignment, Opcode::V128Load32ZeroMemIdxOpcode, offset, srcOffset, dstOffset)
         , m_memIndex(index)
         , m_alignment(alignment)
     {
@@ -3243,7 +4741,34 @@ public:
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
-        printf("V128Load32Zero src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset(), (uint16_t)m_memIndex, (uint16_t)m_alignment);
+        printf("V128Load32ZeroMemIdx src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset(), (uint16_t)m_memIndex, (uint16_t)m_alignment);
+    }
+#endif
+
+    uint16_t memIndex() const
+    {
+        return m_memIndex;
+    }
+    uint16_t alignment() const { return m_alignment; }
+
+protected:
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
+class V128Load32ZeroMemIdxM64 : public MemoryLoadMemIdxM64 {
+public:
+    V128Load32ZeroMemIdxM64(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : MemoryLoadMemIdxM64(index, alignment, Opcode::V128Load32ZeroMemIdxM64Opcode, offset, srcOffset, dstOffset)
+        , m_memIndex(index)
+        , m_alignment(alignment)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("V128Load32ZeroMemIdxM64 src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset(), (uint16_t)m_memIndex, (uint16_t)m_alignment);
     }
 #endif
 
@@ -3273,10 +4798,25 @@ public:
 #endif
 };
 
-class V128Load64ZeroMemIdx : public MemoryLoad {
+class V128Load64ZeroM64 : public MemoryLoadM64 {
+public:
+    V128Load64ZeroM64(uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : MemoryLoadM64(Opcode::V128Load64ZeroM64Opcode, offset, srcOffset, dstOffset)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("V128Load64ZeroM64 src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset());
+    }
+#endif
+};
+
+class V128Load64ZeroMemIdx : public MemoryLoadMemIdx {
 public:
     V128Load64ZeroMemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
-        : MemoryLoad(Opcode::V128Load64ZeroOpcode, offset, srcOffset, dstOffset)
+        : MemoryLoadMemIdx(index, alignment, Opcode::V128Load64ZeroMemIdxOpcode, offset, srcOffset, dstOffset)
         , m_memIndex(index)
         , m_alignment(alignment)
     {
@@ -3285,7 +4825,34 @@ public:
 #if !defined(NDEBUG)
     void dump(size_t pos)
     {
-        printf("V128Load64Zero src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset(), (uint16_t)m_memIndex, (uint16_t)m_alignment);
+        printf("V128Load64ZeroMemIdx src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu32 " memIndex: %" PRIu16 " alignment: %" PRIu16, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset(), (uint16_t)m_memIndex, (uint16_t)m_alignment);
+    }
+#endif
+
+    uint16_t memIndex() const
+    {
+        return m_memIndex;
+    }
+    uint16_t alignment() const { return m_alignment; }
+
+protected:
+    uint16_t m_memIndex;
+    uint16_t m_alignment;
+};
+
+class V128Load64ZeroMemIdxM64 : public MemoryLoadMemIdxM64 {
+public:
+    V128Load64ZeroMemIdxM64(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
+        : MemoryLoadMemIdxM64(index, alignment, Opcode::V128Load64ZeroMemIdxM64Opcode, offset, srcOffset, dstOffset)
+        , m_memIndex(index)
+        , m_alignment(alignment)
+    {
+    }
+
+#if !defined(NDEBUG)
+    void dump(size_t pos)
+    {
+        printf("V128Load64ZeroMemIdxM64 src: %" PRIu32 " dst: %" PRIu32 " offset: %" PRIu64 " memIndex: %" PRIu16 " alignment: %" PRIu16, (uint32_t)srcOffset(), (uint32_t)dstOffset(), offset(), (uint16_t)m_memIndex, (uint16_t)m_alignment);
     }
 #endif
 

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -660,6 +660,19 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                           \
     }
 
+#define MEMORY_LOAD_INT_M64_OPERATION(opcodeName, readType, writeType) \
+    DEFINE_OPCODE(opcodeName)                                          \
+        :                                                              \
+    {                                                                  \
+        MemoryLoadM64* code = (MemoryLoadM64*)programCounter;          \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());  \
+        readType value;                                                \
+        memories[0]->loadM64(state, offset, code->offset(), &value);   \
+        writeValue<writeType>(bp, code->dstOffset(), value);           \
+        ADD_PROGRAM_COUNTER(MemoryLoadM64);                            \
+        NEXT_INSTRUCTION();                                            \
+    }
+
 #define MEMORY_LOAD_FLOAT_OPERATION(opcodeName, readType, writeType)  \
     DEFINE_OPCODE(opcodeName)                                         \
         :                                                             \
@@ -669,8 +682,21 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         readType value;                                               \
         memories[0]->load(state, offset, code->offset(), &value);     \
         writeValue<writeType>(bp, code->dstOffset(), value);          \
-        ADD_PROGRAM_COUNTER(MemoryLoad);                              \
+        ADD_PROGRAM_COUNTER(MemoryLoadFloat);                         \
         NEXT_INSTRUCTION();                                           \
+    }
+
+#define MEMORY_LOAD_FLOAT_M64_OPERATION(opcodeName, readType, writeType) \
+    DEFINE_OPCODE(opcodeName)                                            \
+        :                                                                \
+    {                                                                    \
+        MemoryLoadFloatM64* code = (MemoryLoadFloatM64*)programCounter;  \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());    \
+        readType value;                                                  \
+        memories[0]->loadM64(state, offset, code->offset(), &value);     \
+        writeValue<writeType>(bp, code->dstOffset(), value);             \
+        ADD_PROGRAM_COUNTER(MemoryLoadFloatM64);                         \
+        NEXT_INSTRUCTION();                                              \
     }
 
 #define MEMORY_LOAD_INT_MEMIDX_OPERATION(opcodeName, readType, writeType)        \
@@ -686,6 +712,19 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                      \
     }
 
+#define MEMORY_LOAD_INT_MEMIDX_M64_OPERATION(opcodeName, readType, writeType)       \
+    DEFINE_OPCODE(opcodeName)                                                       \
+        :                                                                           \
+    {                                                                               \
+        MemoryLoadMemIdxM64* code = (MemoryLoadMemIdxM64*)programCounter;           \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());               \
+        readType value;                                                             \
+        memories[code->memIndex()]->loadM64(state, offset, code->offset(), &value); \
+        writeValue<writeType>(bp, code->dstOffset(), value);                        \
+        ADD_PROGRAM_COUNTER(MemoryLoadMemIdxM64);                                   \
+        NEXT_INSTRUCTION();                                                         \
+    }
+
 #define MEMORY_LOAD_FLOAT_MEMIDX_OPERATION(opcodeName, readType, writeType)      \
     DEFINE_OPCODE(opcodeName)                                                    \
         :                                                                        \
@@ -695,8 +734,21 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         readType value;                                                          \
         memories[code->memIndex()]->load(state, offset, code->offset(), &value); \
         writeValue<writeType>(bp, code->dstOffset(), value);                     \
-        ADD_PROGRAM_COUNTER(MemoryLoadMemIdx);                                   \
+        ADD_PROGRAM_COUNTER(MemoryLoadFloatMemIdx);                              \
         NEXT_INSTRUCTION();                                                      \
+    }
+
+#define MEMORY_LOAD_FLOAT_MEMIDX_M64_OPERATION(opcodeName, readType, writeType)     \
+    DEFINE_OPCODE(opcodeName)                                                       \
+        :                                                                           \
+    {                                                                               \
+        MemoryLoadFloatMemIdxM64* code = (MemoryLoadFloatMemIdxM64*)programCounter; \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());               \
+        readType value;                                                             \
+        memories[code->memIndex()]->loadM64(state, offset, code->offset(), &value); \
+        writeValue<writeType>(bp, code->dstOffset(), value);                        \
+        ADD_PROGRAM_COUNTER(MemoryLoadFloatMemIdxM64);                              \
+        NEXT_INSTRUCTION();                                                         \
     }
 
 #define MEMORY_STORE_32_OPERATION(opcodeName, readType, writeType)      \
@@ -708,6 +760,18 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         uint32_t offset = readValue<uint32_t>(bp, code->dstOffset());   \
         memories[0]->store(state, offset, code->offset(), value);       \
         ADD_PROGRAM_COUNTER(MemoryStore32);                             \
+        NEXT_INSTRUCTION();                                             \
+    }
+
+#define MEMORY_STORE_32_M64_OPERATION(opcodeName, readType, writeType)  \
+    DEFINE_OPCODE(opcodeName)                                           \
+        :                                                               \
+    {                                                                   \
+        MemoryStore32M64* code = (MemoryStore32M64*)programCounter;     \
+        writeType value = readValue<readType>(bp, code->valueOffset()); \
+        uint64_t offset = readValue<uint64_t>(bp, code->dstOffset());   \
+        memories[0]->storeM64(state, offset, code->offset(), value);    \
+        ADD_PROGRAM_COUNTER(MemoryStore32M64);                          \
         NEXT_INSTRUCTION();                                             \
     }
 
@@ -723,6 +787,18 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                             \
     }
 
+#define MEMORY_STORE_64_M64_OPERATION(opcodeName, readType, writeType)  \
+    DEFINE_OPCODE(opcodeName)                                           \
+        :                                                               \
+    {                                                                   \
+        MemoryStore64M64* code = (MemoryStore64M64*)programCounter;     \
+        writeType value = readValue<readType>(bp, code->valueOffset()); \
+        uint64_t offset = readValue<uint64_t>(bp, code->dstOffset());   \
+        memories[0]->storeM64(state, offset, code->offset(), value);    \
+        ADD_PROGRAM_COUNTER(MemoryStore64M64);                          \
+        NEXT_INSTRUCTION();                                             \
+    }
+
 #define MEMORY_STORE_MEMIDX_32_OPERATION(opcodeName, readType, writeType)        \
     DEFINE_OPCODE(opcodeName)                                                    \
         :                                                                        \
@@ -735,6 +811,18 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                      \
     }
 
+#define MEMORY_STORE_MEMIDX_32_M64_OPERATION(opcodeName, readType, writeType)       \
+    DEFINE_OPCODE(opcodeName)                                                       \
+        :                                                                           \
+    {                                                                               \
+        MemoryStoreMemIdx32M64* code = (MemoryStoreMemIdx32M64*)programCounter;     \
+        writeType value = readValue<readType>(bp, code->valueOffset());             \
+        uint64_t offset = readValue<uint64_t>(bp, code->dstOffset());               \
+        memories[code->memIndex()]->storeM64(state, offset, code->offset(), value); \
+        ADD_PROGRAM_COUNTER(MemoryStoreMemIdx32M64);                                \
+        NEXT_INSTRUCTION();                                                         \
+    }
+
 #define MEMORY_STORE_MEMIDX_64_OPERATION(opcodeName, readType, writeType)        \
     DEFINE_OPCODE(opcodeName)                                                    \
         :                                                                        \
@@ -745,6 +833,18 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         memories[code->memIndex()]->store(state, offset, code->offset(), value); \
         ADD_PROGRAM_COUNTER(MemoryStoreMemIdx64);                                \
         NEXT_INSTRUCTION();                                                      \
+    }
+
+#define MEMORY_STORE_MEMIDX_64_M64_OPERATION(opcodeName, readType, writeType)       \
+    DEFINE_OPCODE(opcodeName)                                                       \
+        :                                                                           \
+    {                                                                               \
+        MemoryStoreMemIdx64M64* code = (MemoryStoreMemIdx64M64*)programCounter;     \
+        writeType value = readValue<readType>(bp, code->valueOffset());             \
+        uint64_t offset = readValue<uint64_t>(bp, code->dstOffset());               \
+        memories[code->memIndex()]->storeM64(state, offset, code->offset(), value); \
+        ADD_PROGRAM_COUNTER(MemoryStoreMemIdx64M64);                                \
+        NEXT_INSTRUCTION();                                                         \
     }
 
 #define SIMD_MEMORY_LOAD_SPLAT_OPERATION(opcodeName, opType)          \
@@ -763,6 +863,22 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                           \
     }
 
+#define SIMD_MEMORY_LOAD_SPLAT_M64_OPERATION(opcodeName, opType)      \
+    DEFINE_OPCODE(opcodeName)                                         \
+        :                                                             \
+    {                                                                 \
+        using Type = typename SIMDType<opType>::Type;                 \
+        MemoryLoadM64* code = (MemoryLoadM64*)programCounter;         \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset()); \
+        opType value;                                                 \
+        memories[0]->loadM64(state, offset, code->offset(), &value);  \
+        Type result;                                                  \
+        std::fill(std::begin(result.v), std::end(result.v), value);   \
+        writeValue<Type>(bp, code->dstOffset(), result);              \
+        ADD_PROGRAM_COUNTER(MemoryLoadM64);                           \
+        NEXT_INSTRUCTION();                                           \
+    }
+
 #define SIMD_MEMORY_LOAD_SPLAT_MEMIDX_OPERATION(opcodeName, opType)              \
     DEFINE_OPCODE(opcodeName)                                                    \
         :                                                                        \
@@ -777,6 +893,22 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         writeValue<Type>(bp, code->dstOffset(), result);                         \
         ADD_PROGRAM_COUNTER(MemoryLoadMemIdx);                                   \
         NEXT_INSTRUCTION();                                                      \
+    }
+
+#define SIMD_MEMORY_LOAD_SPLAT_MEMIDX_M64_OPERATION(opcodeName, opType)             \
+    DEFINE_OPCODE(opcodeName)                                                       \
+        :                                                                           \
+    {                                                                               \
+        using Type = typename SIMDType<opType>::Type;                               \
+        opType value;                                                               \
+        Type result;                                                                \
+        MemoryLoadMemIdxM64* code = (MemoryLoadMemIdxM64*)programCounter;           \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());               \
+        memories[code->memIndex()]->loadM64(state, offset, code->offset(), &value); \
+        std::fill(std::begin(result.v), std::end(result.v), value);                 \
+        writeValue<Type>(bp, code->dstOffset(), result);                            \
+        ADD_PROGRAM_COUNTER(MemoryLoadMemIdxM64);                                   \
+        NEXT_INSTRUCTION();                                                         \
     }
 
 #define SIMD_MEMORY_LOAD_EXTEND_OPERATION(opcodeName, readType, writeType) \
@@ -797,6 +929,24 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                \
     }
 
+#define SIMD_MEMORY_LOAD_EXTEND_M64_OPERATION(opcodeName, readType, writeType) \
+    DEFINE_OPCODE(opcodeName)                                                  \
+        :                                                                      \
+    {                                                                          \
+        using WriteType = typename SIMDType<writeType>::Type;                  \
+        MemoryLoadM64* code = (MemoryLoadM64*)programCounter;                  \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());          \
+        readType value;                                                        \
+        memories[0]->loadM64(state, offset, code->offset(), &value);           \
+        WriteType result;                                                      \
+        for (uint8_t i = 0; i < WriteType::Lanes; i++) {                       \
+            result[i] = value[i];                                              \
+        }                                                                      \
+        writeValue<WriteType>(bp, code->dstOffset(), result);                  \
+        ADD_PROGRAM_COUNTER(MemoryLoadM64);                                    \
+        NEXT_INSTRUCTION();                                                    \
+    }
+
 #define SIMD_MEMORY_LOAD_EXTEND_MEMIDX_OPERATION(opcodeName, readType, writeType) \
     DEFINE_OPCODE(opcodeName)                                                     \
         :                                                                         \
@@ -815,6 +965,24 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                       \
     }
 
+#define SIMD_MEMORY_LOAD_EXTEND_MEMIDX_M64_OPERATION(opcodeName, readType, writeType) \
+    DEFINE_OPCODE(opcodeName)                                                         \
+        :                                                                             \
+    {                                                                                 \
+        using WriteType = typename SIMDType<writeType>::Type;                         \
+        readType value;                                                               \
+        WriteType result;                                                             \
+        MemoryLoadMemIdxM64* code = (MemoryLoadMemIdxM64*)programCounter;             \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());                 \
+        memories[code->memIndex()]->loadM64(state, offset, code->offset(), &value);   \
+        for (uint8_t i = 0; i < WriteType::Lanes; i++) {                              \
+            result[i] = value[i];                                                     \
+        }                                                                             \
+        writeValue<WriteType>(bp, code->dstOffset(), result);                         \
+        ADD_PROGRAM_COUNTER(MemoryLoadMemIdxM64);                                     \
+        NEXT_INSTRUCTION();                                                           \
+    }
+
 #define SIMD_MEMORY_LOAD_LANE_OPERATION(opcodeName, opType)            \
     DEFINE_OPCODE(opcodeName)                                          \
         :                                                              \
@@ -828,6 +996,22 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         result[code->index()] = value;                                 \
         writeValue<Type>(bp, code->dstOffset(), result);               \
         ADD_PROGRAM_COUNTER(SIMDMemoryLoad);                           \
+        NEXT_INSTRUCTION();                                            \
+    }
+
+#define SIMD_MEMORY_LOAD_LANE_M64_OPERATION(opcodeName, opType)        \
+    DEFINE_OPCODE(opcodeName)                                          \
+        :                                                              \
+    {                                                                  \
+        using Type = typename SIMDType<opType>::Type;                  \
+        SIMDMemoryLoadM64* code = (SIMDMemoryLoadM64*)programCounter;  \
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset()); \
+        Type result = readValue<Type>(bp, code->src1Offset());         \
+        opType value;                                                  \
+        memories[0]->loadM64(state, offset, code->offset(), &value);   \
+        result[code->index()] = value;                                 \
+        writeValue<Type>(bp, code->dstOffset(), result);               \
+        ADD_PROGRAM_COUNTER(SIMDMemoryLoadM64);                        \
         NEXT_INSTRUCTION();                                            \
     }
 
@@ -847,6 +1031,22 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                      \
     }
 
+#define SIMD_MEMORY_LOAD_LANE_MEMIDX_M64_OPERATION(opcodeName, opType)              \
+    DEFINE_OPCODE(opcodeName)                                                       \
+        :                                                                           \
+    {                                                                               \
+        using Type = typename SIMDType<opType>::Type;                               \
+        SIMDMemoryLoadMemIdxM64* code = (SIMDMemoryLoadMemIdxM64*)programCounter;   \
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());              \
+        Type result = readValue<Type>(bp, code->src1Offset());                      \
+        opType value;                                                               \
+        memories[code->memIndex()]->loadM64(state, offset, code->offset(), &value); \
+        result[code->index()] = value;                                              \
+        writeValue<Type>(bp, code->dstOffset(), result);                            \
+        ADD_PROGRAM_COUNTER(SIMDMemoryLoadMemIdxM64);                               \
+        NEXT_INSTRUCTION();                                                         \
+    }
+
 #define SIMD_MEMORY_STORE_LANE_OPERATION(opcodeName, opType)           \
     DEFINE_OPCODE(opcodeName)                                          \
         :                                                              \
@@ -861,6 +1061,20 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                            \
     }
 
+#define SIMD_MEMORY_STORE_LANE_M64_OPERATION(opcodeName, opType)        \
+    DEFINE_OPCODE(opcodeName)                                           \
+        :                                                               \
+    {                                                                   \
+        using Type = typename SIMDType<opType>::Type;                   \
+        SIMDMemoryStoreM64* code = (SIMDMemoryStoreM64*)programCounter; \
+        Type result = readValue<Type>(bp, code->src1Offset());          \
+        opType value = result[code->index()];                           \
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());  \
+        memories[0]->storeM64(state, offset, code->offset(), value);    \
+        ADD_PROGRAM_COUNTER(SIMDMemoryStoreM64);                        \
+        NEXT_INSTRUCTION();                                             \
+    }
+
 #define SIMD_MEMORY_STORE_LANE_MEMIDX_OPERATION(opcodeName, opType)              \
     DEFINE_OPCODE(opcodeName)                                                    \
         :                                                                        \
@@ -873,6 +1087,20 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         memories[code->memIndex()]->store(state, offset, code->offset(), value); \
         ADD_PROGRAM_COUNTER(SIMDMemoryStoreMemIdx);                              \
         NEXT_INSTRUCTION();                                                      \
+    }
+
+#define SIMD_MEMORY_STORE_LANE_MEMIDX_M64_OPERATION(opcodeName, opType)             \
+    DEFINE_OPCODE(opcodeName)                                                       \
+        :                                                                           \
+    {                                                                               \
+        using Type = typename SIMDType<opType>::Type;                               \
+        SIMDMemoryStoreMemIdxM64* code = (SIMDMemoryStoreMemIdxM64*)programCounter; \
+        Type result = readValue<Type>(bp, code->src1Offset());                      \
+        opType value = result[code->index()];                                       \
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());              \
+        memories[code->memIndex()]->storeM64(state, offset, code->offset(), value); \
+        ADD_PROGRAM_COUNTER(SIMDMemoryStoreMemIdxM64);                              \
+        NEXT_INSTRUCTION();                                                         \
     }
 
 #define SIMD_EXTRACT_LANE_OPERATION(opcodeName, readType, writeType)         \
@@ -914,6 +1142,19 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                             \
     }
 
+#define ATOMIC_MEMORY_LOAD_M64_OPERATION(opcodeName, readType, writeType)  \
+    DEFINE_OPCODE(opcodeName)                                              \
+        :                                                                  \
+    {                                                                      \
+        MemoryLoadM64* code = (MemoryLoadM64*)programCounter;              \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());      \
+        readType value;                                                    \
+        memories[0]->atomicLoadM64(state, offset, code->offset(), &value); \
+        writeValue<writeType>(bp, code->dstOffset(), value);               \
+        ADD_PROGRAM_COUNTER(MemoryLoadM64);                                \
+        NEXT_INSTRUCTION();                                                \
+    }
+
 #define ATOMIC_MEMORY_LOAD_MEMIDX_OPERATION(opcodeName, readType, writeType)           \
     DEFINE_OPCODE(opcodeName)                                                          \
         :                                                                              \
@@ -925,6 +1166,19 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         writeValue<writeType>(bp, code->dstOffset(), value);                           \
         ADD_PROGRAM_COUNTER(MemoryLoadMemIdx);                                         \
         NEXT_INSTRUCTION();                                                            \
+    }
+
+#define ATOMIC_MEMORY_LOAD_MEMIDX_M64_OPERATION(opcodeName, readType, writeType)          \
+    DEFINE_OPCODE(opcodeName)                                                             \
+        :                                                                                 \
+    {                                                                                     \
+        MemoryLoadMemIdxM64* code = (MemoryLoadMemIdxM64*)programCounter;                 \
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());                     \
+        readType value;                                                                   \
+        memories[code->memIndex()]->atomicLoadM64(state, offset, code->offset(), &value); \
+        writeValue<writeType>(bp, code->dstOffset(), value);                              \
+        ADD_PROGRAM_COUNTER(MemoryLoadMemIdxM64);                                         \
+        NEXT_INSTRUCTION();                                                               \
     }
 
 #define ATOMIC_MEMORY_STORE_32_OPERATION(opcodeName, readType, writeType) \
@@ -939,6 +1193,18 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                               \
     }
 
+#define ATOMIC_MEMORY_STORE_32_M64_OPERATION(opcodeName, readType, writeType) \
+    DEFINE_OPCODE(opcodeName)                                                 \
+        :                                                                     \
+    {                                                                         \
+        MemoryStore32M64* code = (MemoryStore32M64*)programCounter;           \
+        writeType value = readValue<readType>(bp, code->valueOffset());       \
+        uint64_t offset = readValue<uint64_t>(bp, code->dstOffset());         \
+        memories[0]->atomicStoreM64(state, offset, code->offset(), value);    \
+        ADD_PROGRAM_COUNTER(MemoryStore32M64);                                \
+        NEXT_INSTRUCTION();                                                   \
+    }
+
 #define ATOMIC_MEMORY_STORE_64_OPERATION(opcodeName, readType, writeType) \
     DEFINE_OPCODE(opcodeName)                                             \
         :                                                                 \
@@ -949,6 +1215,18 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         memories[0]->atomicStore(state, offset, code->offset(), value);   \
         ADD_PROGRAM_COUNTER(MemoryStore64);                               \
         NEXT_INSTRUCTION();                                               \
+    }
+
+#define ATOMIC_MEMORY_STORE_64_M64_OPERATION(opcodeName, readType, writeType) \
+    DEFINE_OPCODE(opcodeName)                                                 \
+        :                                                                     \
+    {                                                                         \
+        MemoryStore64M64* code = (MemoryStore64M64*)programCounter;           \
+        writeType value = readValue<readType>(bp, code->valueOffset());       \
+        uint64_t offset = readValue<uint64_t>(bp, code->dstOffset());         \
+        memories[0]->atomicStoreM64(state, offset, code->offset(), value);    \
+        ADD_PROGRAM_COUNTER(MemoryStore64M64);                                \
+        NEXT_INSTRUCTION();                                                   \
     }
 
 #define ATOMIC_MEMORY_STORE_MEMIDX_32_OPERATION(opcodeName, readType, writeType)       \
@@ -963,6 +1241,18 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                            \
     }
 
+#define ATOMIC_MEMORY_STORE_MEMIDX_32_M64_OPERATION(opcodeName, readType, writeType)      \
+    DEFINE_OPCODE(opcodeName)                                                             \
+        :                                                                                 \
+    {                                                                                     \
+        MemoryStoreMemIdx32M64* code = (MemoryStoreMemIdx32M64*)programCounter;           \
+        writeType value = readValue<readType>(bp, code->valueOffset());                   \
+        uint64_t offset = readValue<uint64_t>(bp, code->dstOffset());                     \
+        memories[code->memIndex()]->atomicStoreM64(state, offset, code->offset(), value); \
+        ADD_PROGRAM_COUNTER(MemoryStoreMemIdx32M64);                                      \
+        NEXT_INSTRUCTION();                                                               \
+    }
+
 #define ATOMIC_MEMORY_STORE_MEMIDX_64_OPERATION(opcodeName, readType, writeType)       \
     DEFINE_OPCODE(opcodeName)                                                          \
         :                                                                              \
@@ -973,6 +1263,18 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         memories[code->memIndex()]->atomicStore(state, offset, code->offset(), value); \
         ADD_PROGRAM_COUNTER(MemoryStoreMemIdx64);                                      \
         NEXT_INSTRUCTION();                                                            \
+    }
+
+#define ATOMIC_MEMORY_STORE_MEMIDX_64_M64_OPERATION(opcodeName, readType, writeType)      \
+    DEFINE_OPCODE(opcodeName)                                                             \
+        :                                                                                 \
+    {                                                                                     \
+        MemoryStoreMemIdx64M64* code = (MemoryStoreMemIdx64M64*)programCounter;           \
+        writeType value = readValue<readType>(bp, code->valueOffset());                   \
+        uint64_t offset = readValue<uint64_t>(bp, code->dstOffset());                     \
+        memories[code->memIndex()]->atomicStoreM64(state, offset, code->offset(), value); \
+        ADD_PROGRAM_COUNTER(MemoryStoreMemIdx64M64);                                      \
+        NEXT_INSTRUCTION();                                                               \
     }
 
 #define ATOMIC_MEMORY_RMW_OPERATION(opcodeName, R, T, operationName)                       \
@@ -989,6 +1291,20 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                                \
     }
 
+#define ATOMIC_MEMORY_RMW_M64_OPERATION(opcodeName, R, T, operationName)                      \
+    DEFINE_OPCODE(opcodeName)                                                                 \
+        :                                                                                     \
+    {                                                                                         \
+        AtomicRmwM64* code = (AtomicRmwM64*)programCounter;                                   \
+        T value = static_cast<T>(readValue<R>(bp, code->src1Offset()));                       \
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());                        \
+        T old;                                                                                \
+        memories[0]->atomicRmwM64(state, offset, code->offset(), value, &old, operationName); \
+        writeValue<R>(bp, code->dstOffset(), static_cast<R>(old));                            \
+        ADD_PROGRAM_COUNTER(AtomicRmwM64);                                                    \
+        NEXT_INSTRUCTION();                                                                   \
+    }
+
 #define ATOMIC_MEMORY_RMW_MEMIDX_OPERATION(opcodeName, R, T, operationName)                               \
     DEFINE_OPCODE(opcodeName)                                                                             \
         :                                                                                                 \
@@ -1001,6 +1317,20 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         writeValue<R>(bp, code->dstOffset(), static_cast<R>(old));                                        \
         ADD_PROGRAM_COUNTER(AtomicRmwMemIdx);                                                             \
         NEXT_INSTRUCTION();                                                                               \
+    }
+
+#define ATOMIC_MEMORY_RMW_MEMIDX_M64_OPERATION(opcodeName, R, T, operationName)                              \
+    DEFINE_OPCODE(opcodeName)                                                                                \
+        :                                                                                                    \
+    {                                                                                                        \
+        AtomicRmwMemIdxM64* code = (AtomicRmwMemIdxM64*)programCounter;                                      \
+        T value = static_cast<T>(readValue<R>(bp, code->src1Offset()));                                      \
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());                                       \
+        T old;                                                                                               \
+        memories[code->memIndex()]->atomicRmwM64(state, offset, code->offset(), value, &old, operationName); \
+        writeValue<R>(bp, code->dstOffset(), static_cast<R>(old));                                           \
+        ADD_PROGRAM_COUNTER(AtomicRmwMemIdxM64);                                                             \
+        NEXT_INSTRUCTION();                                                                                  \
     }
 
 #define ATOMIC_MEMORY_RMW_CMPXCHG_OPERATION(opcodeName, T, V)                                    \
@@ -1023,6 +1353,26 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                                      \
     }
 
+#define ATOMIC_MEMORY_RMW_CMPXCHG_M64_OPERATION(opcodeName, T, V)                                   \
+    DEFINE_OPCODE(opcodeName)                                                                       \
+        :                                                                                           \
+    {                                                                                               \
+        AtomicRmwCmpxchgM64* code = (AtomicRmwCmpxchgM64*)programCounter;                           \
+        V replace = static_cast<V>(readValue<T>(bp, code->src2Offset()));                           \
+        T expectValue = readValue<T>(bp, code->src1Offset());                                       \
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());                              \
+        V old;                                                                                      \
+        if (expectValue > std::numeric_limits<V>::max()) {                                          \
+            memories[0]->atomicLoadM64(state, offset, code->offset(), &old);                        \
+        } else {                                                                                    \
+            V expect = static_cast<V>(expectValue);                                                 \
+            memories[0]->atomicRmwCmpxchgM64(state, offset, code->offset(), expect, replace, &old); \
+        }                                                                                           \
+        writeValue<T>(bp, code->dstOffset(), static_cast<T>(old));                                  \
+        ADD_PROGRAM_COUNTER(AtomicRmwCmpxchgM64);                                                   \
+        NEXT_INSTRUCTION();                                                                         \
+    }
+
 #define ATOMIC_MEMORY_RMW_CMPXCHG_MEMIDX_OPERATION(opcodeName, T, V)                                            \
     DEFINE_OPCODE(opcodeName)                                                                                   \
         :                                                                                                       \
@@ -1043,6 +1393,25 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
         NEXT_INSTRUCTION();                                                                                     \
     }
 
+#define ATOMIC_MEMORY_RMW_CMPXCHG_MEMIDX_M64_OPERATION(opcodeName, T, V)                                           \
+    DEFINE_OPCODE(opcodeName)                                                                                      \
+        :                                                                                                          \
+    {                                                                                                              \
+        AtomicRmwCmpxchgMemIdxM64* code = (AtomicRmwCmpxchgMemIdxM64*)programCounter;                              \
+        V replace = static_cast<V>(readValue<T>(bp, code->src2Offset()));                                          \
+        T expectValue = readValue<T>(bp, code->src1Offset());                                                      \
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());                                             \
+        V old;                                                                                                     \
+        if (expectValue > std::numeric_limits<V>::max()) {                                                         \
+            memories[code->memIndex()]->atomicLoadM64(state, offset, code->offset(), &old);                        \
+        } else {                                                                                                   \
+            V expect = static_cast<V>(expectValue);                                                                \
+            memories[code->memIndex()]->atomicRmwCmpxchgM64(state, offset, code->offset(), expect, replace, &old); \
+        }                                                                                                          \
+        writeValue<T>(bp, code->dstOffset(), static_cast<T>(old));                                                 \
+        ADD_PROGRAM_COUNTER(AtomicRmwCmpxchgMemIdxM64);                                                            \
+        NEXT_INSTRUCTION();                                                                                        \
+    }
 
 #if defined(WALRUS_ENABLE_COMPUTED_GOTO)
 #if defined(WALRUS_COMPUTED_GOTO_INTERPRETER_INIT_WITH_NULL)
@@ -1124,6 +1493,16 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
+    DEFINE_OPCODE(Load32M64)
+        :
+    {
+        Load32M64* code = (Load32M64*)programCounter;
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());
+        memories[0]->loadM64(state, offset, reinterpret_cast<uint32_t*>(bp + code->dstOffset()));
+        ADD_PROGRAM_COUNTER(Load32M64);
+        NEXT_INSTRUCTION();
+    }
+
     DEFINE_OPCODE(Load64)
         :
     {
@@ -1131,6 +1510,16 @@ NextInstruction:
         uint32_t offset = readValue<uint32_t>(bp, code->srcOffset());
         memories[0]->load(state, offset, reinterpret_cast<uint64_t*>(bp + code->dstOffset()));
         ADD_PROGRAM_COUNTER(Load64);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(Load64M64)
+        :
+    {
+        Load64M64* code = (Load64M64*)programCounter;
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());
+        memories[0]->loadM64(state, offset, reinterpret_cast<uint64_t*>(bp + code->dstOffset()));
+        ADD_PROGRAM_COUNTER(Load64M64);
         NEXT_INSTRUCTION();
     }
 
@@ -1145,6 +1534,17 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
+    DEFINE_OPCODE(Store32M64)
+        :
+    {
+        Store32M64* code = (Store32M64*)programCounter;
+        uint32_t value = readValue<uint32_t>(bp, code->src1Offset());
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());
+        memories[0]->storeM64(state, offset, value);
+        ADD_PROGRAM_COUNTER(Store32M64);
+        NEXT_INSTRUCTION();
+    }
+
     DEFINE_OPCODE(Store64)
         :
     {
@@ -1153,6 +1553,17 @@ NextInstruction:
         uint32_t offset = readValue<uint32_t>(bp, code->src0Offset());
         memories[0]->store(state, offset, value);
         ADD_PROGRAM_COUNTER(Store64);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(Store64M64)
+        :
+    {
+        Store64M64* code = (Store64M64*)programCounter;
+        uint64_t value = readValue<uint64_t>(bp, code->src1Offset());
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());
+        memories[0]->storeM64(state, offset, value);
+        ADD_PROGRAM_COUNTER(Store64M64);
         NEXT_INSTRUCTION();
     }
 
@@ -1394,33 +1805,59 @@ NextInstruction:
     }
 
     FOR_EACH_BYTECODE_LOAD_INT_OP(MEMORY_LOAD_INT_OPERATION)
+    FOR_EACH_BYTECODE_LOAD_INT_M64_OP(MEMORY_LOAD_INT_M64_OPERATION)
     FOR_EACH_BYTECODE_LOAD_FLOAT_OP(MEMORY_LOAD_FLOAT_OPERATION)
+    FOR_EACH_BYTECODE_LOAD_FLOAT_M64_OP(MEMORY_LOAD_FLOAT_M64_OPERATION)
     FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_OP(MEMORY_LOAD_INT_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_LOAD_INT_MEMIDX_M64_OP(MEMORY_LOAD_INT_MEMIDX_M64_OPERATION)
     FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_OP(MEMORY_LOAD_FLOAT_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_LOAD_FLOAT_MEMIDX_M64_OP(MEMORY_LOAD_FLOAT_MEMIDX_M64_OPERATION)
     FOR_EACH_BYTECODE_STORE_32_OP(MEMORY_STORE_32_OPERATION)
+    FOR_EACH_BYTECODE_STORE_32_M64_OP(MEMORY_STORE_32_M64_OPERATION)
     FOR_EACH_BYTECODE_STORE_64_OP(MEMORY_STORE_64_OPERATION)
+    FOR_EACH_BYTECODE_STORE_64_M64_OP(MEMORY_STORE_64_M64_OPERATION)
     FOR_EACH_BYTECODE_STORE_MEMIDX_32_OP(MEMORY_STORE_MEMIDX_32_OPERATION)
+    FOR_EACH_BYTECODE_STORE_MEMIDX_32_M64_OP(MEMORY_STORE_MEMIDX_32_M64_OPERATION)
     FOR_EACH_BYTECODE_STORE_MEMIDX_64_OP(MEMORY_STORE_MEMIDX_64_OPERATION)
+    FOR_EACH_BYTECODE_STORE_MEMIDX_64_M64_OP(MEMORY_STORE_MEMIDX_64_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_OP(SIMD_MEMORY_LOAD_SPLAT_OPERATION)
+    FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_M64_OP(SIMD_MEMORY_LOAD_SPLAT_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_MEMIDX_OP(SIMD_MEMORY_LOAD_SPLAT_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_SIMD_LOAD_SPLAT_MEMIDX_M64_OP(SIMD_MEMORY_LOAD_SPLAT_MEMIDX_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_OP(SIMD_MEMORY_LOAD_EXTEND_OPERATION)
+    FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_M64_OP(SIMD_MEMORY_LOAD_EXTEND_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_MEMIDX_OP(SIMD_MEMORY_LOAD_EXTEND_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_SIMD_LOAD_EXTEND_MEMIDX_M64_OP(SIMD_MEMORY_LOAD_EXTEND_MEMIDX_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_LOAD_LANE_OP(SIMD_MEMORY_LOAD_LANE_OPERATION)
+    FOR_EACH_BYTECODE_SIMD_LOAD_LANE_M64_OP(SIMD_MEMORY_LOAD_LANE_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_LOAD_LANE_MEMIDX_OP(SIMD_MEMORY_LOAD_LANE_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_SIMD_LOAD_LANE_MEMIDX_M64_OP(SIMD_MEMORY_LOAD_LANE_MEMIDX_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_STORE_LANE_OP(SIMD_MEMORY_STORE_LANE_OPERATION)
+    FOR_EACH_BYTECODE_SIMD_STORE_LANE_M64_OP(SIMD_MEMORY_STORE_LANE_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_STORE_LANE_MEMIDX_OP(SIMD_MEMORY_STORE_LANE_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_SIMD_STORE_LANE_MEMIDX_M64_OP(SIMD_MEMORY_STORE_LANE_MEMIDX_M64_OPERATION)
     FOR_EACH_BYTECODE_SIMD_EXTRACT_LANE_OP(SIMD_EXTRACT_LANE_OPERATION)
     FOR_EACH_BYTECODE_SIMD_REPLACE_LANE_OP(SIMD_REPLACE_LANE_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_LOAD_OP(ATOMIC_MEMORY_LOAD_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_LOAD_M64_OP(ATOMIC_MEMORY_LOAD_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_LOAD_MEMIDX_OP(ATOMIC_MEMORY_LOAD_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_LOAD_MEMIDX_M64_OP(ATOMIC_MEMORY_LOAD_MEMIDX_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_STORE_32_OP(ATOMIC_MEMORY_STORE_32_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_STORE_32_M64_OP(ATOMIC_MEMORY_STORE_32_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_STORE_64_OP(ATOMIC_MEMORY_STORE_64_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_STORE_64_M64_OP(ATOMIC_MEMORY_STORE_64_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_OP(ATOMIC_MEMORY_STORE_MEMIDX_32_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_32_M64_OP(ATOMIC_MEMORY_STORE_MEMIDX_32_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_OP(ATOMIC_MEMORY_STORE_MEMIDX_64_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_STORE_MEMIDX_64_M64_OP(ATOMIC_MEMORY_STORE_MEMIDX_64_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_RMW_OP(ATOMIC_MEMORY_RMW_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_RMW_M64_OP(ATOMIC_MEMORY_RMW_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_RMW_MEMIDX_OP(ATOMIC_MEMORY_RMW_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_RMW_MEMIDX_M64_OP(ATOMIC_MEMORY_RMW_MEMIDX_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_OP(ATOMIC_MEMORY_RMW_CMPXCHG_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_M64_OP(ATOMIC_MEMORY_RMW_CMPXCHG_M64_OPERATION)
     FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_MEMIDX_OP(ATOMIC_MEMORY_RMW_CMPXCHG_MEMIDX_OPERATION)
+    FOR_EACH_BYTECODE_ATOMIC_RMW_CMPXCHG_MEMIDX_M64_OP(ATOMIC_MEMORY_RMW_CMPXCHG_MEMIDX_M64_OPERATION)
 
     DEFINE_OPCODE(MemoryAtomicWait32)
         :
@@ -1433,6 +1870,20 @@ NextInstruction:
         memories[0]->atomicWait(state, instance->module()->store(), offset, code->offset(), expect, timeOut, &result);
         writeValue<uint32_t>(bp, code->dstOffset(), result);
         ADD_PROGRAM_COUNTER(MemoryAtomicWait32);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(MemoryAtomicWait32M64)
+        :
+    {
+        MemoryAtomicWait32M64* code = (MemoryAtomicWait32M64*)programCounter;
+        int64_t timeOut = readValue<int64_t>(bp, code->src2Offset());
+        uint32_t expect = readValue<uint32_t>(bp, code->src1Offset());
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());
+        uint32_t result;
+        memories[0]->atomicWaitM64(state, instance->module()->store(), offset, code->offset(), expect, timeOut, &result);
+        writeValue<uint32_t>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(MemoryAtomicWait32M64);
         NEXT_INSTRUCTION();
     }
 
@@ -1450,6 +1901,20 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
+    DEFINE_OPCODE(MemoryAtomicWait32MemIdxM64)
+        :
+    {
+        MemoryAtomicWait32MemIdxM64* code = (MemoryAtomicWait32MemIdxM64*)programCounter;
+        int64_t timeOut = readValue<int64_t>(bp, code->src2Offset());
+        uint32_t expect = readValue<uint32_t>(bp, code->src1Offset());
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());
+        uint32_t result;
+        memories[code->memIndex()]->atomicWaitM64(state, instance->module()->store(), offset, code->offset(), expect, timeOut, &result);
+        writeValue<uint32_t>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(MemoryAtomicWait32MemIdxM64);
+        NEXT_INSTRUCTION();
+    }
+
     DEFINE_OPCODE(MemoryAtomicWait64)
         :
     {
@@ -1461,6 +1926,20 @@ NextInstruction:
         memories[0]->atomicWait(state, instance->module()->store(), offset, code->offset(), expect, timeOut, &result);
         writeValue<uint32_t>(bp, code->dstOffset(), result);
         ADD_PROGRAM_COUNTER(MemoryAtomicWait64);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(MemoryAtomicWait64M64)
+        :
+    {
+        MemoryAtomicWait64M64* code = (MemoryAtomicWait64M64*)programCounter;
+        int64_t timeOut = readValue<int64_t>(bp, code->src2Offset());
+        uint64_t expect = readValue<uint64_t>(bp, code->src1Offset());
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());
+        uint32_t result;
+        memories[0]->atomicWaitM64(state, instance->module()->store(), offset, code->offset(), expect, timeOut, &result);
+        writeValue<uint32_t>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(MemoryAtomicWait64M64);
         NEXT_INSTRUCTION();
     }
 
@@ -1478,6 +1957,20 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
+    DEFINE_OPCODE(MemoryAtomicWait64MemIdxM64)
+        :
+    {
+        MemoryAtomicWait64MemIdxM64* code = (MemoryAtomicWait64MemIdxM64*)programCounter;
+        int64_t timeOut = readValue<int64_t>(bp, code->src2Offset());
+        uint64_t expect = readValue<uint64_t>(bp, code->src1Offset());
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());
+        uint32_t result;
+        memories[code->memIndex()]->atomicWaitM64(state, instance->module()->store(), offset, code->offset(), expect, timeOut, &result);
+        writeValue<uint32_t>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(MemoryAtomicWait64MemIdxM64);
+        NEXT_INSTRUCTION();
+    }
+
     DEFINE_OPCODE(MemoryAtomicNotify)
         :
     {
@@ -1491,6 +1984,19 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
+    DEFINE_OPCODE(MemoryAtomicNotifyM64)
+        :
+    {
+        MemoryAtomicNotifyM64* code = (MemoryAtomicNotifyM64*)programCounter;
+        uint32_t count = readValue<uint32_t>(bp, code->src1Offset());
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());
+        uint32_t result;
+        memories[0]->atomicNotifyM64(state, instance->module()->store(), offset, code->offset(), count, &result);
+        writeValue<uint32_t>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(MemoryAtomicNotifyM64);
+        NEXT_INSTRUCTION();
+    }
+
     DEFINE_OPCODE(MemoryAtomicNotifyMemIdx)
         :
     {
@@ -1501,6 +2007,19 @@ NextInstruction:
         memories[code->memIndex()]->atomicNotify(state, instance->module()->store(), offset, code->offset(), count, &result);
         writeValue<uint32_t>(bp, code->dstOffset(), result);
         ADD_PROGRAM_COUNTER(MemoryAtomicNotifyMemIdx);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(MemoryAtomicNotifyMemIdxM64)
+        :
+    {
+        MemoryAtomicNotifyMemIdxM64* code = (MemoryAtomicNotifyMemIdxM64*)programCounter;
+        uint32_t count = readValue<uint32_t>(bp, code->src1Offset());
+        uint64_t offset = readValue<uint64_t>(bp, code->src0Offset());
+        uint32_t result;
+        memories[code->memIndex()]->atomicNotifyM64(state, instance->module()->store(), offset, code->offset(), count, &result);
+        writeValue<uint32_t>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(MemoryAtomicNotifyMemIdxM64);
         NEXT_INSTRUCTION();
     }
 
@@ -1537,6 +2056,22 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
+    DEFINE_OPCODE(V128Load32ZeroM64)
+        :
+    {
+        using Type = typename SIMDType<uint32_t>::Type;
+        V128Load32ZeroM64* code = (V128Load32ZeroM64*)programCounter;
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());
+        uint32_t value;
+        memories[0]->loadM64(state, offset, code->offset(), &value);
+        Type result;
+        std::fill(std::begin(result.v), std::end(result.v), 0);
+        result[0] = value;
+        writeValue<Type>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(V128Load32ZeroM64);
+        NEXT_INSTRUCTION();
+    }
+
     DEFINE_OPCODE(V128Load32ZeroMemIdx)
         :
     {
@@ -1550,6 +2085,22 @@ NextInstruction:
         result[0] = value;
         writeValue<Type>(bp, code->dstOffset(), result);
         ADD_PROGRAM_COUNTER(V128Load32ZeroMemIdx);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(V128Load32ZeroMemIdxM64)
+        :
+    {
+        using Type = typename SIMDType<uint32_t>::Type;
+        uint32_t value;
+        Type result;
+        V128Load32ZeroMemIdxM64* code = (V128Load32ZeroMemIdxM64*)programCounter;
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());
+        memories[code->memIndex()]->loadM64(state, offset, code->offset(), &value);
+        std::fill(std::begin(result.v), std::end(result.v), 0);
+        result[0] = value;
+        writeValue<Type>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(V128Load32ZeroMemIdxM64);
         NEXT_INSTRUCTION();
     }
 
@@ -1569,6 +2120,22 @@ NextInstruction:
         NEXT_INSTRUCTION();
     }
 
+    DEFINE_OPCODE(V128Load64ZeroM64)
+        :
+    {
+        using Type = typename SIMDType<uint64_t>::Type;
+        V128Load64ZeroM64* code = (V128Load64ZeroM64*)programCounter;
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());
+        uint64_t value;
+        memories[0]->loadM64(state, offset, code->offset(), &value);
+        Type result;
+        std::fill(std::begin(result.v), std::end(result.v), 0);
+        result[0] = value;
+        writeValue<Type>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(V128Load64ZeroM64);
+        NEXT_INSTRUCTION();
+    }
+
     DEFINE_OPCODE(V128Load64ZeroMemIdx)
         :
     {
@@ -1582,6 +2149,22 @@ NextInstruction:
         result[0] = value;
         writeValue<Type>(bp, code->dstOffset(), result);
         ADD_PROGRAM_COUNTER(V128Load64ZeroMemIdx);
+        NEXT_INSTRUCTION();
+    }
+
+    DEFINE_OPCODE(V128Load64ZeroMemIdxM64)
+        :
+    {
+        using Type = typename SIMDType<uint64_t>::Type;
+        uint64_t value;
+        Type result;
+        V128Load64ZeroMemIdxM64* code = (V128Load64ZeroMemIdxM64*)programCounter;
+        uint64_t offset = readValue<uint64_t>(bp, code->srcOffset());
+        memories[code->memIndex()]->loadM64(state, offset, code->offset(), &value);
+        std::fill(std::begin(result.v), std::end(result.v), 0);
+        result[0] = value;
+        writeValue<Type>(bp, code->dstOffset(), result);
+        ADD_PROGRAM_COUNTER(V128Load64ZeroMemIdxM64);
         NEXT_INSTRUCTION();
     }
 

--- a/src/runtime/Module.cpp
+++ b/src/runtime/Module.cpp
@@ -267,7 +267,8 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
 
     // init memory
     while (memIndex < m_memoryTypes.size()) {
-        instance->m_memories[memIndex] = Memory::createMemory(m_store, m_memoryTypes[memIndex]->initialSize() * Memory::s_memoryPageSize, m_memoryTypes[memIndex]->maximumSize() * Memory::s_memoryPageSize, m_memoryTypes[memIndex]->isShared());
+        instance->m_memories[memIndex] = Memory::createMemory(m_store, m_memoryTypes[memIndex]->initialSize() * Memory::s_memoryPageSize, m_memoryTypes[memIndex]->maximumSize() * Memory::s_memoryPageSize,
+                                                              m_memoryTypes[memIndex]->isShared(), m_memoryTypes[memIndex]->is64());
         memIndex++;
     }
 

--- a/src/runtime/ObjectType.h
+++ b/src/runtime/ObjectType.h
@@ -302,23 +302,26 @@ private:
 
 class MemoryType : public ObjectType {
 public:
-    MemoryType(uint64_t initSize, uint64_t maxSize, bool isShared)
+    MemoryType(uint64_t initSize, uint64_t maxSize, bool isShared, bool is64)
         : ObjectType(ObjectType::MemoryKind)
         , m_initialSize(initSize)
         , m_maximumSize(maxSize)
         , m_isShared(isShared)
+        , m_is64(is64)
     {
     }
 
     uint64_t initialSize() const { return m_initialSize; }
     uint64_t maximumSize() const { return m_maximumSize; }
     bool isShared() const { return m_isShared; }
+    bool is64() const { return m_is64; }
 
 private:
     // size should be uint64_t type
     uint64_t m_initialSize;
     uint64_t m_maximumSize;
     bool m_isShared;
+    bool m_is64;
 };
 
 class TagType : public ObjectType {

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -268,7 +268,7 @@ static Trap::TrapResult executeWASM(Store* store, const std::string& filename, c
             } else if (import->fieldName() == "table") {
                 importValues.push_back(Table::createTable(store, Value::Type::NullFuncRef, 10, 20));
             } else if (import->fieldName() == "memory") {
-                importValues.push_back(Memory::createMemory(store, 1 * Memory::s_memoryPageSize, 2 * Memory::s_memoryPageSize, false));
+                importValues.push_back(Memory::createMemory(store, 1 * Memory::s_memoryPageSize, 2 * Memory::s_memoryPageSize, false, false));
             } else {
                 // import wrong value for test
                 auto ft = functionTypes[DefinedFunctionTypes::INVALID];

--- a/src/util/BitOperation.h
+++ b/src/util/BitOperation.h
@@ -24,6 +24,8 @@
 
 namespace Walrus {
 
+// The memcpyEndianAware uses size_t arguments,
+// which makes 32/64 bit variants unnecessary.
 #if defined(WALRUS_BIG_ENDIAN)
 inline void memcpyEndianAware(void* dst,
                               const void* src,

--- a/test/web-assembly3/jit/memory64_memoptypes.wast
+++ b/test/web-assembly3/jit/memory64_memoptypes.wast
@@ -1,0 +1,1504 @@
+(module
+    (memory i64 1)
+
+    ;; i32
+    (func (export "i32.store") (param i64 i32) (i32.store (local.get 0) (local.get 1)))
+    (func (export "i32.load") (param i64) (result i32) (i32.load (local.get 0)))
+
+    (func (export "i32.store_2") (param i64 i32) (i32.store offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.load_2") (param i64) (result i32) (i32.load offset=16 (local.get 0)))
+
+    (func (export "i32.store_3") (param i64 i32) (i32.store offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.load_3") (param i64) (result i32) (i32.load offset=0x100000000 (local.get 0)))
+
+    ;; i32_8
+    (func (export "i32.store8") (param i64 i32) (i32.store8 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.load8u") (param i64) (result i32) (i32.load8_u offset=16 (local.get 0)))
+    (func (export "i32.load8s") (param i64) (result i32) (i32.load8_s offset=16 (local.get 0)))
+
+    (func (export "i32.store8_2") (param i64 i32) (i32.store8 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.load8u_2") (param i64) (result i32) (i32.load8_u offset=0x100000000 (local.get 0)))
+    (func (export "i32.load8s_2") (param i64) (result i32) (i32.load8_s offset=0x100000000 (local.get 0)))
+
+    ;; i32_16
+    (func (export "i32.store16") (param i64 i32) (i32.store16 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.load16u") (param i64) (result i32) (i32.load16_u offset=16 (local.get 0)))
+    (func (export "i32.load16s") (param i64) (result i32) (i32.load16_s offset=16 (local.get 0)))
+
+    (func (export "i32.store16_2") (param i64 i32) (i32.store16 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.load16u_2") (param i64) (result i32) (i32.load16_u offset=0x100000000 (local.get 0)))
+    (func (export "i32.load16s_2") (param i64) (result i32) (i32.load16_s offset=0x100000000 (local.get 0)))
+
+    ;; i64
+    (func (export "i64.store") (param i64 i64) (i64.store (local.get 0) (local.get 1)))
+    (func (export "i64.load") (param i64) (result i64) (i64.load (local.get 0)))
+
+    (func (export "i64.store_2") (param i64 i64) (i64.store offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.load_2") (param i64) (result i64) (i64.load offset=16 (local.get 0)))
+
+    (func (export "i64.store_3") (param i64 i64) (i64.store offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.load_3") (param i64) (result i64) (i64.load offset=0x100000000 (local.get 0)))
+
+    ;; i64_8
+    (func (export "i64.store8") (param i64 i64) (i64.store8 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.load8u") (param i64) (result i64) (i64.load8_u offset=16 (local.get 0)))
+    (func (export "i64.load8s") (param i64) (result i64) (i64.load8_s offset=16 (local.get 0)))
+
+    (func (export "i64.store8_2") (param i64 i64) (i64.store8 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.load8u_2") (param i64) (result i64) (i64.load8_u offset=0x100000000 (local.get 0)))
+    (func (export "i64.load8s_2") (param i64) (result i64) (i64.load8_s offset=0x100000000 (local.get 0)))
+
+    ;; i64_16
+    (func (export "i64.store16") (param i64 i64) (i64.store16 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.load16u") (param i64) (result i64) (i64.load16_u offset=16 (local.get 0)))
+    (func (export "i64.load16s") (param i64) (result i64) (i64.load16_s offset=16 (local.get 0)))
+
+    (func (export "i64.store16_2") (param i64 i64) (i64.store16 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.load16u_2") (param i64) (result i64) (i64.load16_u offset=0x100000000 (local.get 0)))
+    (func (export "i64.load16s_2") (param i64) (result i64) (i64.load16_s offset=0x100000000 (local.get 0)))
+
+    ;; i64_32
+    (func (export "i64.store32") (param i64 i64) (i64.store32 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.load32u") (param i64) (result i64) (i64.load32_u offset=16 (local.get 0)))
+    (func (export "i64.load32s") (param i64) (result i64) (i64.load32_s offset=16 (local.get 0)))
+
+    (func (export "i64.store32_2") (param i64 i64) (i64.store32 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.load32u_2") (param i64) (result i64) (i64.load32_u offset=0x100000000 (local.get 0)))
+    (func (export "i64.load32s_2") (param i64) (result i64) (i64.load32_s offset=0x100000000 (local.get 0)))
+
+    ;; f32
+    (func (export "f32.store") (param i64 f32) (f32.store offset=16 (local.get 0) (local.get 1)))
+    (func (export "f32.load") (param i64) (result f32) (f32.load offset=16 (local.get 0)))
+
+    (func (export "f32.store_2") (param i64 f32) (f32.store offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "f32.load_2") (param i64) (result f32) (f32.load offset=0x100000000 (local.get 0)))
+
+    ;; f64
+    (func (export "f64.store") (param i64 f64) (f64.store offset=16 (local.get 0) (local.get 1)))
+    (func (export "f64.load") (param i64) (result f64) (f64.load offset=16 (local.get 0)))
+
+    (func (export "f64.store_2") (param i64 f64) (f64.store offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "f64.load_2") (param i64) (result f64) (f64.load offset=0x100000000 (local.get 0)))
+
+    ;; v128
+    (func (export "v128.store") (param i64 v128) (v128.store offset=16 (local.get 0) (local.get 1)))
+    (func (export "v128.load") (param i64) (result v128) (v128.load offset=16 (local.get 0)))
+
+    (func (export "v128.store_2") (param i64 v128) (v128.store offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "v128.load_2") (param i64) (result v128) (v128.load offset=0x100000000 (local.get 0)))
+
+    ;; v128 8x8
+    (func (export "v128.load8x8s") (param i64) (result v128) (v128.load8x8_s offset=16 (local.get 0)))
+    (func (export "v128.load8x8u") (param i64) (result v128) (v128.load8x8_u offset=16 (local.get 0)))
+
+    (func (export "v128.load8x8s_2") (param i64) (result v128) (v128.load8x8_s offset=0x100000000 (local.get 0)))
+    (func (export "v128.load8x8u_2") (param i64) (result v128) (v128.load8x8_u offset=0x100000000 (local.get 0)))
+
+    ;; v128 16x4
+    (func (export "v128.load16x4s") (param i64) (result v128) (v128.load16x4_s offset=16 (local.get 0)))
+    (func (export "v128.load16x4u") (param i64) (result v128) (v128.load16x4_u offset=16 (local.get 0)))
+
+    (func (export "v128.load16x4s_2") (param i64) (result v128) (v128.load16x4_s offset=0x100000000 (local.get 0)))
+    (func (export "v128.load16x4u_2") (param i64) (result v128) (v128.load16x4_u offset=0x100000000 (local.get 0)))
+
+    ;; v128 32x2
+    (func (export "v128.load32x2s") (param i64) (result v128) (v128.load32x2_s offset=16 (local.get 0)))
+    (func (export "v128.load32x2u") (param i64) (result v128) (v128.load32x2_u offset=16 (local.get 0)))
+
+    (func (export "v128.load32x2s_2") (param i64) (result v128) (v128.load32x2_s offset=0x100000000 (local.get 0)))
+    (func (export "v128.load32x2u_2") (param i64) (result v128) (v128.load32x2_u offset=0x100000000 (local.get 0)))
+
+    ;; v128 splat
+    (func (export "v128.load8splat") (param i64) (result v128) (v128.load8_splat offset=16 (local.get 0)))
+    (func (export "v128.load16splat") (param i64) (result v128) (v128.load16_splat offset=16 (local.get 0)))
+    (func (export "v128.load32splat") (param i64) (result v128) (v128.load32_splat offset=16 (local.get 0)))
+    (func (export "v128.load64splat") (param i64) (result v128) (v128.load64_splat offset=16 (local.get 0)))
+
+    (func (export "v128.load8splat_2") (param i64) (result v128) (v128.load8_splat offset=0x100000000 (local.get 0)))
+    (func (export "v128.load16splat_2") (param i64) (result v128) (v128.load16_splat offset=0x100000000 (local.get 0)))
+    (func (export "v128.load32splat_2") (param i64) (result v128) (v128.load32_splat offset=0x100000000 (local.get 0)))
+    (func (export "v128.load64splat_2") (param i64) (result v128) (v128.load64_splat offset=0x100000000 (local.get 0)))
+
+    ;; v128 lane 8
+    (func (export "v128.store8lane") (param i64 v128) (v128.store8_lane offset=16 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load8lane") (param i64) (result v128) (v128.load8_lane offset=16 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    (func (export "v128.store8lane_2") (param i64 v128) (v128.store8_lane offset=0x100000000 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load8lane_2") (param i64) (result v128) (v128.load8_lane offset=0x100000000 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    ;; v128 lane 16
+    (func (export "v128.store16lane") (param i64 v128) (v128.store16_lane offset=16 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load16lane") (param i64) (result v128) (v128.load16_lane offset=16 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    (func (export "v128.store16lane_2") (param i64 v128) (v128.store16_lane offset=0x100000000 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load16lane_2") (param i64) (result v128) (v128.load16_lane offset=0x100000000 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    ;; v128 lane 32
+    (func (export "v128.store32lane") (param i64 v128) (v128.store32_lane offset=16 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load32lane") (param i64) (result v128) (v128.load32_lane offset=16 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    (func (export "v128.store32lane_2") (param i64 v128) (v128.store32_lane offset=0x100000000 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load32lane_2") (param i64) (result v128) (v128.load32_lane offset=0x100000000 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    ;; v128 lane 64
+    (func (export "v128.store64lane") (param i64 v128) (v128.store64_lane offset=16 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load64lane") (param i64) (result v128) (v128.load64_lane offset=16 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    (func (export "v128.store64lane_2") (param i64 v128) (v128.store64_lane offset=0x100000000 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load64lane_2") (param i64) (result v128) (v128.load64_lane offset=0x100000000 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    ;; v128 load zero
+    (func (export "v128.load32zero") (param i64) (result v128) (v128.load32_zero offset=16 (local.get 0)))
+    (func (export "v128.load64zero") (param i64) (result v128) (v128.load64_zero offset=16 (local.get 0)))
+
+    (func (export "v128.load32zero_2") (param i64) (result v128) (v128.load32_zero offset=0x100000000 (local.get 0)))
+    (func (export "v128.load64zero_2") (param i64) (result v128) (v128.load64_zero offset=0x100000000 (local.get 0)))
+
+    ;; atomic core
+    (func (export "atomic.notify") (param i64) (drop (memory.atomic.notify offset=16 (local.get 0) (i32.const 0))))
+    (func (export "memory.atomic.wait32") (param i64) (drop (memory.atomic.wait32 offset=16 (local.get 0) (i32.const 0) (i64.const 0))))
+    (func (export "memory.atomic.wait64") (param i64) (drop (memory.atomic.wait64 offset=16 (local.get 0) (i64.const 0) (i64.const 0))))
+
+    (func (export "atomic.notify_2") (param i64) (drop (memory.atomic.notify offset=0x100000000 (local.get 0) (i32.const 0))))
+    (func (export "memory.atomic.wait32_2") (param i64) (drop (memory.atomic.wait32 offset=0x100000000 (local.get 0) (i32.const 0) (i64.const 0))))
+    (func (export "memory.atomic.wait64_2") (param i64) (drop (memory.atomic.wait64 offset=0x100000000 (local.get 0) (i64.const 0) (i64.const 0))))
+
+    ;; i32 atomic
+    (func (export "i32.atomic.store") (param i64 i32) (i32.atomic.store offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load") (param i64) (result i32) (i32.atomic.load offset=16 (local.get 0)))
+
+    (func (export "i32.atomic.store_2") (param i64 i32) (i32.atomic.store offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load_2") (param i64) (result i32) (i32.atomic.load offset=0x100000000 (local.get 0)))
+
+    ;; i32 atomic 8
+    (func (export "i32.atomic.store8") (param i64 i32) (i32.atomic.store8 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load8") (param i64) (result i32) (i32.atomic.load8_u offset=16 (local.get 0)))
+
+    (func (export "i32.atomic.store8_2") (param i64 i32) (i32.atomic.store8 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load8_2") (param i64) (result i32) (i32.atomic.load8_u offset=0x100000000 (local.get 0)))
+
+    ;; i32 atomic 16
+    (func (export "i32.atomic.store16") (param i64 i32) (i32.atomic.store16 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load16") (param i64) (result i32) (i32.atomic.load16_u offset=16 (local.get 0)))
+
+    (func (export "i32.atomic.store16_2") (param i64 i32) (i32.atomic.store16 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load16_2") (param i64) (result i32) (i32.atomic.load16_u offset=0x100000000 (local.get 0)))
+
+    ;; i64 atomic
+    (func (export "i64.atomic.store") (param i64 i64) (i64.atomic.store offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load") (param i64) (result i64) (i64.atomic.load offset=16 (local.get 0)))
+
+    (func (export "i64.atomic.store_2") (param i64 i64) (i64.atomic.store offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load_2") (param i64) (result i64) (i64.atomic.load offset=0x100000000 (local.get 0)))
+
+    ;; i64 atomic 8
+    (func (export "i64.atomic.store8") (param i64 i64) (i64.atomic.store8 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load8") (param i64) (result i64) (i64.atomic.load8_u offset=16 (local.get 0)))
+
+    (func (export "i64.atomic.store8_2") (param i64 i64) (i64.atomic.store8 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load8_2") (param i64) (result i64) (i64.atomic.load8_u offset=0x100000000 (local.get 0)))
+
+    ;; i64 atomic 16
+    (func (export "i64.atomic.store16") (param i64 i64) (i64.atomic.store16 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load16") (param i64) (result i64) (i64.atomic.load16_u offset=16 (local.get 0)))
+
+    (func (export "i64.atomic.store16_2") (param i64 i64) (i64.atomic.store16 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load16_2") (param i64) (result i64) (i64.atomic.load16_u offset=0x100000000 (local.get 0)))
+
+    ;; i64 atomic 32
+    (func (export "i64.atomic.store32") (param i64 i64) (i64.atomic.store32 offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load32") (param i64) (result i64) (i64.atomic.load32_u offset=16 (local.get 0)))
+
+    (func (export "i64.atomic.store32_2") (param i64 i64) (i64.atomic.store32 offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load32_2") (param i64) (result i64) (i64.atomic.load32_u offset=0x100000000 (local.get 0)))
+
+    ;; i32 atomic rmw
+    (func (export "i32.atomic.rmw.add") (param i64 i32) (result i32) (i32.atomic.rmw.add offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw.sub") (param i64 i32) (result i32) (i32.atomic.rmw.sub offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i32.atomic.rmw.add_2") (param i64 i32) (result i32) (i32.atomic.rmw.add offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw.sub_2") (param i64 i32) (result i32) (i32.atomic.rmw.sub offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i32 atomic rmw 8
+    (func (export "i32.atomic.rmw8.or") (param i64 i32) (result i32) (i32.atomic.rmw8.or_u offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw8.xor") (param i64 i32) (result i32) (i32.atomic.rmw8.xor_u offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i32.atomic.rmw8.or_2") (param i64 i32) (result i32) (i32.atomic.rmw8.or_u offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw8.xor_2") (param i64 i32) (result i32) (i32.atomic.rmw8.xor_u offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i32 atomic rmw 16
+    (func (export "i32.atomic.rmw16.or") (param i64 i32) (result i32) (i32.atomic.rmw16.or_u offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw16.and") (param i64 i32) (result i32) (i32.atomic.rmw16.and_u offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i32.atomic.rmw16.or_2") (param i64 i32) (result i32) (i32.atomic.rmw16.or_u offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw16.and_2") (param i64 i32) (result i32) (i32.atomic.rmw16.and_u offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic rmw
+    (func (export "i64.atomic.rmw.add") (param i64 i64) (result i64) (i64.atomic.rmw.add offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw.sub") (param i64 i64) (result i64) (i64.atomic.rmw.sub offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw.add_2") (param i64 i64) (result i64) (i64.atomic.rmw.add offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw.sub_2") (param i64 i64) (result i64) (i64.atomic.rmw.sub offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic rmw 8
+    (func (export "i64.atomic.rmw8.or") (param i64 i64) (result i64) (i64.atomic.rmw8.or_u offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw8.xor") (param i64 i64) (result i64) (i64.atomic.rmw8.xor_u offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw8.or_2") (param i64 i64) (result i64) (i64.atomic.rmw8.or_u offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw8.xor_2") (param i64 i64) (result i64) (i64.atomic.rmw8.xor_u offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic rmw 16
+    (func (export "i64.atomic.rmw16.or") (param i64 i64) (result i64) (i64.atomic.rmw16.or_u offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw16.and") (param i64 i64) (result i64) (i64.atomic.rmw16.and_u offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw16.or_2") (param i64 i64) (result i64) (i64.atomic.rmw16.or_u offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw16.and_2") (param i64 i64) (result i64) (i64.atomic.rmw16.and_u offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic rmw 32
+    (func (export "i64.atomic.rmw32.add") (param i64 i64) (result i64) (i64.atomic.rmw32.add_u offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw32.and") (param i64 i64) (result i64) (i64.atomic.rmw32.and_u offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw32.add_2") (param i64 i64) (result i64) (i64.atomic.rmw32.add_u offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw32.and_2") (param i64 i64) (result i64) (i64.atomic.rmw32.and_u offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i32 atomic Xchg
+    (func (export "i32.atomic.rmw.xchg") (param i64 i32) (result i32) (i32.atomic.rmw.xchg offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw8.xchg") (param i64 i32) (result i32) (i32.atomic.rmw8.xchg_u offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw16.xchg") (param i64 i32) (result i32) (i32.atomic.rmw16.xchg_u offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i32.atomic.rmw.xchg_2") (param i64 i32) (result i32) (i32.atomic.rmw.xchg offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw8.xchg_2") (param i64 i32) (result i32) (i32.atomic.rmw8.xchg_u offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw16.xchg_2") (param i64 i32) (result i32) (i32.atomic.rmw16.xchg_u offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic Xchg
+    (func (export "i64.atomic.rmw.xchg") (param i64 i64) (result i64) (i64.atomic.rmw.xchg offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw8.xchg") (param i64 i64) (result i64) (i64.atomic.rmw8.xchg_u offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw16.xchg") (param i64 i64) (result i64) (i64.atomic.rmw16.xchg_u offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw32.xchg") (param i64 i64) (result i64) (i64.atomic.rmw32.xchg_u offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw.xchg_2") (param i64 i64) (result i64) (i64.atomic.rmw.xchg offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw8.xchg_2") (param i64 i64) (result i64) (i64.atomic.rmw8.xchg_u offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw16.xchg_2") (param i64 i64) (result i64) (i64.atomic.rmw16.xchg_u offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw32.xchg_2") (param i64 i64) (result i64) (i64.atomic.rmw32.xchg_u offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i32 atomic Cmpxchg
+    (func (export "i32.atomic.rmw.cmpxchg") (param i64 i32 i32) (result i32) (i32.atomic.rmw.cmpxchg offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i32.atomic.rmw8.cmpxchg") (param i64 i32 i32) (result i32) (i32.atomic.rmw8.cmpxchg_u offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i32.atomic.rmw16.cmpxchg") (param i64 i32 i32) (result i32) (i32.atomic.rmw16.cmpxchg_u offset=16 (local.get 0) (local.get 1) (local.get 2)))
+
+    (func (export "i32.atomic.rmw.cmpxchg_2") (param i64 i32 i32) (result i32) (i32.atomic.rmw.cmpxchg offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i32.atomic.rmw8.cmpxchg_2") (param i64 i32 i32) (result i32) (i32.atomic.rmw8.cmpxchg_u offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i32.atomic.rmw16.cmpxchg_2") (param i64 i32 i32) (result i32) (i32.atomic.rmw16.cmpxchg_u offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+
+    ;; i64 atomic Cmpxchg
+    (func (export "i64.atomic.rmw.cmpxchg") (param i64 i64 i64) (result i64) (i64.atomic.rmw.cmpxchg offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw8.cmpxchg") (param i64 i64 i64) (result i64) (i64.atomic.rmw8.cmpxchg_u offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw16.cmpxchg") (param i64 i64 i64) (result i64) (i64.atomic.rmw16.cmpxchg_u offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw32.cmpxchg") (param i64 i64 i64) (result i64) (i64.atomic.rmw32.cmpxchg_u offset=16 (local.get 0) (local.get 1) (local.get 2)))
+
+    (func (export "i64.atomic.rmw.cmpxchg_2") (param i64 i64 i64) (result i64) (i64.atomic.rmw.cmpxchg offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw8.cmpxchg_2") (param i64 i64 i64) (result i64) (i64.atomic.rmw8.cmpxchg_u offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw16.cmpxchg_2") (param i64 i64 i64) (result i64) (i64.atomic.rmw16.cmpxchg_u offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw32.cmpxchg_2") (param i64 i64 i64) (result i64) (i64.atomic.rmw32.cmpxchg_u offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+)
+
+;; i32
+(assert_return (invoke "i32.store" (i64.const 0x10) (i32.const 1234)))
+(assert_return (invoke "i32.load" (i64.const 0x10)) (i32.const 1234))
+(assert_trap (invoke "i32.store" (i64.const 0x100000010) (i32.const 1234)) "out of bounds memory access")
+(assert_trap (invoke "i32.load" (i64.const 0x100000010)) "out of bounds memory access")
+
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 4321)))
+(assert_return (invoke "i32.load_2" (i64.const 0x10)) (i32.const 4321))
+(assert_trap (invoke "i32.store_2" (i64.const 0x100000010) (i32.const 4321)) "out of bounds memory access")
+(assert_trap (invoke "i32.load_2" (i64.const 0x100000010)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.store_3" (i64.const 0x10) (i32.const 1234)) "out of bounds memory access")
+(assert_trap (invoke "i32.load_3" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32_8
+(assert_return (invoke "i32.store8" (i64.const 0x10) (i32.const 101)))
+(assert_return (invoke "i32.load8u" (i64.const 0x10)) (i32.const 101))
+(assert_return (invoke "i32.load8s" (i64.const 0x10)) (i32.const 101))
+(assert_trap (invoke "i32.store8" (i64.const 0x100000000) (i32.const 101)) "out of bounds memory access")
+(assert_trap (invoke "i32.load8u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i32.load8s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.store8_2" (i64.const 0x10) (i32.const 101)) "out of bounds memory access")
+(assert_trap (invoke "i32.load8u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i32.load8s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32_16
+(assert_return (invoke "i32.store16" (i64.const 0x10) (i32.const 32149)))
+(assert_return (invoke "i32.load16u" (i64.const 0x10)) (i32.const 32149))
+(assert_return (invoke "i32.load16s" (i64.const 0x10)) (i32.const 32149))
+(assert_trap (invoke "i32.store16" (i64.const 0x100000000) (i32.const 32149)) "out of bounds memory access")
+(assert_trap (invoke "i32.load16u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i32.load16s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.store16_2" (i64.const 0x10) (i32.const 32149)) "out of bounds memory access")
+(assert_trap (invoke "i32.load16u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i32.load16s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64
+(assert_return (invoke "i64.store" (i64.const 0x10) (i64.const 123456781234)))
+(assert_return (invoke "i64.load" (i64.const 0x10)) (i64.const 123456781234))
+(assert_trap (invoke "i64.store" (i64.const 0x100000010) (i64.const 123456781234)) "out of bounds memory access")
+(assert_trap (invoke "i64.load" (i64.const 0x100000010)) "out of bounds memory access")
+
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 432187654321)))
+(assert_return (invoke "i64.load_2" (i64.const 0x10)) (i64.const 432187654321))
+(assert_trap (invoke "i64.store_2" (i64.const 0x100000010) (i64.const 432187654321)) "out of bounds memory access")
+(assert_trap (invoke "i64.load_2" (i64.const 0x100000010)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.store_3" (i64.const 0x10) (i64.const 123456781234)) "out of bounds memory access")
+(assert_trap (invoke "i64.load_3" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64_8
+(assert_return (invoke "i64.store8" (i64.const 0x10) (i64.const 108)))
+(assert_return (invoke "i64.load8u" (i64.const 0x10)) (i64.const 108))
+(assert_return (invoke "i64.load8s" (i64.const 0x10)) (i64.const 108))
+(assert_trap (invoke "i64.store8" (i64.const 0x100000000) (i64.const 108)) "out of bounds memory access")
+(assert_trap (invoke "i64.load8u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i64.load8s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.store8_2" (i64.const 0x10) (i64.const 108)) "out of bounds memory access")
+(assert_trap (invoke "i64.load8u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i64.load8s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64_16
+(assert_return (invoke "i64.store16" (i64.const 0x10) (i64.const 30571)))
+(assert_return (invoke "i64.load16u" (i64.const 0x10)) (i64.const 30571))
+(assert_return (invoke "i64.load16s" (i64.const 0x10)) (i64.const 30571))
+(assert_trap (invoke "i64.store16" (i64.const 0x100000000) (i64.const 30571)) "out of bounds memory access")
+(assert_trap (invoke "i64.load16u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i64.load16s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.store16_2" (i64.const 0x10) (i64.const 30571)) "out of bounds memory access")
+(assert_trap (invoke "i64.load16u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i64.load16s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64_32
+(assert_return (invoke "i64.store32" (i64.const 0x10) (i64.const 2058934)))
+(assert_return (invoke "i64.load32u" (i64.const 0x10)) (i64.const 2058934))
+(assert_return (invoke "i64.load32s" (i64.const 0x10)) (i64.const 2058934))
+(assert_trap (invoke "i64.store32" (i64.const 0x100000000) (i64.const 2058934)) "out of bounds memory access")
+(assert_trap (invoke "i64.load32u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i64.load32s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.store32_2" (i64.const 0x10) (i64.const 2058934)) "out of bounds memory access")
+(assert_trap (invoke "i64.load32u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i64.load32s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; f32
+(assert_return (invoke "f32.store" (i64.const 0x10) (f32.const 1234.5)))
+(assert_return (invoke "f32.load" (i64.const 0x10)) (f32.const 1234.5))
+(assert_trap (invoke "f32.store" (i64.const 0x100000000) (f32.const 1234.5)) "out of bounds memory access")
+(assert_trap (invoke "f32.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "f32.store_2" (i64.const 0x10) (f32.const 1234.5)) "out of bounds memory access")
+(assert_trap (invoke "f32.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; f64
+(assert_return (invoke "f64.store" (i64.const 0x10) (f64.const 123456789.5)))
+(assert_return (invoke "f64.load" (i64.const 0x10)) (f64.const 123456789.5))
+(assert_trap (invoke "f64.store" (i64.const 0x100000000) (f64.const 123456789.5)) "out of bounds memory access")
+(assert_trap (invoke "f64.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "f64.store_2" (i64.const 0x10) (f64.const 123456789.5)) "out of bounds memory access")
+(assert_trap (invoke "f64.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128
+(assert_return (invoke "v128.store" (i64.const 0x10) (v128.const i64x2 1 2)))
+(assert_return (invoke "v128.load" (i64.const 0x10)) (v128.const i64x2 1 2))
+(assert_trap (invoke "v128.store" (i64.const 0x100000000) (v128.const i64x2 1 2)) "out of bounds memory access")
+(assert_trap (invoke "v128.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store_2" (i64.const 0x10) (v128.const i64x2 1 2)) "out of bounds memory access")
+(assert_trap (invoke "v128.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; clear mem
+(assert_return (invoke "v128.store" (i64.const 0x10) (v128.const i64x2 0 0)))
+
+;; v128 8x8
+(assert_return (invoke "v128.load8x8s" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load8x8u" (i64.const 0x10)) (v128.const i64x2 0 0))
+
+(assert_trap (invoke "v128.load8x8s" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load8x8u" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load8x8s_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load8x8u_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 16x4
+(assert_return (invoke "v128.load16x4s" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load16x4u" (i64.const 0x10)) (v128.const i64x2 0 0))
+
+(assert_trap (invoke "v128.load16x4s" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16x4u" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load16x4s_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16x4u_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 32x2
+(assert_return (invoke "v128.load32x2s" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load32x2u" (i64.const 0x10)) (v128.const i64x2 0 0))
+
+(assert_trap (invoke "v128.load32x2s" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32x2u" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load32x2s_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32x2u_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 splat
+(assert_return (invoke "v128.load8splat" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load16splat" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load32splat" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load64splat" (i64.const 0x10)) (v128.const i64x2 0 0))
+
+(assert_trap (invoke "v128.load8splat" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16splat" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32splat" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64splat" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load8splat_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16splat_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32splat_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64splat_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 lane 8
+(assert_return (invoke "v128.store8lane" (i64.const 0x10) (v128.const i8x16 75 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+(assert_return (invoke "v128.load8lane" (i64.const 0x10)) (v128.const i8x16 75 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+
+(assert_trap (invoke "v128.store8lane" (i64.const 0x100000000) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load8lane" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store8lane_2" (i64.const 0x10) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load8lane_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 lane 16
+(assert_return (invoke "v128.store16lane" (i64.const 0x10) (v128.const i16x8 30678 0 0 0 0 0 0 0)))
+(assert_return (invoke "v128.load16lane" (i64.const 0x10)) (v128.const i16x8 30678 0 0 0 0 0 0 0))
+
+(assert_trap (invoke "v128.store16lane" (i64.const 0x100000000) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16lane" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store16lane_2" (i64.const 0x10) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16lane_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 lane 32
+(assert_return (invoke "v128.store32lane" (i64.const 0x10) (v128.const i32x4 2180785617 0 0 0)))
+(assert_return (invoke "v128.load32lane" (i64.const 0x10)) (v128.const i32x4 2180785617 0 0 0))
+
+(assert_trap (invoke "v128.store32lane" (i64.const 0x100000000) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32lane" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store32lane_2" (i64.const 0x10) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32lane_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 lane 64
+(assert_return (invoke "v128.store64lane" (i64.const 0x10) (v128.const i64x2 314756237046123789 0)))
+(assert_return (invoke "v128.load64lane" (i64.const 0x10)) (v128.const i64x2 314756237046123789 0))
+
+(assert_trap (invoke "v128.store64lane" (i64.const 0x100000000) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64lane" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store64lane_2" (i64.const 0x10) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64lane_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 load zero
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 1579840812)))
+(assert_return (invoke "v128.load32zero" (i64.const 0x10)) (v128.const i32x4 1579840812 0 0 0))
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 84592345257645125)))
+(assert_return (invoke "v128.load64zero" (i64.const 0x10)) (v128.const i64x2 84592345257645125 0))
+
+(assert_trap (invoke "v128.load32zero" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64zero" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load32zero_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64zero_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; atomic core
+(assert_return (invoke "atomic.notify" (i64.const 0x10)))
+(assert_return (invoke "memory.atomic.wait32" (i64.const 0x10)))
+(assert_return (invoke "memory.atomic.wait64" (i64.const 0x10)))
+
+(assert_trap (invoke "atomic.notify" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait32" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait64" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "atomic.notify_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait32_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait64_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32 atomic
+(assert_return (invoke "i32.atomic.store" (i64.const 0x10) (i32.const 1480532187)))
+(assert_return (invoke "i32.atomic.load" (i64.const 0x10)) (i32.const 1480532187))
+
+(assert_trap (invoke "i32.atomic.store" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.store_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32 atomic 8
+(assert_return (invoke "i32.atomic.store8" (i64.const 0x10) (i32.const 245)))
+(assert_return (invoke "i32.atomic.load8" (i64.const 0x10)) (i32.const 245))
+
+(assert_trap (invoke "i32.atomic.store8" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load8" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.store8_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load8_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32 atomic 16
+(assert_return (invoke "i32.atomic.store16" (i64.const 0x10) (i32.const 63416)))
+(assert_return (invoke "i32.atomic.load16" (i64.const 0x10)) (i32.const 63416))
+
+(assert_trap (invoke "i32.atomic.store16" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load16" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.store16_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load16_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64 atomic
+(assert_return (invoke "i64.atomic.store" (i64.const 0x10) (i64.const 8923601264510235)))
+(assert_return (invoke "i64.atomic.load" (i64.const 0x10)) (i64.const 8923601264510235))
+
+(assert_trap (invoke "i64.atomic.store" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.store_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64 atomic 8
+(assert_return (invoke "i64.atomic.store8" (i64.const 0x10) (i64.const 208)))
+(assert_return (invoke "i64.atomic.load8" (i64.const 0x10)) (i64.const 208))
+
+(assert_trap (invoke "i64.atomic.store8" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load8" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.store8_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load8_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64 atomic 16
+(assert_return (invoke "i64.atomic.store16" (i64.const 0x10) (i64.const 58930)))
+(assert_return (invoke "i64.atomic.load16" (i64.const 0x10)) (i64.const 58930))
+
+(assert_trap (invoke "i64.atomic.store16" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load16" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.store16_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load16_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64 atomic 32
+(assert_return (invoke "i64.atomic.store32" (i64.const 0x10) (i64.const 4035164968)))
+(assert_return (invoke "i64.atomic.load32" (i64.const 0x10)) (i64.const 4035164968))
+
+(assert_trap (invoke "i64.atomic.store32" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load32" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.store32_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load32_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32 atomic rmw
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 0)))
+(assert_return (invoke "i32.atomic.rmw.add" (i64.const 0x10) (i32.const 1684902794)) (i32.const 0))
+(assert_return (invoke "i32.atomic.rmw.sub" (i64.const 0x10) (i32.const 1684902794)) (i32.const 1684902794))
+
+(assert_trap (invoke "i32.atomic.rmw.add" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw.sub" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw.add_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw.sub_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+
+;; i32 atomic rmw 8
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 0)))
+(assert_return (invoke "i32.atomic.rmw8.or" (i64.const 0x10) (i32.const 159)) (i32.const 0))
+(assert_return (invoke "i32.atomic.rmw8.xor" (i64.const 0x10) (i32.const 159)) (i32.const 159))
+
+(assert_trap (invoke "i32.atomic.rmw8.or" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.xor" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw8.or_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.xor_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+
+;; i32 atomic rmw 16
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 0)))
+(assert_return (invoke "i32.atomic.rmw16.or" (i64.const 0x10) (i32.const 159)) (i32.const 0))
+(assert_return (invoke "i32.atomic.rmw16.and" (i64.const 0x10) (i32.const 159)) (i32.const 159))
+
+(assert_trap (invoke "i32.atomic.rmw16.or" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.and" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw16.or_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.and_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+
+;; i64 atomic rmw
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 0)))
+(assert_return (invoke "i64.atomic.rmw.add" (i64.const 0x10) (i64.const 194602756123704341)) (i64.const 0))
+(assert_return (invoke "i64.atomic.rmw.sub" (i64.const 0x10) (i64.const 194602756123704341)) (i64.const 194602756123704341))
+
+(assert_trap (invoke "i64.atomic.rmw.add" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw.sub" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw.add_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw.sub_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i64 atomic rmw 8
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 0)))
+(assert_return (invoke "i64.atomic.rmw8.or" (i64.const 0x10) (i64.const 180)) (i64.const 0))
+(assert_return (invoke "i64.atomic.rmw8.xor" (i64.const 0x10) (i64.const 180)) (i64.const 180))
+
+(assert_trap (invoke "i64.atomic.rmw8.or" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.xor" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw8.or_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.xor_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i64 atomic rmw 16
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 0)))
+(assert_return (invoke "i64.atomic.rmw16.or" (i64.const 0x10) (i64.const 59468)) (i64.const 0))
+(assert_return (invoke "i64.atomic.rmw16.and" (i64.const 0x10) (i64.const 59468)) (i64.const 59468))
+
+(assert_trap (invoke "i64.atomic.rmw16.or" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.and" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw16.or_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.and_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i64 atomic rmw 32
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 0)))
+(assert_return (invoke "i64.atomic.rmw32.add" (i64.const 0x10) (i64.const 1962460524)) (i64.const 0))
+(assert_return (invoke "i64.atomic.rmw32.and" (i64.const 0x10) (i64.const 1962460524)) (i64.const 1962460524))
+
+(assert_trap (invoke "i64.atomic.rmw32.add" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.and" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw32.add_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.and_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i32 atomic Xchg
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 1683920478)))
+(assert_return (invoke "i32.atomic.rmw.xchg" (i64.const 0x10) (i32.const 0)) (i32.const 1683920478))
+(assert_return (invoke "i32.store8" (i64.const 0x10) (i32.const 238)))
+(assert_return (invoke "i32.atomic.rmw8.xchg" (i64.const 0x10) (i32.const 0)) (i32.const 238))
+(assert_return (invoke "i32.store16" (i64.const 0x10) (i32.const 57840)))
+(assert_return (invoke "i32.atomic.rmw16.xchg" (i64.const 0x10) (i32.const 0)) (i32.const 57840))
+
+(assert_trap (invoke "i32.atomic.rmw.xchg" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.xchg" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.xchg" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw.xchg_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.xchg_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.xchg_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+
+;; i64 atomic Xchg
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 7686420451258)))
+(assert_return (invoke "i64.atomic.rmw.xchg" (i64.const 0x10) (i64.const 0)) (i64.const 7686420451258))
+(assert_return (invoke "i64.store8" (i64.const 0x10) (i64.const 226)))
+(assert_return (invoke "i64.atomic.rmw8.xchg" (i64.const 0x10) (i64.const 0)) (i64.const 226))
+(assert_return (invoke "i64.store16" (i64.const 0x10) (i64.const 53651)))
+(assert_return (invoke "i64.atomic.rmw16.xchg" (i64.const 0x10) (i64.const 0)) (i64.const 53651))
+(assert_return (invoke "i64.store32" (i64.const 0x10) (i64.const 1687254093)))
+(assert_return (invoke "i64.atomic.rmw32.xchg" (i64.const 0x10) (i64.const 0)) (i64.const 1687254093))
+
+(assert_trap (invoke "i64.atomic.rmw.xchg" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.xchg" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.xchg" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.xchg" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw.xchg_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.xchg_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.xchg_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.xchg_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i32 atomic Cmpxchg
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 1809274815)))
+(assert_return (invoke "i32.atomic.rmw.cmpxchg" (i64.const 0x10) (i32.const 1809274815) (i32.const 0)) (i32.const 1809274815))
+(assert_return (invoke "i32.store8" (i64.const 0x10) (i32.const 164)))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg" (i64.const 0x10) (i32.const 164) (i32.const 0)) (i32.const 164))
+(assert_return (invoke "i32.store16" (i64.const 0x10) (i32.const 59218)))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg" (i64.const 0x10) (i32.const 59218) (i32.const 0)) (i32.const 59218))
+
+(assert_trap (invoke "i32.atomic.rmw.cmpxchg" (i64.const 0x100000000) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.cmpxchg" (i64.const 0x100000000) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.cmpxchg" (i64.const 0x100000000) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw.cmpxchg_2" (i64.const 0x10) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.cmpxchg_2" (i64.const 0x10) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.cmpxchg_2" (i64.const 0x10) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+
+;; i64 atomic Cmpxchg
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 127857628907652)))
+(assert_return (invoke "i64.atomic.rmw.cmpxchg" (i64.const 0x10) (i64.const 127857628907652) (i64.const 0)) (i64.const 127857628907652))
+(assert_return (invoke "i64.store8" (i64.const 0x10) (i64.const 201)))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg" (i64.const 0x10) (i64.const 201) (i64.const 0)) (i64.const 201))
+(assert_return (invoke "i64.store16" (i64.const 0x10) (i64.const 60437)))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg" (i64.const 0x10) (i64.const 60437) (i64.const 0)) (i64.const 60437))
+(assert_return (invoke "i64.store32" (i64.const 0x10) (i64.const 2067381469)))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg" (i64.const 0x10) (i64.const 2067381469) (i64.const 0)) (i64.const 2067381469))
+
+(assert_trap (invoke "i64.atomic.rmw.cmpxchg" (i64.const 0x100000000) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.cmpxchg" (i64.const 0x100000000) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.cmpxchg" (i64.const 0x100000000) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.cmpxchg" (i64.const 0x100000000) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw.cmpxchg_2" (i64.const 0x10) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.cmpxchg_2" (i64.const 0x10) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.cmpxchg_2" (i64.const 0x10) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.cmpxchg_2" (i64.const 0x10) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+
+(module
+    (memory i64 0)
+    (memory $mem i64 1)
+
+    ;; i32
+    (func (export "i32.store") (param i64 i32) (i32.store $mem (local.get 0) (local.get 1)))
+    (func (export "i32.load") (param i64) (result i32) (i32.load $mem (local.get 0)))
+
+    (func (export "i32.store_2") (param i64 i32) (i32.store $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.load_2") (param i64) (result i32) (i32.load $mem offset=16 (local.get 0)))
+
+    (func (export "i32.store_3") (param i64 i32) (i32.store $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.load_3") (param i64) (result i32) (i32.load $mem offset=0x100000000 (local.get 0)))
+
+    ;; i32_8
+    (func (export "i32.store8") (param i64 i32) (i32.store8 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.load8u") (param i64) (result i32) (i32.load8_u $mem offset=16 (local.get 0)))
+    (func (export "i32.load8s") (param i64) (result i32) (i32.load8_s $mem offset=16 (local.get 0)))
+
+    (func (export "i32.store8_2") (param i64 i32) (i32.store8 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.load8u_2") (param i64) (result i32) (i32.load8_u $mem offset=0x100000000 (local.get 0)))
+    (func (export "i32.load8s_2") (param i64) (result i32) (i32.load8_s $mem offset=0x100000000 (local.get 0)))
+
+    ;; i32_16
+    (func (export "i32.store16") (param i64 i32) (i32.store16 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.load16u") (param i64) (result i32) (i32.load16_u $mem offset=16 (local.get 0)))
+    (func (export "i32.load16s") (param i64) (result i32) (i32.load16_s $mem offset=16 (local.get 0)))
+
+    (func (export "i32.store16_2") (param i64 i32) (i32.store16 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.load16u_2") (param i64) (result i32) (i32.load16_u $mem offset=0x100000000 (local.get 0)))
+    (func (export "i32.load16s_2") (param i64) (result i32) (i32.load16_s $mem offset=0x100000000 (local.get 0)))
+
+    ;; i64
+    (func (export "i64.store") (param i64 i64) (i64.store $mem (local.get 0) (local.get 1)))
+    (func (export "i64.load") (param i64) (result i64) (i64.load $mem (local.get 0)))
+
+    (func (export "i64.store_2") (param i64 i64) (i64.store $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.load_2") (param i64) (result i64) (i64.load $mem offset=16 (local.get 0)))
+
+    (func (export "i64.store_3") (param i64 i64) (i64.store $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.load_3") (param i64) (result i64) (i64.load $mem offset=0x100000000 (local.get 0)))
+
+    ;; i64_8
+    (func (export "i64.store8") (param i64 i64) (i64.store8 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.load8u") (param i64) (result i64) (i64.load8_u $mem offset=16 (local.get 0)))
+    (func (export "i64.load8s") (param i64) (result i64) (i64.load8_s $mem offset=16 (local.get 0)))
+
+    (func (export "i64.store8_2") (param i64 i64) (i64.store8 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.load8u_2") (param i64) (result i64) (i64.load8_u $mem offset=0x100000000 (local.get 0)))
+    (func (export "i64.load8s_2") (param i64) (result i64) (i64.load8_s $mem offset=0x100000000 (local.get 0)))
+
+    ;; i64_16
+    (func (export "i64.store16") (param i64 i64) (i64.store16 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.load16u") (param i64) (result i64) (i64.load16_u $mem offset=16 (local.get 0)))
+    (func (export "i64.load16s") (param i64) (result i64) (i64.load16_s $mem offset=16 (local.get 0)))
+
+    (func (export "i64.store16_2") (param i64 i64) (i64.store16 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.load16u_2") (param i64) (result i64) (i64.load16_u $mem offset=0x100000000 (local.get 0)))
+    (func (export "i64.load16s_2") (param i64) (result i64) (i64.load16_s $mem offset=0x100000000 (local.get 0)))
+
+    ;; i64_32
+    (func (export "i64.store32") (param i64 i64) (i64.store32 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.load32u") (param i64) (result i64) (i64.load32_u $mem offset=16 (local.get 0)))
+    (func (export "i64.load32s") (param i64) (result i64) (i64.load32_s $mem offset=16 (local.get 0)))
+
+    (func (export "i64.store32_2") (param i64 i64) (i64.store32 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.load32u_2") (param i64) (result i64) (i64.load32_u $mem offset=0x100000000 (local.get 0)))
+    (func (export "i64.load32s_2") (param i64) (result i64) (i64.load32_s $mem offset=0x100000000 (local.get 0)))
+
+    ;; f32
+    (func (export "f32.store") (param i64 f32) (f32.store $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "f32.load") (param i64) (result f32) (f32.load $mem offset=16 (local.get 0)))
+
+    (func (export "f32.store_2") (param i64 f32) (f32.store $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "f32.load_2") (param i64) (result f32) (f32.load $mem offset=0x100000000 (local.get 0)))
+
+    ;; f64
+    (func (export "f64.store") (param i64 f64) (f64.store $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "f64.load") (param i64) (result f64) (f64.load $mem offset=16 (local.get 0)))
+
+    (func (export "f64.store_2") (param i64 f64) (f64.store $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "f64.load_2") (param i64) (result f64) (f64.load $mem offset=0x100000000 (local.get 0)))
+
+    ;; v128
+    (func (export "v128.store") (param i64 v128) (v128.store $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "v128.load") (param i64) (result v128) (v128.load $mem offset=16 (local.get 0)))
+
+    (func (export "v128.store_2") (param i64 v128) (v128.store $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "v128.load_2") (param i64) (result v128) (v128.load $mem offset=0x100000000 (local.get 0)))
+
+    ;; v128 8x8
+    (func (export "v128.load8x8s") (param i64) (result v128) (v128.load8x8_s $mem offset=16 (local.get 0)))
+    (func (export "v128.load8x8u") (param i64) (result v128) (v128.load8x8_u $mem offset=16 (local.get 0)))
+
+    (func (export "v128.load8x8s_2") (param i64) (result v128) (v128.load8x8_s $mem offset=0x100000000 (local.get 0)))
+    (func (export "v128.load8x8u_2") (param i64) (result v128) (v128.load8x8_u $mem offset=0x100000000 (local.get 0)))
+
+    ;; v128 16x4
+    (func (export "v128.load16x4s") (param i64) (result v128) (v128.load16x4_s $mem offset=16 (local.get 0)))
+    (func (export "v128.load16x4u") (param i64) (result v128) (v128.load16x4_u $mem offset=16 (local.get 0)))
+
+    (func (export "v128.load16x4s_2") (param i64) (result v128) (v128.load16x4_s $mem offset=0x100000000 (local.get 0)))
+    (func (export "v128.load16x4u_2") (param i64) (result v128) (v128.load16x4_u $mem offset=0x100000000 (local.get 0)))
+
+    ;; v128 32x2
+    (func (export "v128.load32x2s") (param i64) (result v128) (v128.load32x2_s $mem offset=16 (local.get 0)))
+    (func (export "v128.load32x2u") (param i64) (result v128) (v128.load32x2_u $mem offset=16 (local.get 0)))
+
+    (func (export "v128.load32x2s_2") (param i64) (result v128) (v128.load32x2_s $mem offset=0x100000000 (local.get 0)))
+    (func (export "v128.load32x2u_2") (param i64) (result v128) (v128.load32x2_u $mem offset=0x100000000 (local.get 0)))
+
+    ;; v128 splat
+    (func (export "v128.load8splat") (param i64) (result v128) (v128.load8_splat $mem offset=16 (local.get 0)))
+    (func (export "v128.load16splat") (param i64) (result v128) (v128.load16_splat $mem offset=16 (local.get 0)))
+    (func (export "v128.load32splat") (param i64) (result v128) (v128.load32_splat $mem offset=16 (local.get 0)))
+    (func (export "v128.load64splat") (param i64) (result v128) (v128.load64_splat $mem offset=16 (local.get 0)))
+
+    (func (export "v128.load8splat_2") (param i64) (result v128) (v128.load8_splat $mem offset=0x100000000 (local.get 0)))
+    (func (export "v128.load16splat_2") (param i64) (result v128) (v128.load16_splat $mem offset=0x100000000 (local.get 0)))
+    (func (export "v128.load32splat_2") (param i64) (result v128) (v128.load32_splat $mem offset=0x100000000 (local.get 0)))
+    (func (export "v128.load64splat_2") (param i64) (result v128) (v128.load64_splat $mem offset=0x100000000 (local.get 0)))
+
+    ;; v128 lane 8
+    (func (export "v128.store8lane") (param i64 v128) (v128.store8_lane $mem offset=16 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load8lane") (param i64) (result v128) (v128.load8_lane $mem offset=16 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    (func (export "v128.store8lane_2") (param i64 v128) (v128.store8_lane $mem offset=0x100000000 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load8lane_2") (param i64) (result v128) (v128.load8_lane $mem offset=0x100000000 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    ;; v128 lane 16
+    (func (export "v128.store16lane") (param i64 v128) (v128.store16_lane $mem offset=16 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load16lane") (param i64) (result v128) (v128.load16_lane $mem offset=16 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    (func (export "v128.store16lane_2") (param i64 v128) (v128.store16_lane $mem offset=0x100000000 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load16lane_2") (param i64) (result v128) (v128.load16_lane $mem offset=0x100000000 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    ;; v128 lane 32
+    (func (export "v128.store32lane") (param i64 v128) (v128.store32_lane $mem offset=16 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load32lane") (param i64) (result v128) (v128.load32_lane $mem offset=16 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    (func (export "v128.store32lane_2") (param i64 v128) (v128.store32_lane $mem offset=0x100000000 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load32lane_2") (param i64) (result v128) (v128.load32_lane $mem offset=0x100000000 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    ;; v128 lane 64
+    (func (export "v128.store64lane") (param i64 v128) (v128.store64_lane $mem offset=16 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load64lane") (param i64) (result v128) (v128.load64_lane $mem offset=16 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    (func (export "v128.store64lane_2") (param i64 v128) (v128.store64_lane $mem offset=0x100000000 0 (local.get 0) (local.get 1)))
+    (func (export "v128.load64lane_2") (param i64) (result v128) (v128.load64_lane $mem offset=0x100000000 0 (local.get 0) (v128.const i64x2 0 0)))
+
+    ;; v128 load zero
+    (func (export "v128.load32zero") (param i64) (result v128) (v128.load32_zero $mem offset=16 (local.get 0)))
+    (func (export "v128.load64zero") (param i64) (result v128) (v128.load64_zero $mem offset=16 (local.get 0)))
+
+    (func (export "v128.load32zero_2") (param i64) (result v128) (v128.load32_zero $mem offset=0x100000000 (local.get 0)))
+    (func (export "v128.load64zero_2") (param i64) (result v128) (v128.load64_zero $mem offset=0x100000000 (local.get 0)))
+
+    ;; atomic core
+    (func (export "atomic.notify") (param i64) (drop (memory.atomic.notify $mem offset=16 (local.get 0) (i32.const 0))))
+    (func (export "memory.atomic.wait32") (param i64) (drop (memory.atomic.wait32 $mem offset=16 (local.get 0) (i32.const 0) (i64.const 0))))
+    (func (export "memory.atomic.wait64") (param i64) (drop (memory.atomic.wait64 $mem offset=16 (local.get 0) (i64.const 0) (i64.const 0))))
+
+    (func (export "atomic.notify_2") (param i64) (drop (memory.atomic.notify $mem offset=0x100000000 (local.get 0) (i32.const 0))))
+    (func (export "memory.atomic.wait32_2") (param i64) (drop (memory.atomic.wait32 $mem offset=0x100000000 (local.get 0) (i32.const 0) (i64.const 0))))
+    (func (export "memory.atomic.wait64_2") (param i64) (drop (memory.atomic.wait64 $mem offset=0x100000000 (local.get 0) (i64.const 0) (i64.const 0))))
+
+    ;; i32 atomic
+    (func (export "i32.atomic.store") (param i64 i32) (i32.atomic.store $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load") (param i64) (result i32) (i32.atomic.load $mem offset=16 (local.get 0)))
+
+    (func (export "i32.atomic.store_2") (param i64 i32) (i32.atomic.store $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load_2") (param i64) (result i32) (i32.atomic.load $mem offset=0x100000000 (local.get 0)))
+
+    ;; i32 atomic 8
+    (func (export "i32.atomic.store8") (param i64 i32) (i32.atomic.store8 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load8") (param i64) (result i32) (i32.atomic.load8_u $mem offset=16 (local.get 0)))
+
+    (func (export "i32.atomic.store8_2") (param i64 i32) (i32.atomic.store8 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load8_2") (param i64) (result i32) (i32.atomic.load8_u $mem offset=0x100000000 (local.get 0)))
+
+    ;; i32 atomic 16
+    (func (export "i32.atomic.store16") (param i64 i32) (i32.atomic.store16 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load16") (param i64) (result i32) (i32.atomic.load16_u $mem offset=16 (local.get 0)))
+
+    (func (export "i32.atomic.store16_2") (param i64 i32) (i32.atomic.store16 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.load16_2") (param i64) (result i32) (i32.atomic.load16_u $mem offset=0x100000000 (local.get 0)))
+
+    ;; i64 atomic
+    (func (export "i64.atomic.store") (param i64 i64) (i64.atomic.store $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load") (param i64) (result i64) (i64.atomic.load $mem offset=16 (local.get 0)))
+
+    (func (export "i64.atomic.store_2") (param i64 i64) (i64.atomic.store $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load_2") (param i64) (result i64) (i64.atomic.load $mem offset=0x100000000 (local.get 0)))
+
+    ;; i64 atomic 8
+    (func (export "i64.atomic.store8") (param i64 i64) (i64.atomic.store8 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load8") (param i64) (result i64) (i64.atomic.load8_u $mem offset=16 (local.get 0)))
+
+    (func (export "i64.atomic.store8_2") (param i64 i64) (i64.atomic.store8 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load8_2") (param i64) (result i64) (i64.atomic.load8_u $mem offset=0x100000000 (local.get 0)))
+
+    ;; i64 atomic 16
+    (func (export "i64.atomic.store16") (param i64 i64) (i64.atomic.store16 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load16") (param i64) (result i64) (i64.atomic.load16_u $mem offset=16 (local.get 0)))
+
+    (func (export "i64.atomic.store16_2") (param i64 i64) (i64.atomic.store16 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load16_2") (param i64) (result i64) (i64.atomic.load16_u $mem offset=0x100000000 (local.get 0)))
+
+    ;; i64 atomic 32
+    (func (export "i64.atomic.store32") (param i64 i64) (i64.atomic.store32 $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load32") (param i64) (result i64) (i64.atomic.load32_u $mem offset=16 (local.get 0)))
+
+    (func (export "i64.atomic.store32_2") (param i64 i64) (i64.atomic.store32 $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.load32_2") (param i64) (result i64) (i64.atomic.load32_u $mem offset=0x100000000 (local.get 0)))
+
+    ;; i32 atomic rmw
+    (func (export "i32.atomic.rmw.add") (param i64 i32) (result i32) (i32.atomic.rmw.add $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw.sub") (param i64 i32) (result i32) (i32.atomic.rmw.sub $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i32.atomic.rmw.add_2") (param i64 i32) (result i32) (i32.atomic.rmw.add $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw.sub_2") (param i64 i32) (result i32) (i32.atomic.rmw.sub $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i32 atomic rmw 8
+    (func (export "i32.atomic.rmw8.or") (param i64 i32) (result i32) (i32.atomic.rmw8.or_u $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw8.xor") (param i64 i32) (result i32) (i32.atomic.rmw8.xor_u $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i32.atomic.rmw8.or_2") (param i64 i32) (result i32) (i32.atomic.rmw8.or_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw8.xor_2") (param i64 i32) (result i32) (i32.atomic.rmw8.xor_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i32 atomic rmw 16
+    (func (export "i32.atomic.rmw16.or") (param i64 i32) (result i32) (i32.atomic.rmw16.or_u $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw16.and") (param i64 i32) (result i32) (i32.atomic.rmw16.and_u $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i32.atomic.rmw16.or_2") (param i64 i32) (result i32) (i32.atomic.rmw16.or_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw16.and_2") (param i64 i32) (result i32) (i32.atomic.rmw16.and_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic rmw
+    (func (export "i64.atomic.rmw.add") (param i64 i64) (result i64) (i64.atomic.rmw.add $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw.sub") (param i64 i64) (result i64) (i64.atomic.rmw.sub $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw.add_2") (param i64 i64) (result i64) (i64.atomic.rmw.add $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw.sub_2") (param i64 i64) (result i64) (i64.atomic.rmw.sub $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic rmw 8
+    (func (export "i64.atomic.rmw8.or") (param i64 i64) (result i64) (i64.atomic.rmw8.or_u $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw8.xor") (param i64 i64) (result i64) (i64.atomic.rmw8.xor_u $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw8.or_2") (param i64 i64) (result i64) (i64.atomic.rmw8.or_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw8.xor_2") (param i64 i64) (result i64) (i64.atomic.rmw8.xor_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic rmw 16
+    (func (export "i64.atomic.rmw16.or") (param i64 i64) (result i64) (i64.atomic.rmw16.or_u $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw16.and") (param i64 i64) (result i64) (i64.atomic.rmw16.and_u $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw16.or_2") (param i64 i64) (result i64) (i64.atomic.rmw16.or_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw16.and_2") (param i64 i64) (result i64) (i64.atomic.rmw16.and_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic rmw 32
+    (func (export "i64.atomic.rmw32.add") (param i64 i64) (result i64) (i64.atomic.rmw32.add_u $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw32.and") (param i64 i64) (result i64) (i64.atomic.rmw32.and_u $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw32.add_2") (param i64 i64) (result i64) (i64.atomic.rmw32.add_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw32.and_2") (param i64 i64) (result i64) (i64.atomic.rmw32.and_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i32 atomic Xchg
+    (func (export "i32.atomic.rmw.xchg") (param i64 i32) (result i32) (i32.atomic.rmw.xchg $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw8.xchg") (param i64 i32) (result i32) (i32.atomic.rmw8.xchg_u $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw16.xchg") (param i64 i32) (result i32) (i32.atomic.rmw16.xchg_u $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i32.atomic.rmw.xchg_2") (param i64 i32) (result i32) (i32.atomic.rmw.xchg $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw8.xchg_2") (param i64 i32) (result i32) (i32.atomic.rmw8.xchg_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i32.atomic.rmw16.xchg_2") (param i64 i32) (result i32) (i32.atomic.rmw16.xchg_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i64 atomic Xchg
+    (func (export "i64.atomic.rmw.xchg") (param i64 i64) (result i64) (i64.atomic.rmw.xchg $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw8.xchg") (param i64 i64) (result i64) (i64.atomic.rmw8.xchg_u $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw16.xchg") (param i64 i64) (result i64) (i64.atomic.rmw16.xchg_u $mem offset=16 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw32.xchg") (param i64 i64) (result i64) (i64.atomic.rmw32.xchg_u $mem offset=16 (local.get 0) (local.get 1)))
+
+    (func (export "i64.atomic.rmw.xchg_2") (param i64 i64) (result i64) (i64.atomic.rmw.xchg $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw8.xchg_2") (param i64 i64) (result i64) (i64.atomic.rmw8.xchg_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw16.xchg_2") (param i64 i64) (result i64) (i64.atomic.rmw16.xchg_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+    (func (export "i64.atomic.rmw32.xchg_2") (param i64 i64) (result i64) (i64.atomic.rmw32.xchg_u $mem offset=0x100000000 (local.get 0) (local.get 1)))
+
+    ;; i32 atomic Cmpxchg
+    (func (export "i32.atomic.rmw.cmpxchg") (param i64 i32 i32) (result i32) (i32.atomic.rmw.cmpxchg $mem offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i32.atomic.rmw8.cmpxchg") (param i64 i32 i32) (result i32) (i32.atomic.rmw8.cmpxchg_u $mem offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i32.atomic.rmw16.cmpxchg") (param i64 i32 i32) (result i32) (i32.atomic.rmw16.cmpxchg_u $mem offset=16 (local.get 0) (local.get 1) (local.get 2)))
+
+    (func (export "i32.atomic.rmw.cmpxchg_2") (param i64 i32 i32) (result i32) (i32.atomic.rmw.cmpxchg $mem offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i32.atomic.rmw8.cmpxchg_2") (param i64 i32 i32) (result i32) (i32.atomic.rmw8.cmpxchg_u $mem offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i32.atomic.rmw16.cmpxchg_2") (param i64 i32 i32) (result i32) (i32.atomic.rmw16.cmpxchg_u $mem offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+
+    ;; i64 atomic Cmpxchg
+    (func (export "i64.atomic.rmw.cmpxchg") (param i64 i64 i64) (result i64) (i64.atomic.rmw.cmpxchg $mem offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw8.cmpxchg") (param i64 i64 i64) (result i64) (i64.atomic.rmw8.cmpxchg_u $mem offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw16.cmpxchg") (param i64 i64 i64) (result i64) (i64.atomic.rmw16.cmpxchg_u $mem offset=16 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw32.cmpxchg") (param i64 i64 i64) (result i64) (i64.atomic.rmw32.cmpxchg_u $mem offset=16 (local.get 0) (local.get 1) (local.get 2)))
+
+    (func (export "i64.atomic.rmw.cmpxchg_2") (param i64 i64 i64) (result i64) (i64.atomic.rmw.cmpxchg $mem offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw8.cmpxchg_2") (param i64 i64 i64) (result i64) (i64.atomic.rmw8.cmpxchg_u $mem offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw16.cmpxchg_2") (param i64 i64 i64) (result i64) (i64.atomic.rmw16.cmpxchg_u $mem offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+    (func (export "i64.atomic.rmw32.cmpxchg_2") (param i64 i64 i64) (result i64) (i64.atomic.rmw32.cmpxchg_u $mem offset=0x100000000 (local.get 0) (local.get 1) (local.get 2)))
+)
+
+;; i32
+(assert_return (invoke "i32.store" (i64.const 0x10) (i32.const 1234)))
+(assert_return (invoke "i32.load" (i64.const 0x10)) (i32.const 1234))
+(assert_trap (invoke "i32.store" (i64.const 0x100000010) (i32.const 1234)) "out of bounds memory access")
+(assert_trap (invoke "i32.load" (i64.const 0x100000010)) "out of bounds memory access")
+
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 4321)))
+(assert_return (invoke "i32.load_2" (i64.const 0x10)) (i32.const 4321))
+(assert_trap (invoke "i32.store_2" (i64.const 0x100000010) (i32.const 4321)) "out of bounds memory access")
+(assert_trap (invoke "i32.load_2" (i64.const 0x100000010)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.store_3" (i64.const 0x10) (i32.const 1234)) "out of bounds memory access")
+(assert_trap (invoke "i32.load_3" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32_8
+(assert_return (invoke "i32.store8" (i64.const 0x10) (i32.const 101)))
+(assert_return (invoke "i32.load8u" (i64.const 0x10)) (i32.const 101))
+(assert_return (invoke "i32.load8s" (i64.const 0x10)) (i32.const 101))
+(assert_trap (invoke "i32.store8" (i64.const 0x100000000) (i32.const 101)) "out of bounds memory access")
+(assert_trap (invoke "i32.load8u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i32.load8s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.store8_2" (i64.const 0x10) (i32.const 101)) "out of bounds memory access")
+(assert_trap (invoke "i32.load8u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i32.load8s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32_16
+(assert_return (invoke "i32.store16" (i64.const 0x10) (i32.const 32149)))
+(assert_return (invoke "i32.load16u" (i64.const 0x10)) (i32.const 32149))
+(assert_return (invoke "i32.load16s" (i64.const 0x10)) (i32.const 32149))
+(assert_trap (invoke "i32.store16" (i64.const 0x100000000) (i32.const 32149)) "out of bounds memory access")
+(assert_trap (invoke "i32.load16u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i32.load16s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.store16_2" (i64.const 0x10) (i32.const 32149)) "out of bounds memory access")
+(assert_trap (invoke "i32.load16u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i32.load16s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64
+(assert_return (invoke "i64.store" (i64.const 0x10) (i64.const 123456781234)))
+(assert_return (invoke "i64.load" (i64.const 0x10)) (i64.const 123456781234))
+(assert_trap (invoke "i64.store" (i64.const 0x100000010) (i64.const 123456781234)) "out of bounds memory access")
+(assert_trap (invoke "i64.load" (i64.const 0x100000010)) "out of bounds memory access")
+
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 432187654321)))
+(assert_return (invoke "i64.load_2" (i64.const 0x10)) (i64.const 432187654321))
+(assert_trap (invoke "i64.store_2" (i64.const 0x100000010) (i64.const 432187654321)) "out of bounds memory access")
+(assert_trap (invoke "i64.load_2" (i64.const 0x100000010)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.store_3" (i64.const 0x10) (i64.const 123456781234)) "out of bounds memory access")
+(assert_trap (invoke "i64.load_3" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64_8
+(assert_return (invoke "i64.store8" (i64.const 0x10) (i64.const 108)))
+(assert_return (invoke "i64.load8u" (i64.const 0x10)) (i64.const 108))
+(assert_return (invoke "i64.load8s" (i64.const 0x10)) (i64.const 108))
+(assert_trap (invoke "i64.store8" (i64.const 0x100000000) (i64.const 108)) "out of bounds memory access")
+(assert_trap (invoke "i64.load8u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i64.load8s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.store8_2" (i64.const 0x10) (i64.const 108)) "out of bounds memory access")
+(assert_trap (invoke "i64.load8u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i64.load8s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64_16
+(assert_return (invoke "i64.store16" (i64.const 0x10) (i64.const 30571)))
+(assert_return (invoke "i64.load16u" (i64.const 0x10)) (i64.const 30571))
+(assert_return (invoke "i64.load16s" (i64.const 0x10)) (i64.const 30571))
+(assert_trap (invoke "i64.store16" (i64.const 0x100000000) (i64.const 30571)) "out of bounds memory access")
+(assert_trap (invoke "i64.load16u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i64.load16s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.store16_2" (i64.const 0x10) (i64.const 30571)) "out of bounds memory access")
+(assert_trap (invoke "i64.load16u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i64.load16s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64_32
+(assert_return (invoke "i64.store32" (i64.const 0x10) (i64.const 2058934)))
+(assert_return (invoke "i64.load32u" (i64.const 0x10)) (i64.const 2058934))
+(assert_return (invoke "i64.load32s" (i64.const 0x10)) (i64.const 2058934))
+(assert_trap (invoke "i64.store32" (i64.const 0x100000000) (i64.const 2058934)) "out of bounds memory access")
+(assert_trap (invoke "i64.load32u" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "i64.load32s" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.store32_2" (i64.const 0x10) (i64.const 2058934)) "out of bounds memory access")
+(assert_trap (invoke "i64.load32u_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "i64.load32s_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; f32
+(assert_return (invoke "f32.store" (i64.const 0x10) (f32.const 1234.5)))
+(assert_return (invoke "f32.load" (i64.const 0x10)) (f32.const 1234.5))
+(assert_trap (invoke "f32.store" (i64.const 0x100000000) (f32.const 1234.5)) "out of bounds memory access")
+(assert_trap (invoke "f32.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "f32.store_2" (i64.const 0x10) (f32.const 1234.5)) "out of bounds memory access")
+(assert_trap (invoke "f32.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; f64
+(assert_return (invoke "f64.store" (i64.const 0x10) (f64.const 123456789.5)))
+(assert_return (invoke "f64.load" (i64.const 0x10)) (f64.const 123456789.5))
+(assert_trap (invoke "f64.store" (i64.const 0x100000000) (f64.const 123456789.5)) "out of bounds memory access")
+(assert_trap (invoke "f64.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "f64.store_2" (i64.const 0x10) (f64.const 123456789.5)) "out of bounds memory access")
+(assert_trap (invoke "f64.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128
+(assert_return (invoke "v128.store" (i64.const 0x10) (v128.const i64x2 1 2)))
+(assert_return (invoke "v128.load" (i64.const 0x10)) (v128.const i64x2 1 2))
+(assert_trap (invoke "v128.store" (i64.const 0x100000000) (v128.const i64x2 1 2)) "out of bounds memory access")
+(assert_trap (invoke "v128.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store_2" (i64.const 0x10) (v128.const i64x2 1 2)) "out of bounds memory access")
+(assert_trap (invoke "v128.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; clear mem
+(assert_return (invoke "v128.store" (i64.const 0x10) (v128.const i64x2 0 0)))
+
+;; v128 8x8
+(assert_return (invoke "v128.load8x8s" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load8x8u" (i64.const 0x10)) (v128.const i64x2 0 0))
+
+(assert_trap (invoke "v128.load8x8s" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load8x8u" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load8x8s_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load8x8u_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 16x4
+(assert_return (invoke "v128.load16x4s" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load16x4u" (i64.const 0x10)) (v128.const i64x2 0 0))
+
+(assert_trap (invoke "v128.load16x4s" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16x4u" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load16x4s_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16x4u_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 32x2
+(assert_return (invoke "v128.load32x2s" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load32x2u" (i64.const 0x10)) (v128.const i64x2 0 0))
+
+(assert_trap (invoke "v128.load32x2s" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32x2u" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load32x2s_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32x2u_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 splat
+(assert_return (invoke "v128.load8splat" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load16splat" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load32splat" (i64.const 0x10)) (v128.const i64x2 0 0))
+(assert_return (invoke "v128.load64splat" (i64.const 0x10)) (v128.const i64x2 0 0))
+
+(assert_trap (invoke "v128.load8splat" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16splat" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32splat" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64splat" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load8splat_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16splat_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32splat_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64splat_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 lane 8
+(assert_return (invoke "v128.store8lane" (i64.const 0x10) (v128.const i8x16 75 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+(assert_return (invoke "v128.load8lane" (i64.const 0x10)) (v128.const i8x16 75 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+
+(assert_trap (invoke "v128.store8lane" (i64.const 0x100000000) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load8lane" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store8lane_2" (i64.const 0x10) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load8lane_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 lane 16
+(assert_return (invoke "v128.store16lane" (i64.const 0x10) (v128.const i16x8 30678 0 0 0 0 0 0 0)))
+(assert_return (invoke "v128.load16lane" (i64.const 0x10)) (v128.const i16x8 30678 0 0 0 0 0 0 0))
+
+(assert_trap (invoke "v128.store16lane" (i64.const 0x100000000) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16lane" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store16lane_2" (i64.const 0x10) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load16lane_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 lane 32
+(assert_return (invoke "v128.store32lane" (i64.const 0x10) (v128.const i32x4 2180785617 0 0 0)))
+(assert_return (invoke "v128.load32lane" (i64.const 0x10)) (v128.const i32x4 2180785617 0 0 0))
+
+(assert_trap (invoke "v128.store32lane" (i64.const 0x100000000) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32lane" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store32lane_2" (i64.const 0x10) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load32lane_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 lane 64
+(assert_return (invoke "v128.store64lane" (i64.const 0x10) (v128.const i64x2 314756237046123789 0)))
+(assert_return (invoke "v128.load64lane" (i64.const 0x10)) (v128.const i64x2 314756237046123789 0))
+
+(assert_trap (invoke "v128.store64lane" (i64.const 0x100000000) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64lane" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.store64lane_2" (i64.const 0x10) (v128.const i64x2 0 0)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64lane_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; v128 load zero
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 1579840812)))
+(assert_return (invoke "v128.load32zero" (i64.const 0x10)) (v128.const i32x4 1579840812 0 0 0))
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 84592345257645125)))
+(assert_return (invoke "v128.load64zero" (i64.const 0x10)) (v128.const i64x2 84592345257645125 0))
+
+(assert_trap (invoke "v128.load32zero" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64zero" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "v128.load32zero_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "v128.load64zero_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; atomic core
+(assert_return (invoke "atomic.notify" (i64.const 0x10)))
+(assert_return (invoke "memory.atomic.wait32" (i64.const 0x10)))
+(assert_return (invoke "memory.atomic.wait64" (i64.const 0x10)))
+
+(assert_trap (invoke "atomic.notify" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait32" (i64.const 0x100000000)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait64" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "atomic.notify_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait32_2" (i64.const 0x10)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait64_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32 atomic
+(assert_return (invoke "i32.atomic.store" (i64.const 0x10) (i32.const 1480532187)))
+(assert_return (invoke "i32.atomic.load" (i64.const 0x10)) (i32.const 1480532187))
+
+(assert_trap (invoke "i32.atomic.store" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.store_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32 atomic 8
+(assert_return (invoke "i32.atomic.store8" (i64.const 0x10) (i32.const 245)))
+(assert_return (invoke "i32.atomic.load8" (i64.const 0x10)) (i32.const 245))
+
+(assert_trap (invoke "i32.atomic.store8" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load8" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.store8_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load8_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32 atomic 16
+(assert_return (invoke "i32.atomic.store16" (i64.const 0x10) (i32.const 63416)))
+(assert_return (invoke "i32.atomic.load16" (i64.const 0x10)) (i32.const 63416))
+
+(assert_trap (invoke "i32.atomic.store16" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load16" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.store16_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.load16_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64 atomic
+(assert_return (invoke "i64.atomic.store" (i64.const 0x10) (i64.const 8923601264510235)))
+(assert_return (invoke "i64.atomic.load" (i64.const 0x10)) (i64.const 8923601264510235))
+
+(assert_trap (invoke "i64.atomic.store" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.store_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64 atomic 8
+(assert_return (invoke "i64.atomic.store8" (i64.const 0x10) (i64.const 208)))
+(assert_return (invoke "i64.atomic.load8" (i64.const 0x10)) (i64.const 208))
+
+(assert_trap (invoke "i64.atomic.store8" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load8" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.store8_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load8_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64 atomic 16
+(assert_return (invoke "i64.atomic.store16" (i64.const 0x10) (i64.const 58930)))
+(assert_return (invoke "i64.atomic.load16" (i64.const 0x10)) (i64.const 58930))
+
+(assert_trap (invoke "i64.atomic.store16" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load16" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.store16_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load16_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i64 atomic 32
+(assert_return (invoke "i64.atomic.store32" (i64.const 0x10) (i64.const 4035164968)))
+(assert_return (invoke "i64.atomic.load32" (i64.const 0x10)) (i64.const 4035164968))
+
+(assert_trap (invoke "i64.atomic.store32" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load32" (i64.const 0x100000000)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.store32_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.load32_2" (i64.const 0x10)) "out of bounds memory access")
+
+;; i32 atomic rmw
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 0)))
+(assert_return (invoke "i32.atomic.rmw.add" (i64.const 0x10) (i32.const 1684902794)) (i32.const 0))
+(assert_return (invoke "i32.atomic.rmw.sub" (i64.const 0x10) (i32.const 1684902794)) (i32.const 1684902794))
+
+(assert_trap (invoke "i32.atomic.rmw.add" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw.sub" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw.add_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw.sub_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+
+;; i32 atomic rmw 8
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 0)))
+(assert_return (invoke "i32.atomic.rmw8.or" (i64.const 0x10) (i32.const 159)) (i32.const 0))
+(assert_return (invoke "i32.atomic.rmw8.xor" (i64.const 0x10) (i32.const 159)) (i32.const 159))
+
+(assert_trap (invoke "i32.atomic.rmw8.or" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.xor" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw8.or_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.xor_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+
+;; i32 atomic rmw 16
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 0)))
+(assert_return (invoke "i32.atomic.rmw16.or" (i64.const 0x10) (i32.const 159)) (i32.const 0))
+(assert_return (invoke "i32.atomic.rmw16.and" (i64.const 0x10) (i32.const 159)) (i32.const 159))
+
+(assert_trap (invoke "i32.atomic.rmw16.or" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.and" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw16.or_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.and_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+
+;; i64 atomic rmw
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 0)))
+(assert_return (invoke "i64.atomic.rmw.add" (i64.const 0x10) (i64.const 194602756123704341)) (i64.const 0))
+(assert_return (invoke "i64.atomic.rmw.sub" (i64.const 0x10) (i64.const 194602756123704341)) (i64.const 194602756123704341))
+
+(assert_trap (invoke "i64.atomic.rmw.add" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw.sub" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw.add_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw.sub_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i64 atomic rmw 8
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 0)))
+(assert_return (invoke "i64.atomic.rmw8.or" (i64.const 0x10) (i64.const 180)) (i64.const 0))
+(assert_return (invoke "i64.atomic.rmw8.xor" (i64.const 0x10) (i64.const 180)) (i64.const 180))
+
+(assert_trap (invoke "i64.atomic.rmw8.or" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.xor" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw8.or_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.xor_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i64 atomic rmw 16
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 0)))
+(assert_return (invoke "i64.atomic.rmw16.or" (i64.const 0x10) (i64.const 59468)) (i64.const 0))
+(assert_return (invoke "i64.atomic.rmw16.and" (i64.const 0x10) (i64.const 59468)) (i64.const 59468))
+
+(assert_trap (invoke "i64.atomic.rmw16.or" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.and" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw16.or_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.and_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i64 atomic rmw 32
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 0)))
+(assert_return (invoke "i64.atomic.rmw32.add" (i64.const 0x10) (i64.const 1962460524)) (i64.const 0))
+(assert_return (invoke "i64.atomic.rmw32.and" (i64.const 0x10) (i64.const 1962460524)) (i64.const 1962460524))
+
+(assert_trap (invoke "i64.atomic.rmw32.add" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.and" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw32.add_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.and_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i32 atomic Xchg
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 1683920478)))
+(assert_return (invoke "i32.atomic.rmw.xchg" (i64.const 0x10) (i32.const 0)) (i32.const 1683920478))
+(assert_return (invoke "i32.store8" (i64.const 0x10) (i32.const 238)))
+(assert_return (invoke "i32.atomic.rmw8.xchg" (i64.const 0x10) (i32.const 0)) (i32.const 238))
+(assert_return (invoke "i32.store16" (i64.const 0x10) (i32.const 57840)))
+(assert_return (invoke "i32.atomic.rmw16.xchg" (i64.const 0x10) (i32.const 0)) (i32.const 57840))
+
+(assert_trap (invoke "i32.atomic.rmw.xchg" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.xchg" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.xchg" (i64.const 0x100000000) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw.xchg_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.xchg_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.xchg_2" (i64.const 0x10) (i32.const 0)) "out of bounds memory access")
+
+;; i64 atomic Xchg
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 7686420451258)))
+(assert_return (invoke "i64.atomic.rmw.xchg" (i64.const 0x10) (i64.const 0)) (i64.const 7686420451258))
+(assert_return (invoke "i64.store8" (i64.const 0x10) (i64.const 226)))
+(assert_return (invoke "i64.atomic.rmw8.xchg" (i64.const 0x10) (i64.const 0)) (i64.const 226))
+(assert_return (invoke "i64.store16" (i64.const 0x10) (i64.const 53651)))
+(assert_return (invoke "i64.atomic.rmw16.xchg" (i64.const 0x10) (i64.const 0)) (i64.const 53651))
+(assert_return (invoke "i64.store32" (i64.const 0x10) (i64.const 1687254093)))
+(assert_return (invoke "i64.atomic.rmw32.xchg" (i64.const 0x10) (i64.const 0)) (i64.const 1687254093))
+
+(assert_trap (invoke "i64.atomic.rmw.xchg" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.xchg" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.xchg" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.xchg" (i64.const 0x100000000) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw.xchg_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.xchg_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.xchg_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.xchg_2" (i64.const 0x10) (i64.const 0)) "out of bounds memory access")
+
+;; i32 atomic Cmpxchg
+(assert_return (invoke "i32.store_2" (i64.const 0x10) (i32.const 1809274815)))
+(assert_return (invoke "i32.atomic.rmw.cmpxchg" (i64.const 0x10) (i32.const 1809274815) (i32.const 0)) (i32.const 1809274815))
+(assert_return (invoke "i32.store8" (i64.const 0x10) (i32.const 164)))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg" (i64.const 0x10) (i32.const 164) (i32.const 0)) (i32.const 164))
+(assert_return (invoke "i32.store16" (i64.const 0x10) (i32.const 59218)))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg" (i64.const 0x10) (i32.const 59218) (i32.const 0)) (i32.const 59218))
+
+(assert_trap (invoke "i32.atomic.rmw.cmpxchg" (i64.const 0x100000000) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.cmpxchg" (i64.const 0x100000000) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.cmpxchg" (i64.const 0x100000000) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i32.atomic.rmw.cmpxchg_2" (i64.const 0x10) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw8.cmpxchg_2" (i64.const 0x10) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i32.atomic.rmw16.cmpxchg_2" (i64.const 0x10) (i32.const 0) (i32.const 0)) "out of bounds memory access")
+
+;; i64 atomic Cmpxchg
+(assert_return (invoke "i64.store_2" (i64.const 0x10) (i64.const 127857628907652)))
+(assert_return (invoke "i64.atomic.rmw.cmpxchg" (i64.const 0x10) (i64.const 127857628907652) (i64.const 0)) (i64.const 127857628907652))
+(assert_return (invoke "i64.store8" (i64.const 0x10) (i64.const 201)))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg" (i64.const 0x10) (i64.const 201) (i64.const 0)) (i64.const 201))
+(assert_return (invoke "i64.store16" (i64.const 0x10) (i64.const 60437)))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg" (i64.const 0x10) (i64.const 60437) (i64.const 0)) (i64.const 60437))
+(assert_return (invoke "i64.store32" (i64.const 0x10) (i64.const 2067381469)))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg" (i64.const 0x10) (i64.const 2067381469) (i64.const 0)) (i64.const 2067381469))
+
+(assert_trap (invoke "i64.atomic.rmw.cmpxchg" (i64.const 0x100000000) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.cmpxchg" (i64.const 0x100000000) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.cmpxchg" (i64.const 0x100000000) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.cmpxchg" (i64.const 0x100000000) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+
+(assert_trap (invoke "i64.atomic.rmw.cmpxchg_2" (i64.const 0x10) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw8.cmpxchg_2" (i64.const 0x10) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw16.cmpxchg_2" (i64.const 0x10) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "i64.atomic.rmw32.cmpxchg_2" (i64.const 0x10) (i64.const 0) (i64.const 0)) "out of bounds memory access")

--- a/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
+++ b/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
@@ -59,14 +59,14 @@ public:
     virtual void OnImportFunc(Index importIndex, std::string moduleName, std::string fieldName, Index funcIndex, Index sigIndex) = 0;
     virtual void OnImportGlobal(Index importIndex, std::string moduleName, std::string fieldName, Index globalIndex, Type type, bool mutable_) = 0;
     virtual void OnImportTable(Index importIndex, std::string moduleName, std::string fieldName, Index tableIndex, Type type, size_t initialSize, size_t maximumSize) = 0;
-    virtual void OnImportMemory(Index importIndex, std::string moduleName, std::string fieldName, Index memoryIndex, size_t initialSize, size_t maximumSize, bool isShared) = 0;
+    virtual void OnImportMemory(Index importIndex, std::string moduleName, std::string fieldName, Index memoryIndex, size_t initialSize, size_t maximumSize, bool isShared, bool is64) = 0;
     virtual void OnImportTag(Index importIndex, std::string moduleName, std::string fieldName, Index tagIndex, Index sigIndex) = 0;
 
     virtual void OnExportCount(Index count) = 0;
     virtual void OnExport(int kind, Index exportIndex, std::string name, Index itemIndex) = 0;
 
     virtual void OnMemoryCount(Index count) = 0;
-    virtual void OnMemory(Index index, uint64_t initialSize, uint64_t maximumSize, bool isShared) = 0;
+    virtual void OnMemory(Index index, uint64_t initialSize, uint64_t maximumSize, bool isShared, bool is64) = 0;
 
     virtual void OnDataSegmentCount(Index count) = 0;
     virtual void BeginDataSegment(Index index, Index memoryIndex, uint8_t flags) = 0;

--- a/third_party/wabt/src/walrus/binary-reader-walrus.cc
+++ b/third_party/wabt/src/walrus/binary-reader-walrus.cc
@@ -90,6 +90,7 @@ static Features getFeatures(const uint32_t featureFlags) {
         features.enable_tail_call();
         features.enable_gc();
         features.enable_multi_memory();
+        features.enable_memory64();
     }
     return features;
 }
@@ -264,7 +265,7 @@ public:
     Result OnImportMemory(Index import_index, nonstd::string_view module_name, nonstd::string_view field_name, Index memory_index, const Limits *page_limits, uint32_t page_size) override {
         CHECK_RESULT(m_validator.OnMemory(GetLocation(), *page_limits, page_size));
         m_externalDelegate->OnImportMemory(import_index, std::string(module_name), std::string(field_name), memory_index, page_limits->initial,
-            page_limits->has_max ? page_limits->max : page_size - 1, page_limits->is_shared);
+            page_limits->has_max ? page_limits->max : page_size - 1, page_limits->is_shared, page_limits->is_64);
         return Result::Ok;
     }
     Result OnImportGlobal(Index import_index, nonstd::string_view module_name, nonstd::string_view field_name, Index global_index, Type type, bool mutable_) override {
@@ -348,7 +349,8 @@ public:
     }
     Result OnMemory(Index index, const Limits *limits, uint32_t page_size) override {
         CHECK_RESULT(m_validator.OnMemory(GetLocation(), *limits, page_size));
-        m_externalDelegate->OnMemory(index, limits->initial, limits->has_max ? limits->max : page_size - 1, limits->is_shared);
+        m_externalDelegate->OnMemory(index, limits->initial, limits->has_max ? limits->max : page_size - 1,
+                                     limits->is_shared, limits->is_64);
         return Result::Ok;
     }
     Result EndMemorySection() override {

--- a/tools/jit_exclude_list.txt
+++ b/tools/jit_exclude_list.txt
@@ -1,0 +1,1 @@
+memory64_memoptypes.wast


### PR DESCRIPTION
Large patch (4200 lines) which implements the Memory 64 variant for all memory / load store opcodes in the interpreter. This is not a full support, the memory.grow, memory.init etc. are not implemented yet.

The patch contains a lot of code duplications. Also #394 should land first.

There was no test for simd / atomic + memidx opcode variants, and this patch adds them. There were typos in the code for these variants.