### PR TITLE
Implement JIT support for memory64 instructions

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -4126,10 +4126,10 @@ public:
 #endif
 };
 
-class MemoryAtomicWait32MemIdx : public ByteCodeOffset4Value {
+class MemoryAtomicWait32MemIdx : public ByteCodeOffset4ValueMemIdx {
 public:
     MemoryAtomicWait32MemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
-        : ByteCodeOffset4Value(Opcode::MemoryAtomicWait32MemIdxOpcode, src0, src1, src2, dst, offset)
+        : ByteCodeOffset4ValueMemIdx(index, alignment, Opcode::MemoryAtomicWait32MemIdxOpcode, src0, src1, src2, dst, offset)
         , m_memIndex(index)
         , m_alignment(alignment)
     {
@@ -4153,10 +4153,10 @@ protected:
     uint16_t m_alignment;
 };
 
-class MemoryAtomicWait32MemIdxM64 : public ByteCodeOffset4Value64 {
+class MemoryAtomicWait32MemIdxM64 : public ByteCodeOffset4Value64MemIdx {
 public:
     MemoryAtomicWait32MemIdxM64(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
-        : ByteCodeOffset4Value64(Opcode::MemoryAtomicWait32MemIdxM64Opcode, src0, src1, src2, dst, offset)
+        : ByteCodeOffset4Value64MemIdx(index, alignment, Opcode::MemoryAtomicWait32MemIdxM64Opcode, src0, src1, src2, dst, offset)
         , m_memIndex(index)
         , m_alignment(alignment)
     {
@@ -4210,10 +4210,10 @@ public:
 #endif
 };
 
-class MemoryAtomicWait64MemIdx : public ByteCodeOffset4Value {
+class MemoryAtomicWait64MemIdx : public ByteCodeOffset4ValueMemIdx {
 public:
     MemoryAtomicWait64MemIdx(uint32_t index, uint32_t alignment, uint32_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
-        : ByteCodeOffset4Value(Opcode::MemoryAtomicWait64MemIdxOpcode, src0, src1, src2, dst, offset)
+        : ByteCodeOffset4ValueMemIdx(index, alignment, Opcode::MemoryAtomicWait64MemIdxOpcode, src0, src1, src2, dst, offset)
         , m_memIndex(index)
         , m_alignment(alignment)
     {
@@ -4238,10 +4238,10 @@ protected:
     uint16_t m_alignment;
 };
 
-class MemoryAtomicWait64MemIdxM64 : public ByteCodeOffset4Value64 {
+class MemoryAtomicWait64MemIdxM64 : public ByteCodeOffset4Value64MemIdx {
 public:
     MemoryAtomicWait64MemIdxM64(uint32_t index, uint32_t alignment, uint64_t offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1, ByteCodeStackOffset src2, ByteCodeStackOffset dst)
-        : ByteCodeOffset4Value64(Opcode::MemoryAtomicWait64MemIdxM64Opcode, src0, src1, src2, dst, offset)
+        : ByteCodeOffset4Value64MemIdx(index, alignment, Opcode::MemoryAtomicWait64MemIdxM64Opcode, src0, src1, src2, dst, offset)
         , m_memIndex(index)
         , m_alignment(alignment)
     {

--- a/src/jit/Compiler.h
+++ b/src/jit/Compiler.h
@@ -258,7 +258,9 @@ public:
     static const uint16_t kFreeUnusedEarly = 1 << 7;
     static const uint16_t kKeepInstruction = 1 << 8;
     static const uint16_t kEarlyReturn = kKeepInstruction;
+    // These two are only used by memory load/store instructions
     static const uint16_t kMultiMemory = 1 << 9;
+    static const uint16_t kMemory64 = 1 << 10;
 
     ByteCode::Opcode opcode() { return m_opcode; }
 

--- a/src/jit/RegisterAlloc.cpp
+++ b/src/jit/RegisterAlloc.cpp
@@ -605,7 +605,7 @@ bool RegisterFile::reuseResult(uint8_t type, VariableList::Variable** reusableRe
     }
 #endif
 #if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
-    bool isInt64 = (type & Instruction::TypeMask) == Instruction::Int64Operand;
+    bool isInt64 = (type & Instruction::TypeMask) == Instruction::Int64Operand || (type & Instruction::TypeMask) == Instruction::Int64LowOperand;
 #endif /* SLJIT_32BIT_ARCHITECTURE */
 
     for (uint32_t i = 0; i < 3; i++) {
@@ -623,8 +623,12 @@ bool RegisterFile::reuseResult(uint8_t type, VariableList::Variable** reusableRe
             registers->updateVariable(resultVariable->reg1, resultVariable);
 
 #if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
-            resultVariable->reg2 = variable->reg2;
-            registers->updateVariable(resultVariable->reg2, resultVariable);
+            resultVariable->reg2 = variable->reg1;
+            if (isInt64) {
+                ASSERT(variable->reg1 != variable->reg2);
+                resultVariable->reg2 = variable->reg2;
+                registers->updateVariable(resultVariable->reg2, resultVariable);
+            }
 #endif /* SLJIT_32BIT_ARCHITECTURE */
             return true;
         }

--- a/tools/jit_exclude_list.txt
+++ b/tools/jit_exclude_list.txt
@@ -1,1 +1,0 @@
-memory64_memoptypes.wast


### PR DESCRIPTION
Another big (1500 lines insert) patch. The JIT support for the already supported Memory 64 opcodes.