### PR TITLE
Implement memory64 management instructions

### DIFF
--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -320,9 +320,8 @@ static void emitInitR0R1(sljit_compiler* compiler, sljit_s32 movOp1, sljit_s32 m
     sljit_emit_op1(compiler, movOp2, SLJIT_R1, 0, SLJIT_TMP_DEST_REG, 0);
 }
 
-static void emitInitR0R1R2(sljit_compiler* compiler, sljit_s32 movOp1, sljit_s32 movOp2, sljit_s32 movOp3, Operand* params)
+static void emitInitR0R1R2Args(sljit_compiler* compiler, sljit_s32 movOp1, sljit_s32 movOp2, sljit_s32 movOp3, JITArg src[3])
 {
-    JITArg src[3] = { params, params + 1, params + 2 };
     int i = 0;
 
     if (src[1].arg == SLJIT_R0 || src[2].arg == SLJIT_R0) {
@@ -377,6 +376,12 @@ static void emitInitR0R1R2(sljit_compiler* compiler, sljit_s32 movOp1, sljit_s32
         sljit_emit_op1(compiler, movOps[other1], sljit_r1, 0, sljit_r2, 0);
         sljit_emit_op1(compiler, movOps[other2], sljit_r2, 0, SLJIT_TMP_DEST_REG, 0);
     }
+}
+
+static void emitInitR0R1R2(sljit_compiler* compiler, sljit_s32 movOp1, sljit_s32 movOp2, sljit_s32 movOp3, Operand* params)
+{
+    JITArg src[3] = { params, params + 1, params + 2 };
+    emitInitR0R1R2Args(compiler, movOp1, movOp2, movOp3, src);
 }
 
 static void emitSelect128(sljit_compiler*, Instruction*, sljit_s32);

--- a/src/jit/MemoryUtilInl.h
+++ b/src/jit/MemoryUtilInl.h
@@ -33,12 +33,68 @@ static sljit_sw initMemory(uint32_t dstStart, uint32_t srcStart, uint32_t srcSiz
     return ExecutionContext::NoError;
 }
 
+static sljit_sw initMemoryM64(sljit_uw dstStart, uint32_t srcStart, uint32_t srcSize, MemoryInitArguments* args)
+{
+    Memory* memory = args->memory;
+    DataSegment* data = args->data;
+
+    if (!memory->checkAccessM64(dstStart, srcSize)) {
+        return ExecutionContext::OutOfBoundsMemAccessError;
+    }
+
+    if (srcStart >= data->sizeInByte() || srcStart + srcSize > data->sizeInByte()) {
+        return ExecutionContext::OutOfBoundsMemAccessError;
+    }
+
+    memory->initMemory(data, dstStart, srcStart, srcSize);
+    return ExecutionContext::NoError;
+}
+
 static sljit_sw copyMemory(uint32_t dstStart, uint32_t srcStart, uint32_t size, MemoryCopyArguments* args)
 {
     Memory* srcMemory = args->srcMemory;
     Memory* dstMemory = args->dstMemory;
 
-    if (!srcMemory->checkAccess(srcStart, size) || !srcMemory->checkAccess(dstStart, size)) {
+    if (!srcMemory->checkAccess(srcStart, size) || !dstMemory->checkAccess(dstStart, size)) {
+        return ExecutionContext::OutOfBoundsMemAccessError;
+    }
+
+    srcMemory->copyMemory(dstMemory, dstStart, srcStart, size);
+    return ExecutionContext::NoError;
+}
+
+static sljit_sw copyMemoryM64(sljit_uw dstStart, sljit_uw srcStart, sljit_uw size, MemoryCopyArguments* args)
+{
+    Memory* srcMemory = args->srcMemory;
+    Memory* dstMemory = args->dstMemory;
+
+    if (!srcMemory->checkAccessM64(srcStart, size) || !dstMemory->checkAccessM64(dstStart, size)) {
+        return ExecutionContext::OutOfBoundsMemAccessError;
+    }
+
+    srcMemory->copyMemory(dstMemory, dstStart, srcStart, size);
+    return ExecutionContext::NoError;
+}
+
+static sljit_sw copyMemoryM64M32(sljit_uw dstStart, uint32_t srcStart, uint32_t size, MemoryCopyArguments* args)
+{
+    Memory* srcMemory = args->srcMemory;
+    Memory* dstMemory = args->dstMemory;
+
+    if (!srcMemory->checkAccess(srcStart, size) || !dstMemory->checkAccessM64(dstStart, size)) {
+        return ExecutionContext::OutOfBoundsMemAccessError;
+    }
+
+    srcMemory->copyMemory(dstMemory, dstStart, srcStart, size);
+    return ExecutionContext::NoError;
+}
+
+static sljit_sw copyMemoryM32M64(uint32_t dstStart, sljit_uw srcStart, uint32_t size, MemoryCopyArguments* args)
+{
+    Memory* srcMemory = args->srcMemory;
+    Memory* dstMemory = args->dstMemory;
+
+    if (!srcMemory->checkAccessM64(srcStart, size) || !dstMemory->checkAccess(dstStart, size)) {
         return ExecutionContext::OutOfBoundsMemAccessError;
     }
 
@@ -49,6 +105,16 @@ static sljit_sw copyMemory(uint32_t dstStart, uint32_t srcStart, uint32_t size, 
 static sljit_sw fillMemory(uint32_t start, uint32_t value, uint32_t size, Memory* memory)
 {
     if (!memory->checkAccess(start, size)) {
+        return ExecutionContext::OutOfBoundsMemAccessError;
+    }
+
+    memory->fillMemory(start, value, size);
+    return ExecutionContext::NoError;
+}
+
+static sljit_sw fillMemoryM64(sljit_uw start, uint32_t value, sljit_uw size, Memory* memory)
+{
+    if (!memory->checkAccessM64(start, size)) {
         return ExecutionContext::OutOfBoundsMemAccessError;
     }
 
@@ -68,6 +134,32 @@ static sljit_s32 growMemory(uint32_t newSize, Instance* instance, uint16_t memIn
     return -1;
 }
 
+static sljit_uw growMemoryM64(sljit_uw newSize, Instance* instance, uint16_t memIndex)
+{
+    Memory* memory = instance->memory(memIndex);
+    uint32_t oldSize = memory->sizeInPageSize();
+
+    if (static_cast<uint64_t>(newSize) < Memory::s_maxMemory64Grow && memory->grow(static_cast<uint64_t>(newSize) * Memory::s_memoryPageSize)) {
+        return static_cast<sljit_s32>(oldSize);
+    }
+
+    return -1;
+}
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+static void memoryParamToArg(sljit_compiler* compiler, CompileContext* context, Operand* param, JITArg* arg)
+{
+    JITArgPair argPair(param);
+
+    context->appendTrapJump(ExecutionContext::OutOfBoundsMemAccessError,
+                            sljit_emit_cmp(compiler, SLJIT_NOT_EQUAL, argPair.arg2, argPair.arg2w, SLJIT_IMM, 0));
+
+    arg->arg = argPair.arg1;
+    arg->argw = argPair.arg1w;
+}
+
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+
 static void emitMemory(sljit_compiler* compiler, Instruction* instr)
 {
     CompileContext* context = CompileContext::get(compiler);
@@ -78,26 +170,124 @@ static void emitMemory(sljit_compiler* compiler, Instruction* instr)
     case ByteCode::MemorySizeOpcode: {
         ASSERT(!(instr->info() & Instruction::kIsCallback));
 
-        uint16_t memIndex = reinterpret_cast<MemorySize*>(instr->byteCode())->memIndex();
+        uint16_t memIndex = reinterpret_cast<ByteCodeOffsetMemIndex*>(instr->byteCode())->memIndex();
         JITArg dstArg(params);
 
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
         /* The sizeInByte is always a 32 bit number on 32 bit systems. */
         sljit_emit_op2(compiler, SLJIT_LSHR, dstArg.arg, dstArg.argw, SLJIT_MEM1(kInstanceReg),
                        context->targetBuffersStart + offsetof(Memory::TargetBuffer, sizeInByte) + memIndex * sizeof(Memory::TargetBuffer) + WORD_LOW_OFFSET,
                        SLJIT_IMM, 16);
+#else /* !SLJIT_32BIT_ARCHITECTURE */
+        sljit_emit_op2(compiler, SLJIT_LSHR, SLJIT_TMP_DEST_REG, 0, SLJIT_MEM1(kInstanceReg),
+                       context->targetBuffersStart + offsetof(Memory::TargetBuffer, sizeInByte) + memIndex * sizeof(Memory::TargetBuffer),
+                       SLJIT_IMM, 16);
+        sljit_emit_op1(compiler, SLJIT_MOV_U32, dstArg.arg, dstArg.argw, SLJIT_TMP_DEST_REG, 0);
+#endif /* SLJIT_32BIT_ARCHITECTURE */
+        return;
+    }
+    case ByteCode::MemorySizeM64Opcode: {
+        ASSERT(!(instr->info() & Instruction::kIsCallback));
+
+        uint16_t memIndex = reinterpret_cast<ByteCodeOffsetMemIndex*>(instr->byteCode())->memIndex();
+
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        JITArgPair dstArgPair(params);
+        /* The sizeInByte is always a 32 bit number on 32 bit systems. */
+        sljit_emit_op2(compiler, SLJIT_LSHR, dstArgPair.arg1, dstArgPair.arg1w, SLJIT_MEM1(kInstanceReg),
+                       context->targetBuffersStart + offsetof(Memory::TargetBuffer, sizeInByte) + memIndex * sizeof(Memory::TargetBuffer) + WORD_LOW_OFFSET,
+                       SLJIT_IMM, 16);
+        sljit_emit_op1(compiler, SLJIT_MOV, dstArgPair.arg2, dstArgPair.arg2w, SLJIT_IMM, 0);
+#else /* !SLJIT_32BIT_ARCHITECTURE */
+        JITArg dstArg(params);
+        sljit_emit_op2(compiler, SLJIT_LSHR, dstArg.arg, dstArg.argw, SLJIT_MEM1(kInstanceReg),
+                       context->targetBuffersStart + offsetof(Memory::TargetBuffer, sizeInByte) + memIndex * sizeof(Memory::TargetBuffer),
+                       SLJIT_IMM, 16);
+#endif /* SLJIT_32BIT_ARCHITECTURE */
         return;
     }
     case ByteCode::MemoryInitOpcode:
+    case ByteCode::MemoryInitM64Opcode:
+    case ByteCode::MemoryFillOpcode:
+    case ByteCode::MemoryFillM64Opcode:
     case ByteCode::MemoryCopyOpcode:
-    case ByteCode::MemoryFillOpcode: {
+    case ByteCode::MemoryCopyM64Opcode:
+    case ByteCode::MemoryCopyM64M32Opcode:
+    case ByteCode::MemoryCopyM32M64Opcode: {
         ASSERT(instr->info() & Instruction::kIsCallback);
 
-        emitInitR0R1R2(compiler, SLJIT_MOV32, SLJIT_MOV32, SLJIT_MOV32, params);
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        JITArg src[3];
+
+        switch (opcode) {
+        case ByteCode::MemoryInitM64Opcode:
+        case ByteCode::MemoryCopyM64M32Opcode:
+            memoryParamToArg(compiler, context, params + 0, src + 0);
+            src[1].set(params + 1);
+            src[2].set(params + 2);
+            break;
+        case ByteCode::MemoryCopyM64Opcode:
+            memoryParamToArg(compiler, context, params + 0, src + 0);
+            memoryParamToArg(compiler, context, params + 1, src + 1);
+            memoryParamToArg(compiler, context, params + 2, src + 2);
+            break;
+        case ByteCode::MemoryCopyM32M64Opcode:
+            src[0].set(params + 0);
+            memoryParamToArg(compiler, context, params + 1, src + 1);
+            src[2].set(params + 2);
+            break;
+        case ByteCode::MemoryFillM64Opcode:
+            memoryParamToArg(compiler, context, params + 0, src + 0);
+            src[1].set(params + 1);
+            memoryParamToArg(compiler, context, params + 2, src + 2);
+            break;
+        default:
+            src[0].set(params + 0);
+            src[1].set(params + 1);
+            src[2].set(params + 2);
+            break;
+        }
+        emitInitR0R1R2Args(compiler, SLJIT_MOV, SLJIT_MOV, SLJIT_MOV, src);
+#else /* !SLJIT_32BIT_ARCHITECTURE */
+        sljit_s32 movOp1, movOp2, movOp3;
+
+        switch (opcode) {
+        case ByteCode::MemoryInitM64Opcode:
+        case ByteCode::MemoryCopyM64M32Opcode:
+            movOp1 = SLJIT_MOV;
+            movOp2 = SLJIT_MOV32;
+            movOp3 = SLJIT_MOV32;
+            break;
+        case ByteCode::MemoryCopyM64Opcode:
+            movOp1 = SLJIT_MOV;
+            movOp2 = SLJIT_MOV;
+            movOp3 = SLJIT_MOV;
+            break;
+        case ByteCode::MemoryCopyM32M64Opcode:
+            movOp1 = SLJIT_MOV32;
+            movOp2 = SLJIT_MOV;
+            movOp3 = SLJIT_MOV32;
+            break;
+        case ByteCode::MemoryFillM64Opcode:
+            movOp1 = SLJIT_MOV;
+            movOp2 = SLJIT_MOV32;
+            movOp3 = SLJIT_MOV;
+            break;
+        default:
+            movOp1 = SLJIT_MOV32;
+            movOp2 = SLJIT_MOV32;
+            movOp3 = SLJIT_MOV32;
+            break;
+        }
+        emitInitR0R1R2(compiler, movOp1, movOp2, movOp3, params);
+#endif /* SLJIT_32BIT_ARCHITECTURE */
 
         sljit_sw addr;
 
-        if (opcode == ByteCode::MemoryInitOpcode) {
-            MemoryInit* memoryInit = reinterpret_cast<MemoryInit*>(instr->byteCode());
+        switch (opcode) {
+        case ByteCode::MemoryInitOpcode:
+        case ByteCode::MemoryInitM64Opcode: {
+            ByteCodeOffset3MemIndexSegmentIndex* memoryInit = reinterpret_cast<ByteCodeOffset3MemIndexSegmentIndex*>(instr->byteCode());
 
             sljit_sw stackTmpStart = CompileContext::get(compiler)->stackTmpStart;
             sljit_get_local_base(compiler, SLJIT_R3, 0, stackTmpStart);
@@ -105,8 +295,18 @@ static void emitMemory(sljit_compiler* compiler, Instruction* instr)
                            SLJIT_MEM1(kInstanceReg), Instance::alignedSize() + memoryInit->memIndex() * sizeof(void*));
             sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_MEM1(SLJIT_SP), OffsetOfStackTmp(MemoryInitArguments, data),
                            kInstanceReg, 0, SLJIT_IMM, context->dataSegmentsStart + (memoryInit->segmentIndex() * sizeof(ElementSegment)));
-            addr = GET_FUNC_ADDR(sljit_sw, initMemory);
-        } else if (opcode == ByteCode::MemoryCopyOpcode) {
+            addr = (opcode == ByteCode::MemoryInitOpcode) ? GET_FUNC_ADDR(sljit_sw, initMemory) : GET_FUNC_ADDR(sljit_sw, initMemoryM64);
+            break;
+        }
+        case ByteCode::MemoryFillOpcode:
+        case ByteCode::MemoryFillM64Opcode: {
+            ByteCodeOffset3MemIndex* memoryFill = reinterpret_cast<ByteCodeOffset3MemIndex*>(instr->byteCode());
+
+            sljit_emit_op1(compiler, SLJIT_MOV_P, SLJIT_R3, 0, SLJIT_MEM1(kInstanceReg), Instance::alignedSize() + memoryFill->memIndex() * sizeof(void*));
+            addr = (opcode == ByteCode::MemoryFillOpcode) ? GET_FUNC_ADDR(sljit_sw, fillMemory) : GET_FUNC_ADDR(sljit_sw, fillMemoryM64);
+            break;
+        }
+        default: {
             MemoryCopy* memoryCopy = reinterpret_cast<MemoryCopy*>(instr->byteCode());
 
             sljit_sw stackTmpStart = CompileContext::get(compiler)->stackTmpStart;
@@ -115,12 +315,23 @@ static void emitMemory(sljit_compiler* compiler, Instruction* instr)
                            SLJIT_MEM1(kInstanceReg), Instance::alignedSize() + memoryCopy->srcMemIndex() * sizeof(void*));
             sljit_emit_op1(compiler, SLJIT_MOV_P, SLJIT_MEM1(SLJIT_SP), OffsetOfStackTmp(MemoryCopyArguments, dstMemory),
                            SLJIT_MEM1(kInstanceReg), Instance::alignedSize() + memoryCopy->dstMemIndex() * sizeof(void*));
-            addr = GET_FUNC_ADDR(sljit_sw, copyMemory);
-        } else {
-            MemoryFill* memoryFill = reinterpret_cast<MemoryFill*>(instr->byteCode());
 
-            sljit_emit_op1(compiler, SLJIT_MOV_P, SLJIT_R3, 0, SLJIT_MEM1(kInstanceReg), Instance::alignedSize() + memoryFill->memIndex() * sizeof(void*));
-            addr = GET_FUNC_ADDR(sljit_sw, fillMemory);
+            switch (opcode) {
+            case ByteCode::MemoryCopyM64Opcode:
+                addr = GET_FUNC_ADDR(sljit_sw, copyMemoryM64);
+                break;
+            case ByteCode::MemoryCopyM64M32Opcode:
+                addr = GET_FUNC_ADDR(sljit_sw, copyMemoryM64M32);
+                break;
+            case ByteCode::MemoryCopyM32M64Opcode:
+                addr = GET_FUNC_ADDR(sljit_sw, copyMemoryM32M64);
+                break;
+            default:
+                addr = GET_FUNC_ADDR(sljit_sw, copyMemory);
+                break;
+            }
+            break;
+        }
         }
 
         sljit_emit_icall(compiler, SLJIT_CALL, SLJIT_ARGS4(W, 32, 32, 32, P), SLJIT_IMM, addr);
@@ -130,21 +341,43 @@ static void emitMemory(sljit_compiler* compiler, Instruction* instr)
         return;
     }
     default: {
-        ASSERT(opcode == ByteCode::MemoryGrowOpcode && (instr->info() & Instruction::kIsCallback));
+        ASSERT((opcode == ByteCode::MemoryGrowOpcode || opcode == ByteCode::MemoryGrowM64Opcode) && (instr->info() & Instruction::kIsCallback));
 
-        uint16_t memIndex = reinterpret_cast<MemoryGrow*>(instr->byteCode())->memIndex();
+        uint16_t memIndex = reinterpret_cast<ByteCodeOffset2MemIndex*>(instr->byteCode())->memIndex();
 
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        JITArg arg;
+        if (opcode == ByteCode::MemoryGrowOpcode) {
+            arg.set(params);
+        } else {
+            memoryParamToArg(compiler, context, params + 0, &arg);
+        }
+        MOVE_TO_REG(compiler, SLJIT_MOV, SLJIT_R0, arg.arg, arg.argw);
+#else /* !SLJIT_32BIT_ARCHITECTURE */
         JITArg arg(params);
+        sljit_s32 movOpcode = (opcode == ByteCode::MemoryGrowOpcode) ? SLJIT_MOV32 : SLJIT_MOV;
+        MOVE_TO_REG(compiler, movOpcode, SLJIT_R0, arg.arg, arg.argw);
+#endif /* SLJIT_32BIT_ARCHITECTURE */
 
-        MOVE_TO_REG(compiler, SLJIT_MOV32, SLJIT_R0, arg.arg, arg.argw);
         sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, kInstanceReg, 0);
         sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R2, 0, SLJIT_IMM, memIndex);
 
-        sljit_sw addr = GET_FUNC_ADDR(sljit_sw, growMemory);
+        sljit_sw addr = (opcode == ByteCode::MemoryGrowOpcode) ? GET_FUNC_ADDR(sljit_sw, growMemory) : GET_FUNC_ADDR(sljit_sw, growMemoryM64);
         sljit_emit_icall(compiler, SLJIT_CALL, SLJIT_ARGS3(32, 32, W, W), SLJIT_IMM, addr);
 
+#if (defined SLJIT_32BIT_ARCHITECTURE && SLJIT_32BIT_ARCHITECTURE)
+        if (opcode == ByteCode::MemoryGrowOpcode) {
+            arg.set(params + 1);
+            MOVE_FROM_REG(compiler, SLJIT_MOV, arg.arg, arg.argw, SLJIT_R0);
+        } else {
+            JITArgPair argPair(params + 1);
+            MOVE_FROM_REG(compiler, SLJIT_MOV, argPair.arg1, argPair.arg1w, SLJIT_R0);
+            sljit_emit_op1(compiler, SLJIT_MOV, argPair.arg2, argPair.arg2w, SLJIT_IMM, 0);
+        }
+#else /* !SLJIT_32BIT_ARCHITECTURE */
         arg.set(params + 1);
-        MOVE_FROM_REG(compiler, SLJIT_MOV32, arg.arg, arg.argw, SLJIT_R0);
+        MOVE_FROM_REG(compiler, movOpcode, arg.arg, arg.argw, SLJIT_R0);
+#endif /* SLJIT_32BIT_ARCHITECTURE */
         return;
     }
     }

--- a/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
+++ b/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
@@ -147,12 +147,12 @@ public:
     virtual void OnTryExpr(Type sigType) = 0;
     virtual void OnCatchExpr(Index tagIndex) = 0;
     virtual void OnCatchAllExpr() = 0;
-    virtual void OnMemoryGrowExpr(Index memidx) = 0;
-    virtual void OnMemoryInitExpr(Index segmentIndex, Index memidx) = 0;
+    virtual void OnMemoryGrowExpr(Index memIdx) = 0;
+    virtual void OnMemoryInitExpr(Index segmentIndex, Index memIdx) = 0;
     virtual void OnMemoryCopyExpr(Index srcMemIndex, Index dstMemIndex) = 0;
-    virtual void OnMemoryFillExpr(Index memidx) = 0;
+    virtual void OnMemoryFillExpr(Index memIdx) = 0;
     virtual void OnDataDropExpr(Index segmentIndex) = 0;
-    virtual void OnMemorySizeExpr(Index memidx) = 0;
+    virtual void OnMemorySizeExpr(Index memIdx) = 0;
     virtual void OnTableGetExpr(Index table_index) = 0;
     virtual void OnTableSetExpr(Index table_index) = 0;
     virtual void OnTableGrowExpr(Index table_index) = 0;

--- a/third_party/wabt/src/walrus/binary-reader-walrus.cc
+++ b/third_party/wabt/src/walrus/binary-reader-walrus.cc
@@ -799,7 +799,7 @@ public:
         return Result::Ok;
     }
     Result OnMemoryCopyExpr(Index destmemidx, Index srcmemidx) override {
-        CHECK_RESULT(m_validator.OnMemoryCopy(GetLocation(), Var(srcmemidx, GetLocation()), Var(destmemidx, GetLocation())));
+        CHECK_RESULT(m_validator.OnMemoryCopy(GetLocation(), Var(destmemidx, GetLocation()), Var(srcmemidx, GetLocation())));
         SHOULD_GENERATE_BYTECODE;
         m_externalDelegate->OnMemoryCopyExpr(srcmemidx, destmemidx);
         return Result::Ok;


### PR DESCRIPTION
This patch adds memory 64 support for memory management instructions.

This patch should be landed after #396
