### PR TITLE
Implement table 64 construction support

### DIFF
--- a/src/api/wasm.cpp
+++ b/src/api/wasm.cpp
@@ -226,7 +226,7 @@ struct wasm_tabletype_t : wasm_externtype_t {
     wasm_tabletype_t(const TableType* type)
         : wasm_externtype_t(WASM_EXTERN_TABLE)
         , valtype(type->type())
-        , limits{ type->initialSize(), type->maximumSize() }
+        , limits{ static_cast<uint32_t>(type->initialSize()), static_cast<uint32_t>(type->maximumSize()) }
     {
     }
 
@@ -1077,9 +1077,9 @@ own wasm_table_t* wasm_table_new(
 {
     Table* table = nullptr;
     if (UNLIKELY((size_t)init & OTHER_EXTERN_REF_TAG)) {
-        table = Table::createTable(store->get(), tt->valtype.type, tt->limits.min, tt->limits.max, reinterpret_cast<Object*>(init));
+        table = Table::createTable(store->get(), tt->valtype.type, tt->limits.min, tt->limits.max, false, reinterpret_cast<Object*>(init));
     } else {
-        table = Table::createTable(store->get(), tt->valtype.type, tt->limits.min, tt->limits.max, init ? const_cast<Object*>(init->get()) : nullptr);
+        table = Table::createTable(store->get(), tt->valtype.type, tt->limits.min, tt->limits.max, false, init ? const_cast<Object*>(init->get()) : nullptr);
     }
 
     return new wasm_table_t(table, tt->clone());

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -1071,19 +1071,19 @@ public:
             moduleName, fieldName, m_result.m_globalTypes[globalIndex]));
     }
 
-    virtual void OnImportTable(Index importIndex, std::string moduleName, std::string fieldName, Index tableIndex, Type type, size_t initialSize, size_t maximumSize) override
+    virtual void OnImportTable(Index importIndex, std::string moduleName, std::string fieldName, Index tableIndex, Type type, uint64_t initialSize, uint64_t maximumSize, bool is64) override
     {
         ASSERT(tableIndex == m_result.m_tableTypes.size());
         ASSERT(m_result.m_imports.size() == importIndex);
         ASSERT(type.IsRef());
 
-        m_result.m_tableTypes.push_back(new Walrus::TableType(toRefValueKind(type, &m_result), initialSize, maximumSize));
+        m_result.m_tableTypes.push_back(new Walrus::TableType(toRefValueKind(type, &m_result), initialSize, maximumSize, is64));
         m_result.m_imports.push_back(new Walrus::ImportType(
             Walrus::ImportType::Table,
             moduleName, fieldName, m_result.m_tableTypes[tableIndex]));
     }
 
-    virtual void OnImportMemory(Index importIndex, std::string moduleName, std::string fieldName, Index memoryIndex, size_t initialSize, size_t maximumSize, bool isShared, bool is64) override
+    virtual void OnImportMemory(Index importIndex, std::string moduleName, std::string fieldName, Index memoryIndex, uint64_t initialSize, uint64_t maximumSize, bool isShared, bool is64) override
     {
         ASSERT(memoryIndex == m_result.m_memoryTypes.size());
         ASSERT(m_result.m_imports.size() == importIndex);
@@ -1130,11 +1130,11 @@ public:
         m_result.m_tableTypes.reserve(count);
     }
 
-    virtual void OnTable(Index index, Type type, size_t initialSize, size_t maximumSize) override
+    virtual void OnTable(Index index, Type type, uint64_t initialSize, uint64_t maximumSize, bool is64) override
     {
         ASSERT(index == m_result.m_tableTypes.size());
         ASSERT(type.IsRef());
-        m_result.m_tableTypes.push_back(new Walrus::TableType(toRefValueKind(type, &m_result), initialSize, maximumSize));
+        m_result.m_tableTypes.push_back(new Walrus::TableType(toRefValueKind(type, &m_result), initialSize, maximumSize, is64));
     }
 
     virtual void BeginTableInitExpr(Index index) override

--- a/src/runtime/Module.cpp
+++ b/src/runtime/Module.cpp
@@ -176,7 +176,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
         case ImportType::Function: {
             if (UNLIKELY(imports[i]->kind() != Object::FunctionKind
                          || !imports[i]->asFunction()->functionType()->equals(m_imports[i]->functionType(), true))) {
-                Trap::throwException(state, "incompatible import type");
+                Trap::throwException(state, "incompatible function import type");
             }
 
             instance->m_functions[funcIndex] = imports[i]->asFunction();
@@ -190,7 +190,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
             if (UNLIKELY(imports[i]->kind() != Object::GlobalKind
                          || !m_imports[i]->globalType()->type().isSubType(imports[i]->asGlobal()->type())
                          || m_imports[i]->globalType()->isMutable() != imports[i]->asGlobal()->isMutable())) {
-                Trap::throwException(state, "incompatible import type");
+                Trap::throwException(state, "incompatible global import type");
             }
 
             instance->m_globals[globIndex++] = imports[i]->asGlobal();
@@ -200,8 +200,9 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
             if (UNLIKELY(imports[i]->kind() != Object::TableKind
                          || m_imports[i]->tableType()->type() != imports[i]->asTable()->type()
                          || m_imports[i]->tableType()->initialSize() > imports[i]->asTable()->size()
-                         || m_imports[i]->tableType()->maximumSize() < imports[i]->asTable()->maximumSize())) {
-                Trap::throwException(state, "incompatible import type");
+                         || m_imports[i]->tableType()->maximumSize() < imports[i]->asTable()->maximumSize()
+                         || m_imports[i]->tableType()->is64() != imports[i]->asTable()->is64())) {
+                Trap::throwException(state, "incompatible table import type");
             }
 
             instance->m_tables[tableIndex++] = imports[i]->asTable();
@@ -213,7 +214,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
                          || m_imports[i]->memoryType()->maximumSize() < imports[i]->asMemory()->maximumSizeInPageSize()
                          || m_imports[i]->memoryType()->isShared() != imports[i]->asMemory()->isShared()
                          || m_imports[i]->memoryType()->is64() != imports[i]->asMemory()->is64())) {
-                Trap::throwException(state, "incompatible import type");
+                Trap::throwException(state, "incompatible memory import type");
             }
 
             instance->m_memories[memIndex++] = imports[i]->asMemory();
@@ -222,7 +223,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
         case ImportType::Tag: {
             if (UNLIKELY(imports[i]->kind() != Object::TagKind
                          || !imports[i]->asTag()->functionType()->equals(m_imports[i]->tagType()->functionType(), true))) {
-                Trap::throwException(state, "incompatible import type");
+                Trap::throwException(state, "incompatible tag import type");
             }
             instance->m_tags[tagIndex++] = imports[i]->asTag();
             break;
@@ -264,7 +265,7 @@ Instance* Module::instantiate(ExecutionState& state, const ExternVector& imports
             initValue = data.initValue;
         }
 
-        instance->m_tables[tableIndex] = Table::createTable(m_store, tableType->type(), tableType->initialSize(), tableType->maximumSize(), initValue);
+        instance->m_tables[tableIndex] = Table::createTable(m_store, tableType->type(), tableType->initialSize(), tableType->maximumSize(), tableType->is64(), initValue);
         tableIndex++;
     }
 

--- a/src/runtime/ObjectType.h
+++ b/src/runtime/ObjectType.h
@@ -294,19 +294,21 @@ private:
 
 class TableType : public ObjectType {
 public:
-    TableType(Type type, uint32_t initSize, uint32_t maxSize)
+    TableType(Type type, uint64_t initSize, uint64_t maxSize, bool is64)
         : ObjectType(ObjectType::TableKind)
         , m_type(type)
         , m_initialSize(initSize)
         , m_maximumSize(maxSize)
+        , m_is64(is64)
         , m_function(nullptr)
     {
     }
 
     Type type() const { return m_type; }
-    uint32_t initialSize() const { return m_initialSize; }
-    uint32_t maximumSize() const { return m_maximumSize; }
+    uint64_t initialSize() const { return m_initialSize; }
+    uint64_t maximumSize() const { return m_maximumSize; }
     ModuleFunction* function() const { return m_function; }
+    bool is64() const { return m_is64; }
 
     inline void setFunction(ModuleFunction* func)
     {
@@ -316,8 +318,9 @@ public:
 
 private:
     Type m_type;
-    uint32_t m_initialSize;
-    uint32_t m_maximumSize;
+    uint64_t m_initialSize;
+    uint64_t m_maximumSize;
+    bool m_is64;
     ModuleFunction* m_function;
 };
 

--- a/src/runtime/Table.cpp
+++ b/src/runtime/Table.cpp
@@ -30,17 +30,18 @@ namespace Walrus {
 
 DEFINE_GLOBAL_TYPE_INFO(tableTypeInfo, TableKind);
 
-Table* Table::createTable(Store* store, Type type, uint32_t initialSize, uint32_t maximumSize, void* init)
+Table* Table::createTable(Store* store, Type type, uint64_t initialSize, uint64_t maximumSize, bool is64, void* init)
 {
-    Table* tbl = new Table(type, initialSize, maximumSize, init ? init : reinterpret_cast<void*>(Value::NullBits));
+    Table* tbl = new Table(type, initialSize, maximumSize, is64, init ? init : reinterpret_cast<void*>(Value::NullBits));
     store->appendExtern(tbl);
 
     return tbl;
 }
 
-Table::Table(Type type, uint32_t initialSize, uint32_t maximumSize, void* init)
+Table::Table(Type type, uint64_t initialSize, uint64_t maximumSize, bool is64, void* init)
     : Extern(GET_GLOBAL_TYPE_INFO(tableTypeInfo))
     , m_type(type)
+    , m_is64(is64)
     , m_size(initialSize)
     , m_maximumSize(maximumSize)
 {
@@ -48,6 +49,12 @@ Table::Table(Type type, uint32_t initialSize, uint32_t maximumSize, void* init)
         m_elements = nullptr;
         return;
     }
+
+    if (initialSize > (SIZE_MAX / sizeof(void*))) {
+        // Should cause an allocation error.
+        initialSize = SIZE_MAX / sizeof(void*);
+    }
+
 #ifdef ENABLE_GC
     m_elements = reinterpret_cast<void**>(GC_MALLOC_UNCOLLECTABLE(static_cast<size_t>(initialSize) * sizeof(void*)));
 #else
@@ -71,6 +78,12 @@ void Table::grow(uint64_t newSize, void* val)
     if (newSize == m_size) {
         return;
     }
+
+    if (newSize > (SIZE_MAX / sizeof(void*))) {
+        // Should cause an allocation error.
+        newSize = SIZE_MAX / sizeof(void*);
+    }
+
 #ifdef ENABLE_GC
     if (LIKELY(m_elements != nullptr)) {
         m_elements = reinterpret_cast<void**>(GC_REALLOC(m_elements, static_cast<size_t>(newSize) * sizeof(void*)));
@@ -84,12 +97,9 @@ void Table::grow(uint64_t newSize, void* val)
     m_size = newSize;
 }
 
-void Table::init(ExecutionState& state, ElementSegment* source, uint32_t dstStart, uint32_t srcStart, uint32_t srcSize)
+void Table::init(ExecutionState& state, ElementSegment* source, uint64_t dstStart, uint64_t srcStart, uint64_t srcSize)
 {
-    if (UNLIKELY((uint64_t)dstStart + (uint64_t)srcSize > (uint64_t)m_size)) {
-        throwException(state);
-    }
-    if (UNLIKELY((srcStart + srcSize) > source->size())) {
+    if (UNLIKELY(!isValidRange(dstStart, srcSize) || (srcSize > source->size() || srcStart > source->size() - srcSize))) {
         throwException(state);
     }
     if (UNLIKELY(!m_type.isRef())) {
@@ -99,18 +109,18 @@ void Table::init(ExecutionState& state, ElementSegment* source, uint32_t dstStar
     this->initTable(source, dstStart, srcStart, srcSize);
 }
 
-void Table::copy(ExecutionState& state, const Table* srcTable, uint32_t n, uint32_t srcIndex, uint32_t dstIndex)
+void Table::copy(ExecutionState& state, const Table* srcTable, uint64_t n, uint64_t srcIndex, uint64_t dstIndex)
 {
-    if (UNLIKELY(((uint64_t)srcIndex + (uint64_t)n > (uint64_t)srcTable->size()) || ((uint64_t)dstIndex + (uint64_t)n > (uint64_t)m_size))) {
+    if (UNLIKELY(!isValidRange(dstIndex, n) || !srcTable->isValidRange(srcIndex, n))) {
         throwException(state);
     }
 
     this->copyTable(srcTable, n, srcIndex, dstIndex);
 }
 
-void Table::fill(ExecutionState& state, uint32_t n, void* value, uint32_t index)
+void Table::fill(ExecutionState& state, uint64_t n, void* value, uint64_t index)
 {
-    if ((uint64_t)index + (uint64_t)n > (uint64_t)m_size) {
+    if (UNLIKELY(!isValidRange(index, n))) {
         throwException(state);
     }
 
@@ -122,26 +132,17 @@ void Table::throwException(ExecutionState& state) const
     Trap::throwException(state, "out of bounds table access");
 }
 
-void Table::initTable(ElementSegment* source, uint32_t dstStart, uint32_t srcStart, uint32_t srcSize)
+void Table::initTable(ElementSegment* source, uint64_t dstStart, uint64_t srcStart, uint64_t srcSize)
 {
     memcpy(m_elements + dstStart, source->elements() + srcStart, srcSize * sizeof(void*));
 }
 
-void Table::copyTable(const Table* srcTable, uint32_t n, uint32_t srcIndex, uint32_t dstIndex)
+void Table::copyTable(const Table* srcTable, uint64_t n, uint64_t srcIndex, uint64_t dstIndex)
 {
-    while (n > 0) {
-        if (dstIndex <= srcIndex) {
-            m_elements[dstIndex] = srcTable->uncheckedGetElement(srcIndex);
-            dstIndex++;
-            srcIndex++;
-        } else {
-            m_elements[dstIndex + n - 1] = srcTable->uncheckedGetElement(srcIndex + n - 1);
-        }
-        n--;
-    }
+    memmove(m_elements + dstIndex, srcTable->m_elements + srcIndex, n * sizeof(void*));
 }
 
-void Table::fillTable(uint32_t n, void* value, uint32_t index)
+void Table::fillTable(uint64_t n, void* value, uint64_t index)
 {
     while (n > 0) {
         m_elements[index] = value;

--- a/src/runtime/Table.h
+++ b/src/runtime/Table.h
@@ -31,7 +31,7 @@ class Table : public Extern {
     friend class JITFieldAccessor;
 
 public:
-    static Table* createTable(Store* store, Type type, uint32_t initialSize, uint32_t maximumSize, void* init = nullptr);
+    static Table* createTable(Store* store, Type type, uint64_t initialSize, uint64_t maximumSize, bool is64, void* init = nullptr);
 
     ~Table();
 
@@ -40,18 +40,33 @@ public:
         return m_type;
     }
 
-    uint32_t size() const
+    bool is64() const
+    {
+        return m_is64;
+    }
+
+    uint64_t size() const
     {
         return m_size;
     }
 
-    uint32_t maximumSize() const
+    uint64_t maximumSize() const
     {
         return m_maximumSize;
     }
 
     void* getElement(ExecutionState& state, uint32_t elemIndex) const
     {
+        ASSERT(!m_is64);
+        if (UNLIKELY(elemIndex >= m_size)) {
+            throwException(state);
+        }
+        return m_elements[elemIndex];
+    }
+
+    void* getElement64(ExecutionState& state, uint64_t elemIndex) const
+    {
+        ASSERT(m_is64);
         if (UNLIKELY(elemIndex >= m_size)) {
             throwException(state);
         }
@@ -60,12 +75,28 @@ public:
 
     void* uncheckedGetElement(uint32_t elemIndex) const
     {
-        ASSERT(elemIndex < m_size);
+        ASSERT(!m_is64 && elemIndex < m_size);
+        return m_elements[elemIndex];
+    }
+
+    void* uncheckedGetElement64(uint64_t elemIndex) const
+    {
+        ASSERT(m_is64 && elemIndex < m_size);
         return m_elements[elemIndex];
     }
 
     void setElement(ExecutionState& state, uint32_t elemIndex, void* val)
     {
+        ASSERT(!m_is64);
+        if (UNLIKELY(elemIndex >= m_size)) {
+            throwException(state);
+        }
+        m_elements[elemIndex] = val;
+    }
+
+    void setElement64(ExecutionState& state, uint64_t elemIndex, void* val)
+    {
+        ASSERT(m_is64);
         if (UNLIKELY(elemIndex >= m_size)) {
             throwException(state);
         }
@@ -74,28 +105,40 @@ public:
 
     void uncheckedSetElement(uint32_t elemIndex, void* val)
     {
-        ASSERT(elemIndex < m_size);
+        ASSERT(!m_is64 && elemIndex < m_size);
+        m_elements[elemIndex] = val;
+    }
+
+    void uncheckedSetElement64(uint64_t elemIndex, void* val)
+    {
+        ASSERT(m_is64 && elemIndex < m_size);
         m_elements[elemIndex] = val;
     }
 
     void grow(uint64_t newSize, void* val);
-    void copy(ExecutionState& state, const Table* srcTable, uint32_t n, uint32_t srcIndex, uint32_t dstIndex);
-    void fill(ExecutionState& state, uint32_t n, void* value, uint32_t index);
-    void init(ExecutionState& state, ElementSegment* source, uint32_t dstStart, uint32_t srcStart, uint32_t srcSize);
+    void copy(ExecutionState& state, const Table* srcTable, uint64_t n, uint64_t srcIndex, uint64_t dstIndex);
+    void fill(ExecutionState& state, uint64_t n, void* value, uint64_t index);
+    void init(ExecutionState& state, ElementSegment* source, uint64_t dstStart, uint64_t srcStart, uint64_t srcSize);
 
-    void initTable(ElementSegment* source, uint32_t dstStart, uint32_t srcStart, uint32_t srcSize);
-    void copyTable(const Table* srcTable, uint32_t n, uint32_t srcIndex, uint32_t dstIndex);
-    void fillTable(uint32_t n, void* value, uint32_t index);
+    void initTable(ElementSegment* source, uint64_t dstStart, uint64_t srcStart, uint64_t srcSize);
+    void copyTable(const Table* srcTable, uint64_t n, uint64_t srcIndex, uint64_t dstIndex);
+    void fillTable(uint64_t n, void* value, uint64_t index);
 
 private:
-    Table(Type type, uint32_t initialSize, uint32_t maximumSize, void* init);
+    Table(Type type, uint64_t initialSize, uint64_t maximumSize, bool is64, void* init);
+
+    bool isValidRange(uint64_t start, uint64_t size) const
+    {
+        return size <= m_size && start <= m_size - size;
+    }
 
     void throwException(ExecutionState& state) const;
 
     // Table has elements of reference type (FuncRef | ExternRef)
     Type m_type;
-    uint32_t m_size;
-    uint32_t m_maximumSize;
+    bool m_is64;
+    uint64_t m_size;
+    uint64_t m_maximumSize;
 
     // FIXME handle references of Function objects
     void** m_elements;

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -270,7 +270,9 @@ static Trap::TrapResult executeWASM(Store* store, const std::string& filename, c
             } else if (import->fieldName() == "global_f64") {
                 importValues.push_back(Global::createGlobal(store, Value(double(0x4084d00000000000)), MutableType(Value::F64, false)));
             } else if (import->fieldName() == "table") {
-                importValues.push_back(Table::createTable(store, Value::Type::NullFuncRef, 10, 20));
+                importValues.push_back(Table::createTable(store, Value::Type::NullFuncRef, 10, 20, false));
+            } else if (import->fieldName() == "table64") {
+                importValues.push_back(Table::createTable(store, Value::Type::NullFuncRef, 10, 20, true));
             } else if (import->fieldName() == "memory") {
                 importValues.push_back(Memory::createMemory(store, 1 * Memory::s_memoryPageSize, 2 * Memory::s_memoryPageSize, false, false));
             } else {
@@ -1027,17 +1029,39 @@ static void executeWAST(Store* store, const std::string& filename, const std::ve
         case wabt::CommandType::AssertInvalid: {
             auto* assertModuleInvalid = static_cast<wabt::AssertModuleCommand<wabt::CommandType::AssertInvalid>*>(command.get());
             auto m = assertModuleInvalid->module.get();
-            auto tsm = dynamic_cast<wabt::TextScriptModule*>(m);
-            auto dsm = dynamic_cast<wabt::BinaryScriptModule*>(m);
-            if (!tsm && !dsm) {
-                printf("Module is neither TextScriptModule nor BinaryScriptModule.\n");
-                RELEASE_ASSERT_NOT_REACHED();
+            wabt::TextScriptModule* tsm = dynamic_cast<wabt::TextScriptModule*>(m);
+            wabt::BinaryScriptModule* dsm = nullptr;
+            wabt::QuotedScriptModule* qsm = nullptr;
+            if (!tsm) {
+                dsm = dynamic_cast<wabt::BinaryScriptModule*>(m);
+                if (!dsm) {
+                    qsm = dynamic_cast<wabt::QuotedScriptModule*>(m);
+                    if (!qsm) {
+                        printf("Module is not TextScriptModule, BinaryScriptModule, or QuotedScriptModule.\n");
+                        RELEASE_ASSERT_NOT_REACHED();
+                    }
+                }
             }
             std::vector<uint8_t> buf;
             if (tsm) {
                 buf = readModuleData(&tsm->module)->data;
-            } else {
+            } else if (dsm) {
                 buf = dsm->data;
+            } else {
+                wabt::Errors errors;
+                wabt::Features features;
+                features.EnableAll();
+                wabt::WastParseOptions options(features);
+                std::unique_ptr<wabt::Module> m;
+                auto lexer = wabt::WastLexer::CreateBufferLexer(filename, qsm->data.data(), qsm->data.size(), &errors);
+                auto result = wabt::ParseWatModule(lexer.get(), &m, &errors, &options);
+                if (result != wabt::Result::Error) {
+                    printf("Parsing WAT returned Ok (in wabt::CommandType::AssertInvalid case)\n");
+                    printf("Expected exception:%s\n", assertModuleInvalid->text.data());
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+                printf("assertModuleInvalid (expect compile error: '%s', actual '%s'(line: %d)) : OK\n", assertModuleInvalid->text.data(), errors[0].message.c_str(), errors[0].loc.line);
+                break;
             }
             auto trapResult = executeWASM(store, filename, buf);
             if (trapResult.exception == nullptr) {

--- a/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
+++ b/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
@@ -58,8 +58,8 @@ public:
     virtual void OnImportCount(Index count) = 0;
     virtual void OnImportFunc(Index importIndex, std::string moduleName, std::string fieldName, Index funcIndex, Index sigIndex) = 0;
     virtual void OnImportGlobal(Index importIndex, std::string moduleName, std::string fieldName, Index globalIndex, Type type, bool mutable_) = 0;
-    virtual void OnImportTable(Index importIndex, std::string moduleName, std::string fieldName, Index tableIndex, Type type, size_t initialSize, size_t maximumSize) = 0;
-    virtual void OnImportMemory(Index importIndex, std::string moduleName, std::string fieldName, Index memoryIndex, size_t initialSize, size_t maximumSize, bool isShared, bool is64) = 0;
+    virtual void OnImportTable(Index importIndex, std::string moduleName, std::string fieldName, Index tableIndex, Type type, uint64_t initialSize, uint64_t maximumSize, bool is64) = 0;
+    virtual void OnImportMemory(Index importIndex, std::string moduleName, std::string fieldName, Index memoryIndex, uint64_t initialSize, uint64_t maximumSize, bool isShared, bool is64) = 0;
     virtual void OnImportTag(Index importIndex, std::string moduleName, std::string fieldName, Index tagIndex, Index sigIndex) = 0;
 
     virtual void OnExportCount(Index count) = 0;
@@ -76,7 +76,7 @@ public:
     virtual void EndDataSegment(Index index) = 0;
 
     virtual void OnTableCount(Index count) = 0;
-    virtual void OnTable(Index index, Type type, size_t initialSize, size_t maximumSize) = 0;
+    virtual void OnTable(Index index, Type type, uint64_t initialSize, uint64_t maximumSize, bool is64) = 0;
     virtual void BeginTableInitExpr(Index index) = 0;
     virtual void EndTableInitExpr(Index index) = 0;
 

--- a/third_party/wabt/src/walrus/binary-reader-walrus.cc
+++ b/third_party/wabt/src/walrus/binary-reader-walrus.cc
@@ -262,7 +262,8 @@ public:
     Result OnImportTable(Index import_index, nonstd::string_view module_name, nonstd::string_view field_name, Index table_index, Type elem_type, const Limits *elem_limits) override {
         CHECK_RESULT(m_validator.OnTable(GetLocation(), elem_type, *elem_limits, wabt::TableImportStatus::TableIsImported, wabt::TableInitExprStatus::TableWithoutInitExpression));
         m_tableTypes.push_back(elem_type);
-        m_externalDelegate->OnImportTable(import_index, std::string(module_name), std::string(field_name), table_index, elem_type, elem_limits->initial, elem_limits->has_max ? elem_limits->max : std::numeric_limits<uint32_t>::max());
+        uint64_t max = elem_limits->has_max ? elem_limits->max : (elem_limits->is_64 ? std::numeric_limits<uint64_t>::max() : std::numeric_limits<uint32_t>::max());
+        m_externalDelegate->OnImportTable(import_index, std::string(module_name), std::string(field_name), table_index, elem_type, elem_limits->initial, max, elem_limits->is_64);
         return Result::Ok;
     }
     Result OnImportMemory(Index import_index, nonstd::string_view module_name, nonstd::string_view field_name, Index memory_index, const Limits *page_limits, uint32_t page_size) override {
@@ -313,7 +314,8 @@ public:
     Result BeginTable(Index index, Type elem_type, const Limits* elem_limits, TableInitExprStatus init_provided) override {
         CHECK_RESULT(m_validator.OnTable(GetLocation(), elem_type, *elem_limits, wabt::TableImportStatus::TableIsNotImported, init_provided));
         m_tableTypes.push_back(elem_type);
-        m_externalDelegate->OnTable(index, elem_type, elem_limits->initial, elem_limits->has_max ? elem_limits->max : std::numeric_limits<uint32_t>::max());
+        uint64_t max = elem_limits->has_max ? elem_limits->max : (elem_limits->is_64 ? std::numeric_limits<uint64_t>::max() : std::numeric_limits<uint32_t>::max());
+        m_externalDelegate->OnTable(index, elem_type, elem_limits->initial, max, elem_limits->is_64);
         assert(m_lastInitType == Type::___);
         m_lastInitType = elem_type;
         return Result::Ok;


### PR DESCRIPTION
This patch extends the tables to support 64 bit limits, and support 64 bit table construction. The interpreter support will be in a follow-up patch.