### PR TITLE
[WASI] Implement fd_pwrite

### DIFF
--- a/src/wasi/WASI.cpp
+++ b/src/wasi/WASI.cpp
@@ -166,6 +166,43 @@ void WASI::clock_time_get(ExecutionState& state, Value* argv, Value* result, Ins
     result[0] = Value(uvwasi_clock_time_get(WASI::g_uvwasi, argv[0].asI32(), argv[1].asI64(), out_addr));
 }
 
+void WASI::fd_pwrite(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t fd = argv[0].asI32();
+    uint64_t offset = argv[3].asI64();
+    size_t iovsLen = static_cast<size_t>(argv[2].asI32());
+
+    uint32_t* iovptr = reinterpret_cast<uint32_t*>(
+        get_memory_pointer(instance, argv[1], iovsLen * (sizeof(uint32_t) << 1)));
+
+    uint32_t* nwritten = reinterpret_cast<uint32_t*>(
+        get_memory_pointer(instance, argv[4], sizeof(uint32_t)));
+
+    if (iovptr == nullptr || nwritten == nullptr) {
+        result[0] = Value(WasiErrNo::inval);
+        return;
+    }
+
+    TemporaryData<uvwasi_ciovec_t, 8> iovsBuffer(iovsLen);
+    uvwasi_ciovec_t* iovs = iovsBuffer.data();
+
+    uint64_t sizeInByte = instance->memory(0)->sizeInByte();
+    uint8_t* buffer = instance->memory(0)->buffer();
+
+    for (uint32_t i = 0; i < iovsLen; i++) {
+        if (iovptr[1] > sizeInByte || iovptr[0] > sizeInByte - iovptr[1]) {
+            result[0] = Value(WasiErrNo::inval);
+            return;
+        }
+
+        iovs[i].buf = buffer + iovptr[0];
+        iovs[i].buf_len = iovptr[1];
+        iovptr += 2;
+    }
+
+    result[0] = Value(uvwasi_fd_pwrite(WASI::g_uvwasi, fd, iovs, iovsLen, offset, nwritten));
+}
+
 void WASI::fd_write(ExecutionState& state, Value* argv, Value* result, Instance* instance)
 {
     uint32_t fd = argv[0].asI32();

--- a/src/wasi/WASI.h
+++ b/src/wasi/WASI.h
@@ -43,6 +43,7 @@ public:
     F(clock_res_get, I32I32_RI32)                          \
     F(clock_time_get, I32I64I32_RI32)                      \
     F(random_get, I32I32_RI32)                             \
+    F(fd_pwrite, I32I32I32I64I32_RI32)                     \
     F(fd_write, I32I32I32I32_RI32)                         \
     F(fd_tell, I32I32_RI32)                                \
     F(fd_read, I32I32I32I32_RI32)                          \

--- a/test/wasi/fd_pwrite.wast
+++ b/test/wasi/fd_pwrite.wast
@@ -1,0 +1,96 @@
+(module
+  (import "wasi_snapshot_preview1" "path_open" (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_pwrite" (func $fd_pwrite (param i32 i32 i32 i64 i32) (result i32)))
+
+  (memory 1)
+  
+  (export "memory" (memory 0))
+
+  ;; File path.
+  (data (i32.const 300) "./write_to_this.txt")
+
+  ;; Data to write.
+  (data (i32.const 400) "hello")
+
+  (func (export "test_pwrite") (result i32)
+    (local $fd i32)
+    (local $errno i32)
+
+    ;; Open the test file.
+    i32.const 3       ;; First preopened directory.
+    i32.const 0       ;; No lookup flags.
+    i32.const 300     ;; Pointer to the file path.
+    i32.const 19      ;; Length of "./write_to_this.txt".
+    i32.const 0       ;; No open flags.
+    i64.const 68      
+    i64.const 0      
+    i32.const 0       ;; No file descriptor flags.
+    i32.const 0       ;; Store the opened fd at memory[0].
+    call $path_open
+
+    local.set $errno
+
+    ;; Return immediately if path_open failed.
+    local.get $errno
+    if
+      local.get $errno
+      return
+    end
+
+    ;; Load the opened file descriptor.
+    i32.const 0
+    i32.load
+    local.set $fd
+
+    ;; Create one ciovec at memory[100].
+    ;;
+    ;; ciovec.buf     = 400
+    ;; ciovec.buf_len = 5
+    i32.const 100
+    i32.const 400
+    i32.store
+
+    i32.const 104
+    i32.const 5
+    i32.store
+
+    ;; fd_pwrite(
+    ;;   fd,
+    ;;   iovs = 100,
+    ;;   iovs_len = 1,
+    ;;   offset = 0,
+    ;;   nwritten = 200
+    ;; )
+    local.get $fd
+    i32.const 100
+    i32.const 1
+    i64.const 0
+    i32.const 200
+    call $fd_pwrite
+
+    local.set $errno
+
+    ;; Return the errno if fd_pwrite failed.
+    local.get $errno
+    if
+      local.get $errno
+      return
+    end
+
+    ;; Verify that exactly 5 bytes were written.
+    i32.const 200
+    i32.load
+    i32.const 5
+    i32.ne
+
+    if
+      i32.const 1
+      return
+    end
+
+    ;; Success.
+    i32.const 0
+  )
+)
+
+(assert_return (invoke "test_pwrite") (i32.const 0))


### PR DESCRIPTION
## Description

This PR implements the WASI `fd_pwrite` function.

### Changes

* Added the `fd_pwrite` WASI function declaration.
* Implemented the `fd_pwrite` wrapper using `uvwasi_fd_pwrite`.
* Added a WASI test for writing data at a specified file offset.
* Verified the returned errno and the number of written bytes.

### Testing

```bash
cmake --build out/release/x64 -j
./tools/run-tests.py wasi --engine ./out/release/x64/walrus
tools/check_tidy.py --clang-format clang-format
```

Related to #435 