### PR TITLE
[WASI] Implement sock_accept

### DIFF
--- a/src/wasi/WASI.cpp
+++ b/src/wasi/WASI.cpp
@@ -371,6 +371,19 @@ void WASI::fd_filestat_set_times(ExecutionState& state, Value* argv, Value* resu
     result[0] = Value(uvwasi_fd_filestat_set_times(WASI::g_uvwasi, fd, st_atim, st_mtim, fst_flags));
 }
 
+void WASI::sock_accept(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t fd = argv[0].asI32();
+    uint32_t flags = argv[1].asI32();
+    uint32_t* ro_fd = reinterpret_cast<uint32_t*>(get_memory_pointer(instance, argv[2], sizeof(uint32_t)));
+    if (ro_fd == nullptr) {
+        result[0] = Value(WasiErrNo::inval);
+        return;
+    }
+
+    result[0] = Value(uvwasi_sock_accept(WASI::g_uvwasi, fd, flags, ro_fd));
+}
+
 void WASI::sock_shutdown(ExecutionState& state, Value* argv, Value* result, Instance* instance)
 {
     uint32_t sock = argv[0].asI32();

--- a/src/wasi/WASI.h
+++ b/src/wasi/WASI.h
@@ -75,6 +75,7 @@ public:
     F(environ_get, I32I32_RI32)                            \
     F(environ_sizes_get, I32I32_RI32)                      \
     F(sched_yield, RI32)                                   \
+    F(sock_accept, I32I32I32_RI32)                         \
     F(sock_shutdown, I32I32_RI32)
 
 #define ERRORS(ERR)                                                   \

--- a/test/wasi/sock_accept.wast
+++ b/test/wasi/sock_accept.wast
@@ -1,0 +1,31 @@
+(module
+  (import "wasi_snapshot_preview1" "sock_accept"
+    (func $sock_accept (param i32 i32 i32) (result i32)))
+
+  (memory 1)
+  (export "memory" (memory 0))
+
+  ;; Call sock_accept with a non-existent listening socket fd.
+  (func (export "test_sock_accept_invalid_fd") (result i32)
+    i32.const 99   ;; non-existent socket fd
+    i32.const 0    ;; no fd flags
+    i32.const 0    ;; address where the accepted fd would be written
+    call $sock_accept
+  )
+
+  ;; Pass an output pointer that does not have enough remaining memory
+  ;; for a 4-byte file descriptor.
+  (func (export "test_sock_accept_invalid_pointer") (result i32)
+    i32.const 99
+    i32.const 0
+    i32.const 65535
+    call $sock_accept
+  )
+)
+
+;; Invalid listening socket fd: errno::badf.
+(assert_return (invoke "test_sock_accept_invalid_fd") (i32.const 8))
+
+;; Invalid output memory pointer: errno::inval.
+(assert_return (invoke "test_sock_accept_invalid_pointer") (i32.const 28))
+


### PR DESCRIPTION
## Summary

This PR implements the missing WASI Preview1 `sock_accept` host function.

The implementation delegates the operation to `uvwasi_sock_accept`.

## Changes

* Added `sock_accept` to `FOR_EACH_WASI_FUNC` in `src/wasi/WASI.h`
* Implemented `WASI::sock_accept` in `src/wasi/WASI.cpp`
* Added test coverage in `test/wasi/sock_accept.wast`

## Testing

```bash
cmake --build out/release/x64 -j
./tools/run-tests.py wasi --engine ./out/release/x64/walrus
./tools/check_tidy.py --clang-format clang-format
```

Related to #435
