### PR TITLE
[WASI] Implement fd_fdstat_set_rights

### DIFF
--- a/src/wasi/WASI.cpp
+++ b/src/wasi/WASI.cpp
@@ -395,6 +395,15 @@ void WASI::fd_fdstat_set_flags(ExecutionState& state, Value* argv, Value* result
     result[0] = Value(uvwasi_fd_fdstat_set_flags(WASI::g_uvwasi, fd, fdflags));
 }
 
+void WASI::fd_fdstat_set_rights(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t fd = argv[0].asI32();
+    uint64_t fs_rights_base = argv[1].asI64();
+    uint64_t fs_rights_inheriting = argv[2].asI64();
+
+    result[0] = Value(uvwasi_fd_fdstat_set_rights(WASI::g_uvwasi, fd, fs_rights_base, fs_rights_inheriting));
+}
+
 void WASI::fd_prestat_get(ExecutionState& state, Value* argv, Value* result, Instance* instance)
 {
     uint32_t fd = argv[0].asI32();

--- a/src/wasi/WASI.h
+++ b/src/wasi/WASI.h
@@ -58,6 +58,7 @@ public:
     F(fd_filestat_set_times, I32I64I64I32_RI32)            \
     F(fd_fdstat_get, I32I32_RI32)                          \
     F(fd_fdstat_set_flags, I32I32_RI32)                    \
+    F(fd_fdstat_set_rights, I32I64I64_RI32)                \
     F(fd_prestat_get, I32I32_RI32)                         \
     F(fd_prestat_dir_name, I32I32I32_RI32)                 \
     F(fd_filestat_get, I32I32_RI32)                        \

--- a/test/wasi/fd_fdstat_set_rights.wast
+++ b/test/wasi/fd_fdstat_set_rights.wast
@@ -1,0 +1,76 @@
+(module
+  (import "wasi_snapshot_preview1" "path_open"
+    (func $path_open
+      (param i32 i32 i32 i32 i32 i64 i64 i32 i32)
+      (result i32)))
+
+  (import "wasi_snapshot_preview1" "fd_fdstat_set_rights"
+    (func $fd_fdstat_set_rights
+      (param i32 i64 i64)
+      (result i32)))
+
+  (import "wasi_snapshot_preview1" "fd_close"
+    (func $fd_close
+      (param i32)
+      (result i32)))
+
+  (memory 1)
+
+  (data (i32.const 32) "./fd_fdstat_set_rights.txt")
+
+  (func (export "test_fdstat_set_rights") (result i32)
+    (local $fd i32)
+    (local $error i32)
+
+    i32.const 3
+    i32.const 0
+    i32.const 32
+    i32.const 26
+    i32.const 1
+    i64.const 0x42
+    i64.const 0
+    i32.const 0
+    i32.const 0
+    call $path_open
+    local.set $error
+
+    local.get $error
+    if
+      local.get $error
+      return
+    end
+
+    i32.const 0
+    i32.load
+    local.set $fd
+
+    local.get $fd
+    i64.const 0x2
+    i64.const 0
+    call $fd_fdstat_set_rights
+    local.set $error
+
+    local.get $fd
+    call $fd_close
+    drop
+
+    local.get $error
+  )
+
+  (func (export "test_fdstat_set_rights_badfd") (result i32)
+    i32.const 999
+    i64.const 0
+    i64.const 0
+    call $fd_fdstat_set_rights
+  )
+)
+
+(assert_return
+  (invoke "test_fdstat_set_rights")
+  (i32.const 0)
+)
+
+(assert_return
+  (invoke "test_fdstat_set_rights_badfd")
+  (i32.const 8)
+)


### PR DESCRIPTION
## Summary

- Implement the WASI `fd_fdstat_set_rights` wrapper.
- Add a test for `fd_fdstat_set_rights`.

## Testing

- Passed the WASI test suite.