### PR TITLE
[WASI] Implement sock_recv

### DIFF
--- a/src/wasi/WASI.cpp
+++ b/src/wasi/WASI.cpp
@@ -416,6 +416,39 @@ void WASI::sock_send(ExecutionState& state, Value* argv, Value* result, Instance
     result[0] = Value(uvwasi_sock_send(WASI::g_uvwasi, fd, iovs, iovsLen, flags, nwritten));
 }
 
+void WASI::sock_recv(ExecutionState& state, Value* argv, Value* result, Instance* instance)
+{
+    uint32_t fd = argv[0].asI32();
+    size_t iovsLen = static_cast<size_t>(argv[2].asI32());
+    uvwasi_riflags_t flags = static_cast<uvwasi_riflags_t>(argv[3].asI32());
+    uint32_t* nread = reinterpret_cast<uint32_t*>(get_memory_pointer(instance, argv[4], sizeof(uint32_t)));
+    uvwasi_roflags_t* roflags = reinterpret_cast<uvwasi_roflags_t*>(get_memory_pointer(instance, argv[5], sizeof(uvwasi_roflags_t)));
+    uint32_t* iovptr = reinterpret_cast<uint32_t*>(get_memory_pointer(instance, argv[1], iovsLen * (sizeof(uint32_t) << 1)));
+
+    if (iovsLen == 0 || iovptr == nullptr || nread == nullptr || roflags == nullptr) {
+        result[0] = Value(WasiErrNo::inval);
+        return;
+    }
+
+    TemporaryData<uvwasi_iovec_t, 8> iovsBuffer(iovsLen);
+    uvwasi_iovec_t* iovs = iovsBuffer.data();
+    uint64_t sizeInByte = instance->memory(0)->sizeInByte();
+    uint8_t* buffer = instance->memory(0)->buffer();
+
+    for (uint32_t i = 0; i < iovsLen; i++) {
+        if (iovptr[1] > sizeInByte || iovptr[0] > sizeInByte - iovptr[1]) {
+            result[0] = Value(WasiErrNo::inval);
+            return;
+        }
+
+        iovs[i].buf = buffer + iovptr[0];
+        iovs[i].buf_len = iovptr[1];
+        iovptr += 2;
+    }
+
+    result[0] = Value(uvwasi_sock_recv(WASI::g_uvwasi, fd, iovs, iovsLen, flags, nread, roflags));
+}
+
 void WASI::sock_shutdown(ExecutionState& state, Value* argv, Value* result, Instance* instance)
 {
     uint32_t sock = argv[0].asI32();

--- a/src/wasi/WASI.h
+++ b/src/wasi/WASI.h
@@ -80,6 +80,7 @@ public:
     F(sched_yield, RI32)                                   \
     F(sock_accept, I32I32I32_RI32)                         \
     F(sock_send, I32I32I32I32I32_RI32)                     \
+    F(sock_recv, I32I32I32I32I32I32_RI32)                  \
     F(sock_shutdown, I32I32_RI32)
 
 #define ERRORS(ERR)                                                   \

--- a/test/wasi/sock_recv.wast
+++ b/test/wasi/sock_recv.wast
@@ -1,0 +1,43 @@
+(module
+  (import "wasi_snapshot_preview1" "sock_recv"
+    (func $sock_recv (param i32 i32 i32 i32 i32 i32) (result i32)))
+
+  (memory 1)
+  (export "memory" (memory 0))
+
+  (func (export "test_sock_recv_invalid_fd") (result i32)
+    i32.const 100
+    i32.const 400
+    i32.store
+
+    i32.const 104
+    i32.const 5
+    i32.store
+
+    i32.const 99
+    i32.const 100
+    i32.const 1
+    i32.const 0
+    i32.const 200
+    i32.const 204
+    call $sock_recv
+  )
+
+  (func (export "test_sock_recv_invalid_pointer") (result i32)
+    i32.const 99
+    i32.const 65535
+    i32.const 1
+    i32.const 0
+    i32.const 200
+    i32.const 204
+    call $sock_recv
+  )
+)
+
+(assert_return
+  (invoke "test_sock_recv_invalid_fd")
+  (i32.const 8))
+
+(assert_return
+  (invoke "test_sock_recv_invalid_pointer")
+  (i32.const 28))


### PR DESCRIPTION
## Summary

- Implement `sock_recv` for WASI.

## Changes

- Add the `sock_recv` implementation.
- Add WAST tests for `sock_recv`.

## Testing

- Run the WASI test suite and verify that all tests pass.

```bash
python3 tools/run-tests.py --engine ./out/release/x64/walrus wasi
```