### PR TITLE
Implement TCO into ReturnCallIndirect and ReturnCallRef in JIT

### DIFF
--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -3433,60 +3433,6 @@ NEVER_INLINE bool Interpreter::tailCallOperation(
     return false;
 }
 
-#if defined(WALRUS_ENABLE_JIT)
-NEVER_INLINE void Interpreter::prepareTailFrame(StackFrame& frame, ByteCodeStackOffset* offsets, uint16_t parameterOffsetCount, size_t requiredStackSize)
-{
-    if (UNLIKELY(requiredStackSize > frame.capacity())) {
-        uint8_t* newBuffer = StackFrame::allocateBuffer(requiredStackSize);
-        for (size_t i = 0; i < parameterOffsetCount; i++) {
-            ((size_t*)newBuffer)[i] = *((size_t*)(frame.bp() + offsets[i]));
-        }
-        frame.replaceBuffer(newBuffer, requiredStackSize);
-    } else {
-        ALLOCA(size_t, paramBuffer, parameterOffsetCount * sizeof(size_t));
-        for (size_t i = 0; i < parameterOffsetCount; i++) {
-            paramBuffer[i] = *((size_t*)(frame.bp() + offsets[i]));
-        }
-        VectorCopier<size_t>::copy((size_t*)frame.bp(), paramBuffer, parameterOffsetCount);
-    }
-}
-
-ByteCodeStackOffset* Interpreter::runJITFunction(ExecutionState& state, DefinedFunction* function, StackFrame& frame)
-{
-    Instance* instance = function->instance();
-    ModuleFunction* moduleFunction = function->moduleFunction();
-
-    while (true) {
-        JITTailCall tail;
-        tail.target = nullptr;
-        ByteCodeStackOffset* resultOffsets = moduleFunction->jitFunction()->call(state, instance, frame.bp(), &tail);
-
-        if (LIKELY(tail.target == nullptr)) {
-            // Normal return (or an exception was already thrown by JITFunction::call).
-            return resultOffsets;
-        }
-
-        Function* target = tail.target;
-        if (LIKELY(target->kind() == Function::DefinedFunctionKind)) {
-            DefinedFunction* definedTarget = target->asDefinedFunction();
-            ModuleFunction* targetModuleFunction = definedTarget->moduleFunction();
-            if (LIKELY(targetModuleFunction->jitFunction() != nullptr)) {
-                prepareTailFrame(frame, tail.offsets, tail.paramCount, targetModuleFunction->requiredStackSize());
-                state.m_currentFunction = definedTarget;
-                instance = definedTarget->instance();
-                function = definedTarget;
-                moduleFunction = targetModuleFunction;
-                continue;
-            }
-        }
-
-        // Fallback
-        target->interpreterCall(state, frame.bp(), tail.offsets, tail.paramCount, tail.resultCount);
-        return tail.offsets + tail.paramCount;
-    }
-}
-#endif
-
 NEVER_INLINE bool Interpreter::testRefGeneric(void* refPtr, Value::Type type)
 {
     ASSERT(!Value::isNull(refPtr));

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -3433,6 +3433,60 @@ NEVER_INLINE bool Interpreter::tailCallOperation(
     return false;
 }
 
+#if defined(WALRUS_ENABLE_JIT)
+NEVER_INLINE void Interpreter::prepareTailFrame(StackFrame& frame, ByteCodeStackOffset* offsets, uint16_t parameterOffsetCount, size_t requiredStackSize)
+{
+    if (UNLIKELY(requiredStackSize > frame.capacity())) {
+        uint8_t* newBuffer = StackFrame::allocateBuffer(requiredStackSize);
+        for (size_t i = 0; i < parameterOffsetCount; i++) {
+            ((size_t*)newBuffer)[i] = *((size_t*)(frame.bp() + offsets[i]));
+        }
+        frame.replaceBuffer(newBuffer, requiredStackSize);
+    } else {
+        ALLOCA(size_t, paramBuffer, parameterOffsetCount * sizeof(size_t));
+        for (size_t i = 0; i < parameterOffsetCount; i++) {
+            paramBuffer[i] = *((size_t*)(frame.bp() + offsets[i]));
+        }
+        VectorCopier<size_t>::copy((size_t*)frame.bp(), paramBuffer, parameterOffsetCount);
+    }
+}
+
+ByteCodeStackOffset* Interpreter::runJITFunction(ExecutionState& state, DefinedFunction* function, StackFrame& frame)
+{
+    Instance* instance = function->instance();
+    ModuleFunction* moduleFunction = function->moduleFunction();
+
+    while (true) {
+        JITTailCall tail;
+        tail.target = nullptr;
+        ByteCodeStackOffset* resultOffsets = moduleFunction->jitFunction()->call(state, instance, frame.bp(), &tail);
+
+        if (LIKELY(tail.target == nullptr)) {
+            // Normal return (or an exception was already thrown by JITFunction::call).
+            return resultOffsets;
+        }
+
+        Function* target = tail.target;
+        if (LIKELY(target->kind() == Function::DefinedFunctionKind)) {
+            DefinedFunction* definedTarget = target->asDefinedFunction();
+            ModuleFunction* targetModuleFunction = definedTarget->moduleFunction();
+            if (LIKELY(targetModuleFunction->jitFunction() != nullptr)) {
+                prepareTailFrame(frame, tail.offsets, tail.paramCount, targetModuleFunction->requiredStackSize());
+                state.m_currentFunction = definedTarget;
+                instance = definedTarget->instance();
+                function = definedTarget;
+                moduleFunction = targetModuleFunction;
+                continue;
+            }
+        }
+
+        // Fallback
+        target->interpreterCall(state, frame.bp(), tail.offsets, tail.paramCount, tail.resultCount);
+        return tail.offsets + tail.paramCount;
+    }
+}
+#endif
+
 NEVER_INLINE bool Interpreter::testRefGeneric(void* refPtr, Value::Type type)
 {
     ASSERT(!Value::isNull(refPtr));

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -116,7 +116,10 @@ private:
 
 #if defined(WALRUS_ENABLE_JIT)
         if (moduleFunction->jitFunction() != nullptr) {
-            resultOffsets = moduleFunction->jitFunction()->call(newState, function->instance(), functionStackBase);
+            const JITFunction* jitFunc = moduleFunction->jitFunction();
+            ExecutionContext context(jitFunc->instanceConstData(), newState, function->instance());
+            context.frameCapacity = frame.capacity();
+            resultOffsets = jitFunc->call(context, frame.bp());
         } else
 #endif
         {

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -120,6 +120,10 @@ private:
             ExecutionContext context(jitFunc->instanceConstData(), newState, function->instance());
             context.frameCapacity = frame.capacity();
             resultOffsets = jitFunc->call(context, frame.bp());
+
+            if (UNLIKELY(context.ownedFrame != nullptr)) {
+                frame.replaceBuffer(context.ownedFrame, context.frameCapacity);
+            }
         } else
 #endif
         {

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -116,7 +116,7 @@ private:
 
 #if defined(WALRUS_ENABLE_JIT)
         if (moduleFunction->jitFunction() != nullptr) {
-            resultOffsets = moduleFunction->jitFunction()->call(newState, function->instance(), functionStackBase);
+            resultOffsets = runJITFunction(newState, function, frame);
         } else
 #endif
         {
@@ -200,6 +200,11 @@ private:
 
     static bool testRefGeneric(void* refPtr, Value::Type type);
     static bool testRefDefined(void* refPtr, const CompositeType** typeInfo);
+
+#if defined(WALRUS_ENABLE_JIT)
+    static ByteCodeStackOffset* runJITFunction(ExecutionState& state, DefinedFunction* function, StackFrame& frame);
+    static void prepareTailFrame(StackFrame& frame, ByteCodeStackOffset* offsets, uint16_t parameterOffsetCount, size_t requiredStackSize);
+#endif
 };
 
 } // namespace Walrus

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -114,13 +114,34 @@ private:
         StackFrame frame(functionStackBase, moduleFunction->requiredStackSize());
         ByteCodeStackOffset* resultOffsets;
 
+        while (true) {
 #if defined(WALRUS_ENABLE_JIT)
-        if (moduleFunction->jitFunction() != nullptr) {
-            resultOffsets = runJITFunction(newState, function, frame);
-        } else
+            if (moduleFunction->jitFunction() != nullptr) {
+                const JITFunction* jitFunc = moduleFunction->jitFunction();
+                ExecutionContext context(jitFunc->instanceConstData(), newState, function->instance());
+                resultOffsets = jitFunc->call(context, frame.bp());
+
+                if (LIKELY(context.error != ExecutionContext::TailCall)) {
+                    break;
+                }
+
+                // Restart the pending tail call in the current frame: its
+                // arguments are already placed at the frame base.
+                newState.m_currentFunction = context.tailCallTarget;
+                function = newState.m_currentFunction.value()->asDefinedFunction();
+                moduleFunction = function->moduleFunction();
+                programCounter = reinterpret_cast<size_t>(moduleFunction->byteCode());
+
+                size_t requiredStackSize = moduleFunction->requiredStackSize();
+                if (UNLIKELY(requiredStackSize > frame.capacity())) {
+                    uint8_t* newBuffer = StackFrame::allocateBuffer(requiredStackSize);
+                    memcpy(newBuffer, frame.bp(), function->functionType()->paramStackSize());
+                    frame.replaceBuffer(newBuffer, requiredStackSize);
+                }
+                continue;
+            }
 #endif
-        {
-            while (true) {
+            {
                 try {
                     resultOffsets = interpret(newState, programCounter, frame, function->instance());
                     break;
@@ -200,11 +221,6 @@ private:
 
     static bool testRefGeneric(void* refPtr, Value::Type type);
     static bool testRefDefined(void* refPtr, const CompositeType** typeInfo);
-
-#if defined(WALRUS_ENABLE_JIT)
-    static ByteCodeStackOffset* runJITFunction(ExecutionState& state, DefinedFunction* function, StackFrame& frame);
-    static void prepareTailFrame(StackFrame& frame, ByteCodeStackOffset* offsets, uint16_t parameterOffsetCount, size_t requiredStackSize);
-#endif
 };
 
 } // namespace Walrus

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -114,34 +114,16 @@ private:
         StackFrame frame(functionStackBase, moduleFunction->requiredStackSize());
         ByteCodeStackOffset* resultOffsets;
 
-        while (true) {
 #if defined(WALRUS_ENABLE_JIT)
-            if (moduleFunction->jitFunction() != nullptr) {
-                const JITFunction* jitFunc = moduleFunction->jitFunction();
-                ExecutionContext context(jitFunc->instanceConstData(), newState, function->instance());
-                resultOffsets = jitFunc->call(context, frame.bp());
-
-                if (LIKELY(context.error != ExecutionContext::TailCall)) {
-                    break;
-                }
-
-                // Restart the pending tail call in the current frame: its
-                // arguments are already placed at the frame base.
-                newState.m_currentFunction = context.tailCallTarget;
-                function = newState.m_currentFunction.value()->asDefinedFunction();
-                moduleFunction = function->moduleFunction();
-                programCounter = reinterpret_cast<size_t>(moduleFunction->byteCode());
-
-                size_t requiredStackSize = moduleFunction->requiredStackSize();
-                if (UNLIKELY(requiredStackSize > frame.capacity())) {
-                    uint8_t* newBuffer = StackFrame::allocateBuffer(requiredStackSize);
-                    memcpy(newBuffer, frame.bp(), function->functionType()->paramStackSize());
-                    frame.replaceBuffer(newBuffer, requiredStackSize);
-                }
-                continue;
-            }
+        if (moduleFunction->jitFunction() != nullptr) {
+            const JITFunction* jitFunc = moduleFunction->jitFunction();
+            ExecutionContext context(jitFunc->instanceConstData(), newState, function->instance());
+            context.frameCapacity = frame.capacity();
+            resultOffsets = jitFunc->call(context, frame.bp());
+        } else
 #endif
-            {
+        {
+            while (true) {
                 try {
                     resultOffsets = interpret(newState, programCounter, frame, function->instance());
                     break;

--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -18,6 +18,7 @@
 
 #include "Walrus.h"
 
+#include "GCUtil.h"
 #include "runtime/GCArray.h"
 #include "runtime/GCStruct.h"
 #include "runtime/Global.h"

--- a/src/jit/CallInl.h
+++ b/src/jit/CallInl.h
@@ -15,7 +15,6 @@
  */
 
 /* Only included by jit-backend.cc */
-
 static sljit_sw callFunction(
     Call* code,
     uint8_t* bp,
@@ -145,12 +144,7 @@ static sljit_sw callFunctionRef(
 
 static sljit_sw shuffleTailCallSelfArguments(uint8_t* bp, ByteCodeStackOffset* offsets, sljit_uw parameterOffsetCount)
 {
-    size_t stackBuffer[64];
-    size_t* paramBuffer = stackBuffer;
-
-    if (UNLIKELY(parameterOffsetCount > 64)) {
-        paramBuffer = static_cast<size_t*>(malloc(parameterOffsetCount * sizeof(size_t)));
-    }
+    ALLOCA(size_t, paramBuffer, parameterOffsetCount * sizeof(size_t));
 
     for (sljit_uw i = 0; i < parameterOffsetCount; i++) {
         paramBuffer[i] = *reinterpret_cast<size_t*>(bp + offsets[i]);
@@ -158,10 +152,6 @@ static sljit_sw shuffleTailCallSelfArguments(uint8_t* bp, ByteCodeStackOffset* o
 
     for (sljit_uw i = 0; i < parameterOffsetCount; i++) {
         reinterpret_cast<size_t*>(bp)[i] = paramBuffer[i];
-    }
-
-    if (UNLIKELY(paramBuffer != stackBuffer)) {
-        free(paramBuffer);
     }
 
     return ExecutionContext::NoError;
@@ -182,10 +172,35 @@ static sljit_sw resolvePendingTailCall(
 
         // It is really TCO capable function?
         if (LIKELY(targetJitFunction != nullptr && targetJitFunction->isCompiled()
-                   && targetJitFunction->instanceConstData() == context->currentInstanceConstData
-                   && targetModuleFunction->requiredStackSize() <= context->frameCapacity)) {
+                   && targetJitFunction->instanceConstData() == context->currentInstanceConstData)) {
+            size_t requiredStackSize = targetModuleFunction->requiredStackSize();
+            // Allocate more stack and hang to pointer
+            if (UNLIKELY(requiredStackSize > context->frameCapacity)) {
+#ifdef ENABLE_GC
+                uint8_t* newFrame = reinterpret_cast<uint8_t*>(GC_MALLOC_UNCOLLECTABLE(requiredStackSize));
+#else
+                uint8_t* newFrame = reinterpret_cast<uint8_t*>(malloc(requiredStackSize));
+#endif
+                for (sljit_uw i = 0; i < parameterOffsetCount; i++) {
+                    reinterpret_cast<size_t*>(newFrame)[i] = *reinterpret_cast<size_t*>(bp + offsets[i]);
+                }
+
+                if (context->ownedFrame != nullptr) {
+#ifdef ENABLE_GC
+                    GC_FREE(context->ownedFrame);
+#else
+                    free(context->ownedFrame);
+#endif
+                }
+                context->ownedFrame = newFrame;
+                context->frameCapacity = requiredStackSize;
+                bp = newFrame;
+            } else {
+                shuffleTailCallSelfArguments(bp, offsets, parameterOffsetCount);
+            }
+
             // The caller jumps directly to the target entry.
-            shuffleTailCallSelfArguments(bp, offsets, parameterOffsetCount);
+            context->frameStart = bp;
             context->instance = definedTarget->instance();
             context->tailCallEntry = targetJitFunction->exportEntry();
             return ExecutionContext::TailCallJump;
@@ -448,6 +463,7 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
         // Jump to the entry of the resolved target
         sljit_set_label(tailCallJump, sljit_emit_label(compiler));
         sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_SP), kContextOffset);
+        sljit_emit_op1(compiler, SLJIT_MOV_P, kFrameReg, 0, SLJIT_MEM1(SLJIT_R0), OffsetOfContextField(frameStart));
         sljit_emit_op1(compiler, SLJIT_MOV_P, kInstanceReg, 0, SLJIT_MEM1(SLJIT_R0), OffsetOfContextField(instance));
         sljit_emit_op1(compiler, SLJIT_MOV_P, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_R0), OffsetOfContextField(tailCallEntry));
         sljit_emit_icall(compiler, SLJIT_CALL_REG_ARG | SLJIT_CALL_RETURN, SLJIT_ARGS1(P, P), SLJIT_R2, 0);

--- a/src/jit/CallInl.h
+++ b/src/jit/CallInl.h
@@ -159,6 +159,108 @@ static sljit_sw shuffleTailCallSelfArguments(uint8_t* bp, ByteCodeStackOffset* o
     return ExecutionContext::NoError;
 }
 
+static sljit_sw tailCallFunction(
+    ReturnCall* code,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    context->tailCallTarget = context->instance->function(code->index());
+    context->tailCallOffsets = code->stackOffsets();
+    context->tailCallParamCount = code->parameterOffsetsSize();
+    context->tailCallResultCount = code->resultOffsetsSize();
+    return ExecutionContext::NoError;
+}
+
+static sljit_sw tailCallFunctionIndirect(
+    ReturnCallIndirect* code,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    Instance* instance = context->instance;
+    Table* table = instance->table(code->tableIndex());
+
+    uint32_t idx = *reinterpret_cast<uint32_t*>(bp + code->calleeOffset());
+    if (idx >= table->size()) {
+        context->error = ExecutionContext::UndefinedElementError;
+        return ExecutionContext::UndefinedElementError;
+    }
+
+    auto target = reinterpret_cast<Function*>(table->uncheckedGetElement(idx));
+    if (UNLIKELY(Value::isNull(target))) {
+        context->error = ExecutionContext::UninitializedElementError;
+        return ExecutionContext::UninitializedElementError;
+    }
+
+    const FunctionType* ft = target->functionType();
+    if (!ft->equals(code->functionType())) {
+        context->error = ExecutionContext::IndirectCallTypeMismatchError;
+        return ExecutionContext::IndirectCallTypeMismatchError;
+    }
+
+    context->tailCallTarget = target;
+    context->tailCallOffsets = code->stackOffsets();
+    context->tailCallParamCount = code->parameterOffsetsSize();
+    context->tailCallResultCount = code->resultOffsetsSize();
+    return ExecutionContext::NoError;
+}
+
+static sljit_sw tailCallFunctionIndirectM64(
+    ReturnCallIndirectM64* code,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    Instance* instance = context->instance;
+    Table* table = instance->table(code->tableIndex());
+
+    uint64_t idx = *reinterpret_cast<uint64_t*>(bp + code->calleeOffset());
+    if (idx >= table->size()) {
+        context->error = ExecutionContext::UndefinedElementError;
+        return ExecutionContext::UndefinedElementError;
+    }
+
+    auto target = reinterpret_cast<Function*>(table->uncheckedGetElementM64(idx));
+    if (UNLIKELY(Value::isNull(target))) {
+        context->error = ExecutionContext::UninitializedElementError;
+        return ExecutionContext::UninitializedElementError;
+    }
+
+    const FunctionType* ft = target->functionType();
+    if (!ft->equals(code->functionType())) {
+        context->error = ExecutionContext::IndirectCallTypeMismatchError;
+        return ExecutionContext::IndirectCallTypeMismatchError;
+    }
+
+    context->tailCallTarget = target;
+    context->tailCallOffsets = code->stackOffsets();
+    context->tailCallParamCount = code->parameterOffsetsSize();
+    context->tailCallResultCount = code->resultOffsetsSize();
+    return ExecutionContext::NoError;
+}
+
+static sljit_sw tailCallFunctionRef(
+    ReturnCallRef* code,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    auto target = *reinterpret_cast<Function**>(bp + code->calleeOffset());
+    if (UNLIKELY(Value::isNull(target))) {
+        context->error = ExecutionContext::NullFunctionReferenceError;
+        return ExecutionContext::NullFunctionReferenceError;
+    }
+
+    const FunctionType* ft = target->functionType();
+    if (!ft->equals(code->functionType())) {
+        context->error = ExecutionContext::CallRefTypeMismatchError;
+        return ExecutionContext::CallRefTypeMismatchError;
+    }
+
+    context->tailCallTarget = target;
+    context->tailCallOffsets = code->stackOffsets();
+    context->tailCallParamCount = code->parameterOffsetsSize();
+    context->tailCallResultCount = code->resultOffsetsSize();
+    return ExecutionContext::NoError;
+}
+
 static void emitCall(sljit_compiler* compiler, Instruction* instr)
 {
     FunctionType* functionType;
@@ -178,7 +280,7 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     }
     case ByteCode::ReturnCallOpcode: {
         ReturnCall* call = reinterpret_cast<ReturnCall*>(instr->byteCode());
-        addr = GET_FUNC_ADDR(sljit_sw, callFunction);
+        addr = GET_FUNC_ADDR(sljit_sw, tailCallFunction);
         functionType = context->compiler->module()->function(call->index())->functionType();
         stackOffset = call->stackOffsets();
         break;
@@ -188,11 +290,17 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     case ByteCode::ReturnCallIndirectOpcode:
     case ByteCode::ReturnCallIndirectM64Opcode: {
         CallTable* callTable = reinterpret_cast<CallTable*>(instr->byteCode());
-        if (instr->opcode() == ByteCode::CallIndirectOpcode || instr->opcode() == ByteCode::ReturnCallIndirectOpcode) {
+        if (instr->opcode() == ByteCode::CallIndirectOpcode) {
             addr = GET_FUNC_ADDR(sljit_sw, callFunctionIndirect);
             calleeType = Instruction::Int32Operand;
-        } else {
+        } else if (instr->opcode() == ByteCode::ReturnCallIndirectOpcode) {
+            addr = GET_FUNC_ADDR(sljit_sw, tailCallFunctionIndirect);
+            calleeType = Instruction::Int32Operand;
+        } else if (instr->opcode() == ByteCode::CallIndirectM64Opcode) {
             addr = GET_FUNC_ADDR(sljit_sw, callFunctionIndirectM64);
+            calleeType = Instruction::Int64Operand;
+        } else {
+            addr = GET_FUNC_ADDR(sljit_sw, tailCallFunctionIndirectM64);
             calleeType = Instruction::Int64Operand;
         }
         functionType = callTable->functionType();
@@ -221,7 +329,7 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
 #else /* !SLJIT_64BIT_ARCHITECTURE */
         calleeType = Instruction::Int32Operand;
 #endif /* SLJIT_64BIT_ARCHITECTURE */
-        addr = GET_FUNC_ADDR(sljit_sw, callFunctionRef);
+        addr = GET_FUNC_ADDR(sljit_sw, tailCallFunctionRef);
         functionType = callRef->functionType();
         stackOffset = callRef->stackOffsets();
         calleeOffset = callRef->calleeOffset();
@@ -231,7 +339,17 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
 
     Operand* operand = instr->operands();
 
+    bool isReturnCall = instr->opcode() == ByteCode::ReturnCallOpcode
+        || instr->opcode() == ByteCode::ReturnCallIndirectOpcode
+        || instr->opcode() == ByteCode::ReturnCallIndirectM64Opcode
+        || instr->opcode() == ByteCode::ReturnCallRefOpcode;
+    bool isSelfDirect = false;
     if (instr->opcode() == ByteCode::ReturnCallOpcode) {
+        ReturnCall* returnCall = reinterpret_cast<ReturnCall*>(instr->byteCode());
+        isSelfDirect = context->compiler->module()->function(returnCall->index()) == context->compiler->moduleFunction();
+    }
+
+    if (isSelfDirect) {
         ReturnCall* returnCall = reinterpret_cast<ReturnCall*>(instr->byteCode());
 
         // Detect memory offset instr for copy all oprands related to memory
@@ -302,16 +420,20 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
 
     sljit_jump* jump = sljit_emit_cmp(compiler, SLJIT_NOT_EQUAL, SLJIT_R0, 0, SLJIT_IMM, ExecutionContext::NoError);
 
-    for (auto it : functionType->result().types()) {
-        ASSERT(VARIABLE_TYPE(*operand) != Instruction::ConstPtr);
+    if (isReturnCall) {
+        context->earlyReturns.push_back(sljit_emit_jump(compiler, SLJIT_JUMP));
+    } else {
+        for (auto it : functionType->result().types()) {
+            ASSERT(VARIABLE_TYPE(*operand) != Instruction::ConstPtr);
 
-        if (VARIABLE_TYPE(*operand) == Instruction::Register) {
-            Operand src = VARIABLE_SET(STACK_OFFSET(*stackOffset), Instruction::Offset);
-            emitMove(compiler, Instruction::valueTypeToOperandType(it), &src, operand);
+            if (VARIABLE_TYPE(*operand) == Instruction::Register) {
+                Operand src = VARIABLE_SET(STACK_OFFSET(*stackOffset), Instruction::Offset);
+                emitMove(compiler, Instruction::valueTypeToOperandType(it), &src, operand);
+            }
+
+            operand++;
+            stackOffset += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
         }
-
-        operand++;
-        stackOffset += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
     }
 
     if (context->currentTryBlock == InstanceConstData::globalTryBlock) {

--- a/src/jit/CallInl.h
+++ b/src/jit/CallInl.h
@@ -159,16 +159,39 @@ static sljit_sw shuffleTailCallSelfArguments(uint8_t* bp, ByteCodeStackOffset* o
     return ExecutionContext::NoError;
 }
 
+static sljit_sw resolvePendingTailCall(
+    Function* target,
+    ByteCodeStackOffset* offsets,
+    uint16_t parameterOffsetCount,
+    uint16_t resultOffsetCount,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    if (LIKELY(target->kind() == Function::DefinedFunctionKind)) {
+        shuffleTailCallSelfArguments(bp, offsets, parameterOffsetCount);
+        context->tailCallTarget = target;
+        context->error = ExecutionContext::TailCall;
+        return ExecutionContext::TailCall;
+    }
+
+    sljit_sw result = reinterpret_cast<sljit_sw>(offsets + parameterOffsetCount);
+    try {
+        target->interpreterCall(context->state, bp, offsets, parameterOffsetCount, resultOffsetCount);
+    } catch (std::unique_ptr<Exception>& exception) {
+        context->capturedException = exception.release();
+        context->error = ExecutionContext::CapturedException;
+        result = ExecutionContext::CapturedException;
+    }
+    return result;
+}
+
 static sljit_sw tailCallFunction(
     ReturnCall* code,
     uint8_t* bp,
     ExecutionContext* context)
 {
-    context->tailCallTarget = context->instance->function(code->index());
-    context->tailCallOffsets = code->stackOffsets();
-    context->tailCallParamCount = code->parameterOffsetsSize();
-    context->tailCallResultCount = code->resultOffsetsSize();
-    return ExecutionContext::NoError;
+    Function* target = context->instance->function(code->index());
+    return resolvePendingTailCall(target, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize(), bp, context);
 }
 
 static sljit_sw tailCallFunctionIndirect(
@@ -197,11 +220,7 @@ static sljit_sw tailCallFunctionIndirect(
         return ExecutionContext::IndirectCallTypeMismatchError;
     }
 
-    context->tailCallTarget = target;
-    context->tailCallOffsets = code->stackOffsets();
-    context->tailCallParamCount = code->parameterOffsetsSize();
-    context->tailCallResultCount = code->resultOffsetsSize();
-    return ExecutionContext::NoError;
+    return resolvePendingTailCall(target, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize(), bp, context);
 }
 
 static sljit_sw tailCallFunctionIndirectM64(
@@ -230,11 +249,7 @@ static sljit_sw tailCallFunctionIndirectM64(
         return ExecutionContext::IndirectCallTypeMismatchError;
     }
 
-    context->tailCallTarget = target;
-    context->tailCallOffsets = code->stackOffsets();
-    context->tailCallParamCount = code->parameterOffsetsSize();
-    context->tailCallResultCount = code->resultOffsetsSize();
-    return ExecutionContext::NoError;
+    return resolvePendingTailCall(target, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize(), bp, context);
 }
 
 static sljit_sw tailCallFunctionRef(
@@ -254,11 +269,7 @@ static sljit_sw tailCallFunctionRef(
         return ExecutionContext::CallRefTypeMismatchError;
     }
 
-    context->tailCallTarget = target;
-    context->tailCallOffsets = code->stackOffsets();
-    context->tailCallParamCount = code->parameterOffsetsSize();
-    context->tailCallResultCount = code->resultOffsetsSize();
-    return ExecutionContext::NoError;
+    return resolvePendingTailCall(target, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize(), bp, context);
 }
 
 static void emitCall(sljit_compiler* compiler, Instruction* instr)
@@ -338,18 +349,14 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     }
 
     Operand* operand = instr->operands();
+    ReturnCall* returnCall = reinterpret_cast<ReturnCall*>(instr->byteCode());
 
-    bool isReturnCall = instr->opcode() == ByteCode::ReturnCallOpcode
+    bool isTailCall = instr->opcode() == ByteCode::ReturnCallOpcode
         || instr->opcode() == ByteCode::ReturnCallIndirectOpcode
         || instr->opcode() == ByteCode::ReturnCallIndirectM64Opcode
         || instr->opcode() == ByteCode::ReturnCallRefOpcode;
-    bool isSelfDirect = false;
-    if (instr->opcode() == ByteCode::ReturnCallOpcode) {
-        ReturnCall* returnCall = reinterpret_cast<ReturnCall*>(instr->byteCode());
-        isSelfDirect = context->compiler->module()->function(returnCall->index()) == context->compiler->moduleFunction();
-    }
 
-    if (isSelfDirect) {
+    if (instr->opcode() == ByteCode::ReturnCallOpcode && context->compiler->module()->function(returnCall->index()) == context->compiler->moduleFunction()) {
         ReturnCall* returnCall = reinterpret_cast<ReturnCall*>(instr->byteCode());
 
         // Detect memory offset instr for copy all oprands related to memory
@@ -418,22 +425,23 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_SP), kContextOffset);
     sljit_emit_icall(compiler, SLJIT_CALL, SLJIT_ARGS3(W, W, W, W), SLJIT_IMM, addr);
 
+    if (isTailCall) {
+        context->earlyReturns.push_back(sljit_emit_jump(compiler, SLJIT_JUMP));
+        return;
+    }
+
     sljit_jump* jump = sljit_emit_cmp(compiler, SLJIT_NOT_EQUAL, SLJIT_R0, 0, SLJIT_IMM, ExecutionContext::NoError);
 
-    if (isReturnCall) {
-        context->earlyReturns.push_back(sljit_emit_jump(compiler, SLJIT_JUMP));
-    } else {
-        for (auto it : functionType->result().types()) {
-            ASSERT(VARIABLE_TYPE(*operand) != Instruction::ConstPtr);
+    for (auto it : functionType->result().types()) {
+        ASSERT(VARIABLE_TYPE(*operand) != Instruction::ConstPtr);
 
-            if (VARIABLE_TYPE(*operand) == Instruction::Register) {
-                Operand src = VARIABLE_SET(STACK_OFFSET(*stackOffset), Instruction::Offset);
-                emitMove(compiler, Instruction::valueTypeToOperandType(it), &src, operand);
-            }
-
-            operand++;
-            stackOffset += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
+        if (VARIABLE_TYPE(*operand) == Instruction::Register) {
+            Operand src = VARIABLE_SET(STACK_OFFSET(*stackOffset), Instruction::Offset);
+            emitMove(compiler, Instruction::valueTypeToOperandType(it), &src, operand);
         }
+
+        operand++;
+        stackOffset += (valueSize(it) + (sizeof(size_t) - 1)) / sizeof(size_t);
     }
 
     if (context->currentTryBlock == InstanceConstData::globalTryBlock) {

--- a/src/jit/CallInl.h
+++ b/src/jit/CallInl.h
@@ -145,8 +145,12 @@ static sljit_sw callFunctionRef(
 
 static sljit_sw shuffleTailCallSelfArguments(uint8_t* bp, ByteCodeStackOffset* offsets, sljit_uw parameterOffsetCount)
 {
-    Vector<size_t> paramBuffer;
-    paramBuffer.resizeWithUninitializedValues(parameterOffsetCount);
+    size_t stackBuffer[64];
+    size_t* paramBuffer = stackBuffer;
+
+    if (UNLIKELY(parameterOffsetCount > 64)) {
+        paramBuffer = static_cast<size_t*>(malloc(parameterOffsetCount * sizeof(size_t)));
+    }
 
     for (sljit_uw i = 0; i < parameterOffsetCount; i++) {
         paramBuffer[i] = *reinterpret_cast<size_t*>(bp + offsets[i]);
@@ -156,7 +160,135 @@ static sljit_sw shuffleTailCallSelfArguments(uint8_t* bp, ByteCodeStackOffset* o
         reinterpret_cast<size_t*>(bp)[i] = paramBuffer[i];
     }
 
+    if (UNLIKELY(paramBuffer != stackBuffer)) {
+        free(paramBuffer);
+    }
+
     return ExecutionContext::NoError;
+}
+
+static sljit_sw resolvePendingTailCall(
+    Function* target,
+    ByteCodeStackOffset* offsets,
+    uint16_t parameterOffsetCount,
+    uint16_t resultOffsetCount,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    if (LIKELY(target->kind() == Function::DefinedFunctionKind)) {
+        DefinedFunction* definedTarget = target->asDefinedFunction();
+        ModuleFunction* targetModuleFunction = definedTarget->moduleFunction();
+        JITFunction* targetJitFunction = targetModuleFunction->jitFunction();
+
+        // It is really TCO capable function?
+        if (LIKELY(targetJitFunction != nullptr && targetJitFunction->isCompiled()
+                   && targetJitFunction->instanceConstData() == context->currentInstanceConstData
+                   && targetModuleFunction->requiredStackSize() <= context->frameCapacity)) {
+            // The caller jumps directly to the target entry.
+            shuffleTailCallSelfArguments(bp, offsets, parameterOffsetCount);
+            context->instance = definedTarget->instance();
+            context->tailCallEntry = targetJitFunction->exportEntry();
+            return ExecutionContext::TailCallJump;
+        }
+    }
+
+    sljit_sw result = reinterpret_cast<sljit_sw>(offsets + parameterOffsetCount);
+    // Cannot resolved with TCO
+    try {
+        target->interpreterCall(context->state, bp, offsets, parameterOffsetCount, resultOffsetCount);
+    } catch (std::unique_ptr<Exception>& exception) {
+        context->capturedException = exception.release();
+        context->error = ExecutionContext::CapturedException;
+        result = ExecutionContext::CapturedException;
+    }
+    return result;
+}
+
+static sljit_sw tailCallFunction(
+    ReturnCall* code,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    Function* target = context->instance->function(code->index());
+    return resolvePendingTailCall(target, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize(), bp, context);
+}
+
+static sljit_sw tailCallFunctionIndirect(
+    ReturnCallIndirect* code,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    Instance* instance = context->instance;
+    Table* table = instance->table(code->tableIndex());
+
+    uint32_t idx = *reinterpret_cast<uint32_t*>(bp + code->calleeOffset());
+    if (idx >= table->size()) {
+        context->error = ExecutionContext::UndefinedElementError;
+        return ExecutionContext::UndefinedElementError;
+    }
+
+    auto target = reinterpret_cast<Function*>(table->uncheckedGetElement(idx));
+    if (UNLIKELY(Value::isNull(target))) {
+        context->error = ExecutionContext::UninitializedElementError;
+        return ExecutionContext::UninitializedElementError;
+    }
+
+    const FunctionType* ft = target->functionType();
+    if (!ft->equals(code->functionType())) {
+        context->error = ExecutionContext::IndirectCallTypeMismatchError;
+        return ExecutionContext::IndirectCallTypeMismatchError;
+    }
+
+    return resolvePendingTailCall(target, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize(), bp, context);
+}
+
+static sljit_sw tailCallFunctionIndirectM64(
+    ReturnCallIndirectM64* code,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    Instance* instance = context->instance;
+    Table* table = instance->table(code->tableIndex());
+
+    uint64_t idx = *reinterpret_cast<uint64_t*>(bp + code->calleeOffset());
+    if (idx >= table->size()) {
+        context->error = ExecutionContext::UndefinedElementError;
+        return ExecutionContext::UndefinedElementError;
+    }
+
+    auto target = reinterpret_cast<Function*>(table->uncheckedGetElementM64(idx));
+    if (UNLIKELY(Value::isNull(target))) {
+        context->error = ExecutionContext::UninitializedElementError;
+        return ExecutionContext::UninitializedElementError;
+    }
+
+    const FunctionType* ft = target->functionType();
+    if (!ft->equals(code->functionType())) {
+        context->error = ExecutionContext::IndirectCallTypeMismatchError;
+        return ExecutionContext::IndirectCallTypeMismatchError;
+    }
+
+    return resolvePendingTailCall(target, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize(), bp, context);
+}
+
+static sljit_sw tailCallFunctionRef(
+    ReturnCallRef* code,
+    uint8_t* bp,
+    ExecutionContext* context)
+{
+    auto target = *reinterpret_cast<Function**>(bp + code->calleeOffset());
+    if (UNLIKELY(Value::isNull(target))) {
+        context->error = ExecutionContext::NullFunctionReferenceError;
+        return ExecutionContext::NullFunctionReferenceError;
+    }
+
+    const FunctionType* ft = target->functionType();
+    if (!ft->equals(code->functionType())) {
+        context->error = ExecutionContext::CallRefTypeMismatchError;
+        return ExecutionContext::CallRefTypeMismatchError;
+    }
+
+    return resolvePendingTailCall(target, code->stackOffsets(), code->parameterOffsetsSize(), code->resultOffsetsSize(), bp, context);
 }
 
 static void emitCall(sljit_compiler* compiler, Instruction* instr)
@@ -178,7 +310,7 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     }
     case ByteCode::ReturnCallOpcode: {
         ReturnCall* call = reinterpret_cast<ReturnCall*>(instr->byteCode());
-        addr = GET_FUNC_ADDR(sljit_sw, callFunction);
+        addr = GET_FUNC_ADDR(sljit_sw, tailCallFunction);
         functionType = context->compiler->module()->function(call->index())->functionType();
         stackOffset = call->stackOffsets();
         break;
@@ -188,11 +320,17 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     case ByteCode::ReturnCallIndirectOpcode:
     case ByteCode::ReturnCallIndirectM64Opcode: {
         CallTable* callTable = reinterpret_cast<CallTable*>(instr->byteCode());
-        if (instr->opcode() == ByteCode::CallIndirectOpcode || instr->opcode() == ByteCode::ReturnCallIndirectOpcode) {
+        if (instr->opcode() == ByteCode::CallIndirectOpcode) {
             addr = GET_FUNC_ADDR(sljit_sw, callFunctionIndirect);
             calleeType = Instruction::Int32Operand;
-        } else {
+        } else if (instr->opcode() == ByteCode::ReturnCallIndirectOpcode) {
+            addr = GET_FUNC_ADDR(sljit_sw, tailCallFunctionIndirect);
+            calleeType = Instruction::Int32Operand;
+        } else if (instr->opcode() == ByteCode::CallIndirectM64Opcode) {
             addr = GET_FUNC_ADDR(sljit_sw, callFunctionIndirectM64);
+            calleeType = Instruction::Int64Operand;
+        } else {
+            addr = GET_FUNC_ADDR(sljit_sw, tailCallFunctionIndirectM64);
             calleeType = Instruction::Int64Operand;
         }
         functionType = callTable->functionType();
@@ -221,7 +359,7 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
 #else /* !SLJIT_64BIT_ARCHITECTURE */
         calleeType = Instruction::Int32Operand;
 #endif /* SLJIT_64BIT_ARCHITECTURE */
-        addr = GET_FUNC_ADDR(sljit_sw, callFunctionRef);
+        addr = GET_FUNC_ADDR(sljit_sw, tailCallFunctionRef);
         functionType = callRef->functionType();
         stackOffset = callRef->stackOffsets();
         calleeOffset = callRef->calleeOffset();
@@ -230,10 +368,14 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     }
 
     Operand* operand = instr->operands();
+    ReturnCall* returnCall = reinterpret_cast<ReturnCall*>(instr->byteCode());
 
-    if (instr->opcode() == ByteCode::ReturnCallOpcode) {
-        ReturnCall* returnCall = reinterpret_cast<ReturnCall*>(instr->byteCode());
+    bool isTailCall = instr->opcode() == ByteCode::ReturnCallOpcode
+        || instr->opcode() == ByteCode::ReturnCallIndirectOpcode
+        || instr->opcode() == ByteCode::ReturnCallIndirectM64Opcode
+        || instr->opcode() == ByteCode::ReturnCallRefOpcode;
 
+    if (instr->opcode() == ByteCode::ReturnCallOpcode && context->compiler->module()->function(returnCall->index()) == context->compiler->moduleFunction()) {
         // Detect memory offset instr for copy all oprands related to memory
         bool hasMemoryArgument = false;
         for (uint32_t i = 0; i < instr->paramCount(); i++) {
@@ -278,7 +420,6 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     stackOffset = emitStoreOntoStack(compiler, operand, stackOffset, functionType->param(), true);
     operand += instr->paramCount();
 
-    ByteCode::Opcode callOpcode = instr->opcode();
     if (calleeType != 0) {
         Operand dst = VARIABLE_SET(STACK_OFFSET(calleeOffset), Instruction::Offset);
         operand--;
@@ -299,6 +440,19 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, kFrameReg, 0);
     sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_SP), kContextOffset);
     sljit_emit_icall(compiler, SLJIT_CALL, SLJIT_ARGS3(W, W, W, W), SLJIT_IMM, addr);
+
+    if (isTailCall) {
+        sljit_jump* tailCallJump = sljit_emit_cmp(compiler, SLJIT_EQUAL, SLJIT_R0, 0, SLJIT_IMM, ExecutionContext::TailCallJump);
+        context->earlyReturns.push_back(sljit_emit_jump(compiler, SLJIT_JUMP));
+
+        // Jump to the entry of the resolved target
+        sljit_set_label(tailCallJump, sljit_emit_label(compiler));
+        sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_SP), kContextOffset);
+        sljit_emit_op1(compiler, SLJIT_MOV_P, kInstanceReg, 0, SLJIT_MEM1(SLJIT_R0), OffsetOfContextField(instance));
+        sljit_emit_op1(compiler, SLJIT_MOV_P, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_R0), OffsetOfContextField(tailCallEntry));
+        sljit_emit_icall(compiler, SLJIT_CALL_REG_ARG | SLJIT_CALL_RETURN, SLJIT_ARGS1(P, P), SLJIT_R2, 0);
+        return;
+    }
 
     sljit_jump* jump = sljit_emit_cmp(compiler, SLJIT_NOT_EQUAL, SLJIT_R0, 0, SLJIT_IMM, ExecutionContext::NoError);
 

--- a/src/jit/CallInl.h
+++ b/src/jit/CallInl.h
@@ -145,8 +145,12 @@ static sljit_sw callFunctionRef(
 
 static sljit_sw shuffleTailCallSelfArguments(uint8_t* bp, ByteCodeStackOffset* offsets, sljit_uw parameterOffsetCount)
 {
-    Vector<size_t> paramBuffer;
-    paramBuffer.resizeWithUninitializedValues(parameterOffsetCount);
+    size_t stackBuffer[64];
+    size_t* paramBuffer = stackBuffer;
+
+    if (UNLIKELY(parameterOffsetCount > 64)) {
+        paramBuffer = static_cast<size_t*>(malloc(parameterOffsetCount * sizeof(size_t)));
+    }
 
     for (sljit_uw i = 0; i < parameterOffsetCount; i++) {
         paramBuffer[i] = *reinterpret_cast<size_t*>(bp + offsets[i]);
@@ -154,6 +158,10 @@ static sljit_sw shuffleTailCallSelfArguments(uint8_t* bp, ByteCodeStackOffset* o
 
     for (sljit_uw i = 0; i < parameterOffsetCount; i++) {
         reinterpret_cast<size_t*>(bp)[i] = paramBuffer[i];
+    }
+
+    if (UNLIKELY(paramBuffer != stackBuffer)) {
+        free(paramBuffer);
     }
 
     return ExecutionContext::NoError;
@@ -168,13 +176,24 @@ static sljit_sw resolvePendingTailCall(
     ExecutionContext* context)
 {
     if (LIKELY(target->kind() == Function::DefinedFunctionKind)) {
-        shuffleTailCallSelfArguments(bp, offsets, parameterOffsetCount);
-        context->tailCallTarget = target;
-        context->error = ExecutionContext::TailCall;
-        return ExecutionContext::TailCall;
+        DefinedFunction* definedTarget = target->asDefinedFunction();
+        ModuleFunction* targetModuleFunction = definedTarget->moduleFunction();
+        JITFunction* targetJitFunction = targetModuleFunction->jitFunction();
+
+        // It is really TCO capable function?
+        if (LIKELY(targetJitFunction != nullptr && targetJitFunction->isCompiled()
+                   && targetJitFunction->instanceConstData() == context->currentInstanceConstData
+                   && targetModuleFunction->requiredStackSize() <= context->frameCapacity)) {
+            // The caller jumps directly to the target entry.
+            shuffleTailCallSelfArguments(bp, offsets, parameterOffsetCount);
+            context->instance = definedTarget->instance();
+            context->tailCallEntry = targetJitFunction->exportEntry();
+            return ExecutionContext::TailCallJump;
+        }
     }
 
     sljit_sw result = reinterpret_cast<sljit_sw>(offsets + parameterOffsetCount);
+    // Cannot resolved with TCO
     try {
         target->interpreterCall(context->state, bp, offsets, parameterOffsetCount, resultOffsetCount);
     } catch (std::unique_ptr<Exception>& exception) {
@@ -357,8 +376,6 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
         || instr->opcode() == ByteCode::ReturnCallRefOpcode;
 
     if (instr->opcode() == ByteCode::ReturnCallOpcode && context->compiler->module()->function(returnCall->index()) == context->compiler->moduleFunction()) {
-        ReturnCall* returnCall = reinterpret_cast<ReturnCall*>(instr->byteCode());
-
         // Detect memory offset instr for copy all oprands related to memory
         bool hasMemoryArgument = false;
         for (uint32_t i = 0; i < instr->paramCount(); i++) {
@@ -403,7 +420,6 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     stackOffset = emitStoreOntoStack(compiler, operand, stackOffset, functionType->param(), true);
     operand += instr->paramCount();
 
-    ByteCode::Opcode callOpcode = instr->opcode();
     if (calleeType != 0) {
         Operand dst = VARIABLE_SET(STACK_OFFSET(calleeOffset), Instruction::Offset);
         operand--;
@@ -426,7 +442,15 @@ static void emitCall(sljit_compiler* compiler, Instruction* instr)
     sljit_emit_icall(compiler, SLJIT_CALL, SLJIT_ARGS3(W, W, W, W), SLJIT_IMM, addr);
 
     if (isTailCall) {
+        sljit_jump* tailCallJump = sljit_emit_cmp(compiler, SLJIT_EQUAL, SLJIT_R0, 0, SLJIT_IMM, ExecutionContext::TailCallJump);
         context->earlyReturns.push_back(sljit_emit_jump(compiler, SLJIT_JUMP));
+
+        // Jump to the entry of the resolved target
+        sljit_set_label(tailCallJump, sljit_emit_label(compiler));
+        sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_SP), kContextOffset);
+        sljit_emit_op1(compiler, SLJIT_MOV_P, kInstanceReg, 0, SLJIT_MEM1(SLJIT_R0), OffsetOfContextField(instance));
+        sljit_emit_op1(compiler, SLJIT_MOV_P, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_R0), OffsetOfContextField(tailCallEntry));
+        sljit_emit_icall(compiler, SLJIT_CALL_REG_ARG | SLJIT_CALL_RETURN, SLJIT_ARGS1(P, P), SLJIT_R2, 0);
         return;
     }
 

--- a/src/jit/RegisterAlloc.cpp
+++ b/src/jit/RegisterAlloc.cpp
@@ -698,7 +698,8 @@ void JITCompiler::allocateRegisters()
             ASSERT(instr->opcode() == ByteCode::EndOpcode || instr->opcode() == ByteCode::ThrowOpcode
                    || instr->opcode() == ByteCode::CallOpcode || instr->opcode() == ByteCode::ReturnCallOpcode
                    || instr->opcode() == ByteCode::CallIndirectOpcode || instr->opcode() == ByteCode::CallIndirectM64Opcode
-                   || instr->opcode() == ByteCode::CallRefOpcode
+                   || instr->opcode() == ByteCode::ReturnCallIndirectOpcode || instr->opcode() == ByteCode::ReturnCallIndirectM64Opcode
+                   || instr->opcode() == ByteCode::CallRefOpcode || instr->opcode() == ByteCode::ReturnCallRefOpcode
                    || instr->opcode() == ByteCode::JumpOpcode
                    || instr->opcode() == ByteCode::ElemDropOpcode || instr->opcode() == ByteCode::DataDropOpcode
                    || instr->opcode() == ByteCode::StructNewOpcode || instr->opcode() == ByteCode::ArrayNewFixedOpcode
@@ -1037,7 +1038,8 @@ void JITCompiler::allocateRegistersSimple()
             ASSERT(instr->opcode() == ByteCode::EndOpcode || instr->opcode() == ByteCode::ThrowOpcode
                    || instr->opcode() == ByteCode::CallOpcode || instr->opcode() == ByteCode::ReturnCallOpcode
                    || instr->opcode() == ByteCode::CallIndirectOpcode || instr->opcode() == ByteCode::CallIndirectM64Opcode
-                   || instr->opcode() == ByteCode::CallRefOpcode
+                   || instr->opcode() == ByteCode::ReturnCallIndirectOpcode || instr->opcode() == ByteCode::ReturnCallIndirectM64Opcode
+                   || instr->opcode() == ByteCode::CallRefOpcode || instr->opcode() == ByteCode::ReturnCallRefOpcode
                    || instr->opcode() == ByteCode::JumpOpcode
                    || instr->opcode() == ByteCode::ElemDropOpcode || instr->opcode() == ByteCode::DataDropOpcode
                    || instr->opcode() == ByteCode::StructNewOpcode || instr->opcode() == ByteCode::ArrayNewFixedOpcode

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -623,7 +623,6 @@ private:
 
     bool m_inInitExpr;
     Walrus::ModuleFunction* m_currentFunction;
-    uint32_t m_currentFunctionIndex;
     Walrus::FunctionType* m_currentFunctionType;
     Walrus::Vector<uint8_t, std::allocator<uint8_t>> m_currentByteCode;
     uint32_t m_initialFunctionStackSize;
@@ -1357,7 +1356,6 @@ public:
     {
         ASSERT(resumeGenerateByteCodeAfterNBlockEnd() == 0);
         ASSERT(m_currentFunction == nullptr);
-        m_currentFunctionIndex = index;
         beginFunction(m_result.m_functions[index], false);
     }
 
@@ -1628,11 +1626,6 @@ public:
     virtual void OnReturnCallExpr(uint32_t index) override
     {
         m_preprocessData.seenBranch();
-        if (m_useJIT && index != m_currentFunctionIndex) {
-            OnCallExpr(index);
-            generateFunctionReturnCode();
-            return;
-        }
         auto functionType = m_result.m_functions[index]->functionType();
         auto callPos = m_currentByteCode.size();
         auto parameterCount = computeFunctionParameterOrResultOffsetCount(functionType->param());
@@ -1650,11 +1643,6 @@ public:
     virtual void OnReturnCallIndirectExpr(Index sigIndex, Index tableIndex) override
     {
         m_preprocessData.seenBranch();
-        if (m_useJIT) {
-            OnCallIndirectExpr(sigIndex, tableIndex);
-            generateFunctionReturnCode();
-            return;
-        }
         ASSERT(peekVMStackValueType() == m_result.m_tableTypes[tableIndex]->is64() ? Walrus::Value::Type::I64 : Walrus::Value::Type::I32);
         auto functionType = getFunctionType(sigIndex);
         auto callPos = m_currentByteCode.size();
@@ -1677,11 +1665,6 @@ public:
     virtual void OnReturnCallRefExpr(Type sig_type) override
     {
         m_preprocessData.seenBranch();
-        if (m_useJIT) {
-            OnCallRefExpr(sig_type);
-            generateFunctionReturnCode();
-            return;
-        }
         auto functionType = getFunctionType(sig_type.GetReferenceIndex());
         auto callPos = m_currentByteCode.size();
         auto parameterCount = computeFunctionParameterOrResultOffsetCount(functionType->param());

--- a/src/runtime/JITExec.cpp
+++ b/src/runtime/JITExec.cpp
@@ -24,7 +24,7 @@
 
 namespace Walrus {
 
-ByteCodeStackOffset* JITFunction::call(ExecutionState& state, Instance* instance, uint8_t* bp) const
+ByteCodeStackOffset* JITFunction::call(ExecutionState& state, Instance* instance, uint8_t* bp, JITTailCall* tailOut) const
 {
     ASSERT(m_exportEntry);
 
@@ -32,6 +32,15 @@ ByteCodeStackOffset* JITFunction::call(ExecutionState& state, Instance* instance
     Memory* memory0 = nullptr;
 
     ByteCodeStackOffset* resultOffsets = m_module->exportCall()(&context, bp, m_exportEntry);
+
+    if (context.tailCallTarget != nullptr) {
+        ASSERT(tailOut != nullptr);
+        tailOut->target = context.tailCallTarget;
+        tailOut->offsets = context.tailCallOffsets;
+        tailOut->paramCount = context.tailCallParamCount;
+        tailOut->resultCount = context.tailCallResultCount;
+        return nullptr;
+    }
 
     if (context.error != ExecutionContext::NoError) {
         switch (context.error) {

--- a/src/runtime/JITExec.cpp
+++ b/src/runtime/JITExec.cpp
@@ -24,26 +24,17 @@
 
 namespace Walrus {
 
-ByteCodeStackOffset* JITFunction::call(ExecutionState& state, Instance* instance, uint8_t* bp, JITTailCall* tailOut) const
+ByteCodeStackOffset* JITFunction::call(ExecutionContext& context, uint8_t* bp) const
 {
     ASSERT(m_exportEntry);
 
-    ExecutionContext context(m_module->instanceConstData(), state, instance);
-    Memory* memory0 = nullptr;
-
+    ExecutionState& state = context.state;
     ByteCodeStackOffset* resultOffsets = m_module->exportCall()(&context, bp, m_exportEntry);
-
-    if (context.tailCallTarget != nullptr) {
-        ASSERT(tailOut != nullptr);
-        tailOut->target = context.tailCallTarget;
-        tailOut->offsets = context.tailCallOffsets;
-        tailOut->paramCount = context.tailCallParamCount;
-        tailOut->resultCount = context.tailCallResultCount;
-        return nullptr;
-    }
 
     if (context.error != ExecutionContext::NoError) {
         switch (context.error) {
+        case ExecutionContext::TailCall:
+            return nullptr;
         case ExecutionContext::CapturedException:
             throw std::unique_ptr<Exception>(context.capturedException);
         case ExecutionContext::OutOfStackError:

--- a/src/runtime/JITExec.cpp
+++ b/src/runtime/JITExec.cpp
@@ -33,8 +33,6 @@ ByteCodeStackOffset* JITFunction::call(ExecutionContext& context, uint8_t* bp) c
 
     if (context.error != ExecutionContext::NoError) {
         switch (context.error) {
-        case ExecutionContext::TailCall:
-            return nullptr;
         case ExecutionContext::CapturedException:
             throw std::unique_ptr<Exception>(context.capturedException);
         case ExecutionContext::OutOfStackError:

--- a/src/runtime/JITExec.cpp
+++ b/src/runtime/JITExec.cpp
@@ -24,13 +24,11 @@
 
 namespace Walrus {
 
-ByteCodeStackOffset* JITFunction::call(ExecutionState& state, Instance* instance, uint8_t* bp) const
+ByteCodeStackOffset* JITFunction::call(ExecutionContext& context, uint8_t* bp) const
 {
     ASSERT(m_exportEntry);
 
-    ExecutionContext context(m_module->instanceConstData(), state, instance);
-    Memory* memory0 = nullptr;
-
+    ExecutionState& state = context.state;
     ByteCodeStackOffset* resultOffsets = m_module->exportCall()(&context, bp, m_exportEntry);
 
     if (context.error != ExecutionContext::NoError) {

--- a/src/runtime/JITExec.cpp
+++ b/src/runtime/JITExec.cpp
@@ -16,6 +16,7 @@
 
 #include "Walrus.h"
 
+#include "GCUtil.h"
 #include "runtime/JITExec.h"
 #include "runtime/Instance.h"
 #include "runtime/Module.h"
@@ -32,6 +33,15 @@ ByteCodeStackOffset* JITFunction::call(ExecutionContext& context, uint8_t* bp) c
     ByteCodeStackOffset* resultOffsets = m_module->exportCall()(&context, bp, m_exportEntry);
 
     if (context.error != ExecutionContext::NoError) {
+        if (UNLIKELY(context.ownedFrame != nullptr)) {
+#ifdef ENABLE_GC
+            GC_FREE(context.ownedFrame);
+#else
+            free(context.ownedFrame);
+#endif
+            context.ownedFrame = nullptr;
+        }
+
         switch (context.error) {
         case ExecutionContext::CapturedException:
             throw std::unique_ptr<Exception>(context.capturedException);

--- a/src/runtime/JITExec.h
+++ b/src/runtime/JITExec.h
@@ -26,6 +26,7 @@ namespace Walrus {
 class Exception;
 class Memory;
 class InstanceConstData;
+class Function;
 
 struct ExecutionContext {
     enum ErrorCodes : uint32_t {
@@ -67,6 +68,10 @@ struct ExecutionContext {
         , instance(instance)
         , capturedException(nullptr)
         , error(NoError)
+        , tailCallTarget(nullptr)
+        , tailCallOffsets(nullptr)
+        , tailCallParamCount(0)
+        , tailCallResultCount(0)
     {
     }
 
@@ -82,6 +87,10 @@ struct ExecutionContext {
     Instance* instance;
     Exception* capturedException;
     ErrorCodes error;
+    Function* tailCallTarget;
+    ByteCodeStackOffset* tailCallOffsets;
+    uint16_t tailCallParamCount;
+    uint16_t tailCallResultCount;
 };
 
 class JITModule {
@@ -113,6 +122,13 @@ private:
     std::vector<void*> m_codeBlocks;
 };
 
+struct JITTailCall {
+    Function* target;
+    ByteCodeStackOffset* offsets;
+    uint16_t paramCount;
+    uint16_t resultCount;
+};
+
 class JITFunction {
     friend class JITCompiler;
 
@@ -132,7 +148,7 @@ public:
     }
 
     bool isCompiled() const { return m_exportEntry != nullptr; }
-    ByteCodeStackOffset* call(ExecutionState& state, Instance* instance, uint8_t* bp) const;
+    ByteCodeStackOffset* call(ExecutionState& state, Instance* instance, uint8_t* bp, JITTailCall* tailOut = nullptr) const;
 
 private:
     void* m_exportEntry;

--- a/src/runtime/JITExec.h
+++ b/src/runtime/JITExec.h
@@ -60,6 +60,7 @@ struct ExecutionContext {
         GenericTrap, // Error code received in SLJIT_R0.
         ReturnToLabel, // Used for returning with an exception.
         ErrorCodesEnd,
+        TailCall,
     };
 
     ExecutionContext(InstanceConstData* currentInstanceConstData, ExecutionState& state, Instance* instance)
@@ -69,9 +70,6 @@ struct ExecutionContext {
         , capturedException(nullptr)
         , error(NoError)
         , tailCallTarget(nullptr)
-        , tailCallOffsets(nullptr)
-        , tailCallParamCount(0)
-        , tailCallResultCount(0)
     {
     }
 
@@ -88,9 +86,6 @@ struct ExecutionContext {
     Exception* capturedException;
     ErrorCodes error;
     Function* tailCallTarget;
-    ByteCodeStackOffset* tailCallOffsets;
-    uint16_t tailCallParamCount;
-    uint16_t tailCallResultCount;
 };
 
 class JITModule {
@@ -122,13 +117,6 @@ private:
     std::vector<void*> m_codeBlocks;
 };
 
-struct JITTailCall {
-    Function* target;
-    ByteCodeStackOffset* offsets;
-    uint16_t paramCount;
-    uint16_t resultCount;
-};
-
 class JITFunction {
     friend class JITCompiler;
 
@@ -148,7 +136,8 @@ public:
     }
 
     bool isCompiled() const { return m_exportEntry != nullptr; }
-    ByteCodeStackOffset* call(ExecutionState& state, Instance* instance, uint8_t* bp, JITTailCall* tailOut = nullptr) const;
+    InstanceConstData* instanceConstData() const { return m_module->instanceConstData(); }
+    ByteCodeStackOffset* call(ExecutionContext& context, uint8_t* bp) const;
 
 private:
     void* m_exportEntry;

--- a/src/runtime/JITExec.h
+++ b/src/runtime/JITExec.h
@@ -69,6 +69,8 @@ struct ExecutionContext {
         , capturedException(nullptr)
         , error(NoError)
         , tailCallEntry(nullptr)
+        , frameStart(nullptr)
+        , ownedFrame(nullptr)
         , frameCapacity(0)
     {
     }
@@ -86,6 +88,8 @@ struct ExecutionContext {
     Exception* capturedException;
     ErrorCodes error;
     void* tailCallEntry;
+    uint8_t* frameStart;
+    uint8_t* ownedFrame;
     size_t frameCapacity;
 };
 

--- a/src/runtime/JITExec.h
+++ b/src/runtime/JITExec.h
@@ -59,6 +59,7 @@ struct ExecutionContext {
         GenericTrap, // Error code received in SLJIT_R0.
         ReturnToLabel, // Used for returning with an exception.
         ErrorCodesEnd,
+        TailCallJump,
     };
 
     ExecutionContext(InstanceConstData* currentInstanceConstData, ExecutionState& state, Instance* instance)
@@ -67,6 +68,8 @@ struct ExecutionContext {
         , instance(instance)
         , capturedException(nullptr)
         , error(NoError)
+        , tailCallEntry(nullptr)
+        , frameCapacity(0)
     {
     }
 
@@ -82,6 +85,8 @@ struct ExecutionContext {
     Instance* instance;
     Exception* capturedException;
     ErrorCodes error;
+    void* tailCallEntry;
+    size_t frameCapacity;
 };
 
 class JITModule {
@@ -132,7 +137,9 @@ public:
     }
 
     bool isCompiled() const { return m_exportEntry != nullptr; }
-    ByteCodeStackOffset* call(ExecutionState& state, Instance* instance, uint8_t* bp) const;
+    void* exportEntry() const { return m_exportEntry; }
+    InstanceConstData* instanceConstData() const { return m_module->instanceConstData(); }
+    ByteCodeStackOffset* call(ExecutionContext& context, uint8_t* bp) const;
 
 private:
     void* m_exportEntry;

--- a/src/runtime/JITExec.h
+++ b/src/runtime/JITExec.h
@@ -26,7 +26,6 @@ namespace Walrus {
 class Exception;
 class Memory;
 class InstanceConstData;
-class Function;
 
 struct ExecutionContext {
     enum ErrorCodes : uint32_t {
@@ -60,7 +59,7 @@ struct ExecutionContext {
         GenericTrap, // Error code received in SLJIT_R0.
         ReturnToLabel, // Used for returning with an exception.
         ErrorCodesEnd,
-        TailCall,
+        TailCallJump,
     };
 
     ExecutionContext(InstanceConstData* currentInstanceConstData, ExecutionState& state, Instance* instance)
@@ -69,7 +68,8 @@ struct ExecutionContext {
         , instance(instance)
         , capturedException(nullptr)
         , error(NoError)
-        , tailCallTarget(nullptr)
+        , tailCallEntry(nullptr)
+        , frameCapacity(0)
     {
     }
 
@@ -85,7 +85,8 @@ struct ExecutionContext {
     Instance* instance;
     Exception* capturedException;
     ErrorCodes error;
-    Function* tailCallTarget;
+    void* tailCallEntry;
+    size_t frameCapacity;
 };
 
 class JITModule {
@@ -136,6 +137,7 @@ public:
     }
 
     bool isCompiled() const { return m_exportEntry != nullptr; }
+    void* exportEntry() const { return m_exportEntry; }
     InstanceConstData* instanceConstData() const { return m_module->instanceConstData(); }
     ByteCodeStackOffset* call(ExecutionContext& context, uint8_t* bp) const;
 

--- a/test/web-assembly3/tail-call/return-call-indirect.wast
+++ b/test/web-assembly3/tail-call/return-call-indirect.wast
@@ -1,0 +1,53 @@
+(module
+  (type $acc_t (func (param i64 i64) (result i64)))
+  (type $unary (func (param i64) (result i64)))
+
+  (table $t 4 funcref)
+
+  ;; large frame (extra locals): forces frame realloc when tail-called
+  (func $acc (type $acc_t) (param $n i64) (param $s i64) (result i64)
+    (local $l0 i64) (local $l1 i64) (local $l2 i64) (local $l3 i64)
+    (local $l4 i64) (local $l5 i64) (local $l6 i64) (local $l7 i64)
+    (if (result i64) (i64.eqz (local.get $n))
+      (then (local.get $s))
+      (else
+        (return_call_indirect (type $acc_t)
+          (i64.sub (local.get $n) (i64.const 1))
+          (i64.add (local.get $s) (local.get $n))
+          (i32.const 0)))))
+
+  (func $even (type $unary) (param $n i64) (result i64)
+    (if (result i64) (i64.eqz (local.get $n)) (then (i64.const 1))
+      (else (return_call_indirect (type $unary) (i64.sub (local.get $n) (i64.const 1)) (i32.const 2)))))
+  (func $odd (type $unary) (param $n i64) (result i64)
+    (if (result i64) (i64.eqz (local.get $n)) (then (i64.const 0))
+      (else (return_call_indirect (type $unary) (i64.sub (local.get $n) (i64.const 1)) (i32.const 1)))))
+
+  (elem (table $t) (i32.const 0) $acc $even $odd)
+
+  (func (export "sum") (param $n i64) (result i64)
+    (return_call_indirect (type $acc_t) (local.get $n) (i64.const 0) (i32.const 0)))
+  (func (export "is-even") (param $n i64) (result i64)
+    (return_call_indirect (type $unary) (local.get $n) (i32.const 1)))
+
+  (func (export "oob") (param $n i64) (result i64)
+    (return_call_indirect (type $acc_t) (local.get $n) (i64.const 0) (i32.const 9)))
+  (func (export "mismatch") (param $n i64) (result i64)
+    (return_call_indirect (type $acc_t) (local.get $n) (i64.const 0) (i32.const 1)))
+)
+
+;; frame growth + deep chain
+(assert_return (invoke "sum" (i64.const 0)) (i64.const 0))
+(assert_return (invoke "sum" (i64.const 10)) (i64.const 55))
+(assert_return (invoke "sum" (i64.const 100)) (i64.const 5050))
+(assert_return (invoke "sum" (i64.const 1000000)) (i64.const 500000500000))
+
+;; mutual recursion through the table
+(assert_return (invoke "is-even" (i64.const 0)) (i64.const 1))
+(assert_return (invoke "is-even" (i64.const 1)) (i64.const 0))
+(assert_return (invoke "is-even" (i64.const 1000000)) (i64.const 1))
+(assert_return (invoke "is-even" (i64.const 1000001)) (i64.const 0))
+
+;; traps
+(assert_trap (invoke "oob" (i64.const 5)) "undefined element")
+(assert_trap (invoke "mismatch" (i64.const 5)) "indirect call type mismatch")

--- a/test/web-assembly3/tail-call/return-call-ref.wast
+++ b/test/web-assembly3/tail-call/return-call-ref.wast
@@ -1,0 +1,60 @@
+(module
+  (type $acc_t (func (param i64 i64) (result i64)))
+  (type $unary (func (param i64) (result i64)))
+
+  (elem declare func $acc $even $odd)
+
+  ;; large frame (extra locals): forces frame realloc when tail-called
+  (func $acc (type $acc_t) (param $n i64) (param $s i64) (result i64)
+    (local $l0 i64) (local $l1 i64) (local $l2 i64) (local $l3 i64)
+    (local $l4 i64) (local $l5 i64) (local $l6 i64) (local $l7 i64)
+    (if (result i64) (i64.eqz (local.get $n))
+      (then (local.get $s))
+      (else
+        (return_call_ref $acc_t
+          (i64.sub (local.get $n) (i64.const 1))
+          (i64.add (local.get $s) (local.get $n))
+          (ref.func $acc)))))
+
+  (func $even (type $unary) (param $n i64) (result i64)
+    (if (result i64) (i64.eqz (local.get $n)) (then (i64.const 1))
+      (else (return_call_ref $unary (i64.sub (local.get $n) (i64.const 1)) (ref.func $odd)))))
+  (func $odd (type $unary) (param $n i64) (result i64)
+    (if (result i64) (i64.eqz (local.get $n)) (then (i64.const 0))
+      (else (return_call_ref $unary (i64.sub (local.get $n) (i64.const 1)) (ref.func $even)))))
+
+  (func (export "sum") (param $n i64) (result i64)
+    (return_call_ref $acc_t (local.get $n) (i64.const 0) (ref.func $acc)))
+  (func (export "is-even") (param $n i64) (result i64)
+    (return_call_ref $unary (local.get $n) (ref.func $even)))
+
+  (func (export "pick") (param $n i64) (param $which i32) (result i64)
+    (local $f (ref null $unary))
+    (if (local.get $which)
+      (then (local.set $f (ref.func $odd)))
+      (else (local.set $f (ref.func $even))))
+    (return_call_ref $unary (local.get $n) (local.get $f)))
+
+  (func (export "null") (param $n i64) (result i64)
+    (return_call_ref $acc_t (local.get $n) (i64.const 0) (ref.null $acc_t)))
+)
+
+;; frame growth + deep chain
+(assert_return (invoke "sum" (i64.const 0)) (i64.const 0))
+(assert_return (invoke "sum" (i64.const 10)) (i64.const 55))
+(assert_return (invoke "sum" (i64.const 100)) (i64.const 5050))
+(assert_return (invoke "sum" (i64.const 1000000)) (i64.const 500000500000))
+
+;; mutual recursion through references
+(assert_return (invoke "is-even" (i64.const 0)) (i64.const 1))
+(assert_return (invoke "is-even" (i64.const 1)) (i64.const 0))
+(assert_return (invoke "is-even" (i64.const 1000000)) (i64.const 1))
+(assert_return (invoke "is-even" (i64.const 1000001)) (i64.const 0))
+
+;; reference chosen at runtime
+(assert_return (invoke "pick" (i64.const 10) (i32.const 0)) (i64.const 1))
+(assert_return (invoke "pick" (i64.const 7) (i32.const 1)) (i64.const 1))
+(assert_return (invoke "pick" (i64.const 10) (i32.const 1)) (i64.const 0))
+
+;; trap
+(assert_trap (invoke "null" (i64.const 5)) "null function reference")


### PR DESCRIPTION
I found ReturnCallIndirect and ReturnCallRef works in fallback mode that makes stack memory consumption is not a consist.
Problem is they not use a fully stack-frame destructive way to jumping in another function to function situation(so call non-self-call) and also it may be problematic in runtime determination of jump address that used in ReturnCallIndirect and ReturnCallRef.

It cannot handled in in-function flow control method, so I rewrite all JIT TCO code into fully trampoline loop.
It can now full ALL pass the test without stack overflow.