### PR TITLE
Add reverse-complement benchmark

### DIFF
--- a/test/wasmBenchmarker/benchmark.py
+++ b/test/wasmBenchmarker/benchmark.py
@@ -53,6 +53,7 @@ expectedValues = {
     "prime": 70657,
     "quickSort": 0,
     "redBlack": 13354000,
+    "reverse-complement": 1,
     "rsa": 0,
     "salesman": 2520,
     "simdMandelbrotFloat": 775014,
@@ -64,7 +65,7 @@ expectedValues = {
 }
 
 # https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/simple.html#simple
-gameTests = ["mandelbrotFloat", "nbody", "gregory", "fannkuch", "kNucleotide", "binary-trees", "spectral-norm"]
+gameTests = ["mandelbrotFloat", "nbody", "gregory", "fannkuch", "kNucleotide", "binary-trees", "spectral-norm", "reverse-complement"]
 
 simdTests = [
     "simdMandelbrotFloat",

--- a/test/wasmBenchmarker/ctests/include/fastaInput.h
+++ b/test/wasmBenchmarker/ctests/include/fastaInput.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026-present Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FASTA_INPUT_H
+#define FASTA_INPUT_H
+
+#define FASTA_ONE_SEQUENCE \
+    "GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGA" \
+    "TCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACT" \
+    "AAAAATACAAAAATTAGCCGGGCGTGGTGGCGCGCGCCTGTAATCCCAGCTACTCGGGAG" \
+    "GCTGAGGCAGGAGAATCGCTTGAACCCGGGAGGCGGAGGTTGCAGTGAGCCGAGATCGCG" \
+    "CCACTGCACTCCAGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAAGGCCGGGCGCGGT" \
+    "GGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGATCACCTGAGGTCA" \
+    "GGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACTAAAAATACAAAAA" \
+    "TTAGCCGGGCGTGGTGGCGCGCGCCTGTAATCCCAGCTACTCGGGAGGCTGAGGCAGGAG" \
+    "AATCGCTTGAACCCGGGAGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCCA" \
+    "GCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAAGGCCGGGCGCGGTGGCTCACGCCTGT" \
+    "AATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGATCACCTGAGGTCAGGAGTTCGAGACC" \
+    "AGCCTGGCCAACATGGTGAAACCCCGTCTCTACTAAAAATACAAAAATTAGCCGGGCGTG" \
+    "GTGGCGCGCGCCTGTAATCCCAGCTACTCGGGAGGCTGAGGCAGGAGAATCGCTTGAACC" \
+    "CGGGAGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCCAGCCTGGGCGACAG" \
+    "AGCGAGACTCCGTCTCAAAAAGGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTT" \
+    "TGGGAGGCCGAGGCGGGCGGATCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACA" \
+    "TGGTGAAACCCCGTCTCTACTAAAAATACAAAAATTAGCCGGGCGTGGTGGCGCGCGCCT" \
+    "GTAATCCCAGCTACTCGGGAGGCTGAGGCAGGAGAATCGCTTGAACCCGGGAGGCGGAGG" \
+    "TTGCAGTGAGCCGAGATCGCGCCACTGCACTCCAGCCTGGGCGACAGAGCGAGACTCCGT" \
+    "CTCAAAAAGGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGG" \
+    "CGGGCGGATCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCG" \
+    "TCTCTACTAAAAATACAAAAATTAGCCGGGCGTGGTGGCGCGCGCCTGTAATCCCAGCTA" \
+    "CTCGGGAGGCTGAGGCAGGAGAATCGCTTGAACCCGGGAGGCGGAGGTTGCAGTGAGCCG" \
+    "AGATCGCGCCACTGCACTCCAGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAAGGCCG" \
+    "GGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGATCACC" \
+    "TGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACTAAAAA" \
+    "TACAAAAATTAGCCGGGCGTGGTGGCGCGCGCCTGTAATCCCAGCTACTCGGGAGGCTGA" \
+    "GGCAGGAGAATCGCTTGAACCCGGGAGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACT" \
+    "GCACTCCAGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAAGGCCGGGCGCGGTGGCTC" \
+    "ACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGATCACCTGAGGTCAGGAGT" \
+    "TCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACTAAAAATACAAAAATTAGC" \
+    "CGGGCGTGGTGGCGCGCGCCTGTAATCCCAGCTACTCGGGAGGCTGAGGCAGGAGAATCG" \
+    "CTTGAACCCGGGAGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCCAGCCTG" \
+    "GGCGACAGAGCGAGACTCCG" 
+
+#define FASTA_TWO_SEQUENCE \
+    "cttBtatcatatgctaKggNcataaaSatgtaaaDcDRtBggDtctttataattcBgtcg" \
+    "tactDtDagcctatttSVHtHttKtgtHMaSattgWaHKHttttagacatWatgtRgaaa" \
+    "NtactMcSMtYtcMgRtacttctWBacgaaatatagScDtttgaagacacatagtVgYgt" \
+    "cattHWtMMWcStgttaggKtSgaYaaccWStcgBttgcgaMttBYatcWtgacaYcaga" \
+    "gtaBDtRacttttcWatMttDBcatWtatcttactaBgaYtcttgttttttttYaaScYa" \
+    "HgtgttNtSatcMtcVaaaStccRcctDaataataStcYtRDSaMtDttgttSagtRRca" \
+    "tttHatSttMtWgtcgtatSSagactYaaattcaMtWatttaSgYttaRgKaRtccactt" \
+    "tattRggaMcDaWaWagttttgacatgttctacaaaRaatataataaMttcgDacgaSSt" \
+    "acaStYRctVaNMtMgtaggcKatcttttattaaaaagVWaHKYagtttttatttaacct" \
+    "tacgtVtcVaattVMBcttaMtttaStgacttagattWWacVtgWYagWVRctDattBYt" \
+    "gtttaagaagattattgacVatMaacattVctgtBSgaVtgWWggaKHaatKWcBScSWa" \
+    "accRVacacaaactaccScattRatatKVtactatatttHttaagtttSKtRtacaaagt" \
+    "RDttcaaaaWgcacatWaDgtDKacgaacaattacaRNWaatHtttStgttattaaMtgt" \
+    "tgDcgtMgcatBtgcttcgcgaDWgagctgcgaggggVtaaScNatttacttaatgacag" \
+    "cccccacatYScaMgtaggtYaNgttctgaMaacNaMRaacaaacaKctacatagYWctg" \
+    "ttWaaataaaataRattagHacacaagcgKatacBttRttaagtatttccgatctHSaat" \
+    "actcNttMaagtattMtgRtgaMgcataatHcMtaBSaRattagttgatHtMttaaKagg" \
+    "YtaaBataSaVatactWtataVWgKgttaaaacagtgcgRatatacatVtHRtVYataSa" \
+    "KtWaStVcNKHKttactatccctcatgWHatWaRcttactaggatctataDtDHBttata" \
+    "aaaHgtacVtagaYttYaKcctattcttcttaataNDaaggaaaDYgcggctaaWSctBa" \
+    "aNtgctggMBaKctaMVKagBaactaWaDaMaccYVtNtaHtVWtKgRtcaaNtYaNacg" \
+    "gtttNattgVtttctgtBaWgtaattcaagtcaVWtactNggattctttaYtaaagccgc" \
+    "tcttagHVggaYtgtNcDaVagctctctKgacgtatagYcctRYHDtgBattDaaDgccK" \
+    "tcHaaStttMcctagtattgcRgWBaVatHaaaataYtgtttagMDMRtaataaggatMt" \
+    "ttctWgtNtgtgaaaaMaatatRtttMtDgHHtgtcattttcWattRSHcVagaagtacg" \
+    "ggtaKVattKYagactNaatgtttgKMMgYNtcccgSKttctaStatatNVataYHgtNa" \
+    "BKRgNacaactgatttcctttaNcgatttctctataScaHtataRagtcRVttacDSDtt" \
+    "aRtSatacHgtSKacYagttMHtWataggatgactNtatSaNctataVtttRNKtgRacc" \
+    "tttYtatgttactttttcctttaaacatacaHactMacacggtWataMtBVacRaSaatc" \
+    "cgtaBVttccagccBcttaRKtgtgcctttttRtgtcagcRttKtaaacKtaaatctcac" \
+    "aattgcaNtSBaaccgggttattaaBcKatDagttactcttcattVtttHaaggctKKga" \
+    "tacatcBggScagtVcacattttgaHaDSgHatRMaHWggtatatRgccDttcgtatcga" \
+    "aacaHtaagttaRatgaVacttagattVKtaaYttaaatcaNatccRttRRaMScNaaaD" \
+    "gttVHWgtcHaaHgacVaWtgttScactaagSgttatcttagggDtaccagWattWtRtg" \
+    "ttHWHacgattBtgVcaYatcggttgagKcWtKKcaVtgaYgWctgYggVctgtHgaNcV" \
+    "taBtWaaYatcDRaaRtSctgaHaYRttagatMatgcatttNattaDttaattgttctaa" \
+    "ccctcccctagaWBtttHtBccttagaVaatMcBHagaVcWcagBVttcBtaYMccagat" \
+    "gaaaaHctctaacgttagNWRtcggattNatcRaNHttcagtKttttgWatWttcSaNgg" \
+    "gaWtactKKMaacatKatacNattgctWtatctaVgagctatgtRaHtYcWcttagccaa" \
+    "tYttWttaWSSttaHcaaaaagVacVgtaVaRMgattaVcDactttcHHggHRtgNcctt" \
+    "tYatcatKgctcctctatVcaaaaKaaaagtatatctgMtWtaaaacaStttMtcgactt" \
+    "taSatcgDataaactaaacaagtaaVctaggaSccaatMVtaaSKNVattttgHccatca" \
+    "cBVctgcaVatVttRtactgtVcaattHgtaaattaaattttYtatattaaRSgYtgBag" \
+    "aHSBDgtagcacRHtYcBgtcacttacactaYcgctWtattgSHtSatcataaatataHt" \
+    "cgtYaaMNgBaatttaRgaMaatatttBtttaaaHHKaatctgatWatYaacttMctctt" \
+    "ttVctagctDaaagtaVaKaKRtaacBgtatccaaccactHHaagaagaaggaNaaatBW" \
+    "attccgStaMSaMatBttgcatgRSacgttVVtaaDMtcSgVatWcaSatcttttVatag" \
+    "ttactttacgatcaccNtaDVgSRcgVcgtgaacgaNtaNatatagtHtMgtHcMtagaa" \
+    "attBgtataRaaaacaYKgtRccYtatgaagtaataKgtaaMttgaaRVatgcagaKStc" \
+    "tHNaaatctBBtcttaYaBWHgtVtgacagcaRcataWctcaBcYacYgatDgtDHccta" 
+
+#define FASTA_THREE_SEQUENCE \
+    "aacacttcaccaggtatcgtgaaggctcaagattacccagagaacctttgcaatataaga" \
+    "atatgtatgcagcattaccctaagtaattatattctttttctgactcaaagtgacaagcc" \
+    "ctagtgtatattaaatcggtatatttgggaaattcctcaaactatcctaatcaggtagcc" \
+    "atgaaagtgatcaaaaaagttcgtacttataccatacatgaattctggccaagtaaaaaa" \
+    "tagattgcgcaaaattcgtaccttaagtctctcgccaagatattaggatcctattactca" \
+    "tatcgtgtttttctttattgccgccatccccggagtatctcacccatccttctcttaaag" \
+    "gcctaatattacctatgcaaataaacatatattgttgaaaattgagaacctgatcgtgat" \
+    "tcttatgtgtaccatatgtatagtaatcacgcgactatatagtgctttagtatcgcccgt" \
+    "gggtgagtgaatattctgggctagcgtgagatagtttcttgtcctaatatttttcagatc" \
+    "gaatagcttctatttttgtgtttattgacatatgtcgaaactccttactcagtgaaagtc" \
+    "atgaccagatccacgaacaatcttcggaatcagtctcgttttacggcggaatcttgagtc" \
+    "taacttatatcccgtcgcttactttctaacaccccttatgtatttttaaaattacgttta" \
+    "ttcgaacgtacttggcggaagcgttattttttgaagtaagttacattgggcagactcttg" \
+    "acattttcgatacgactttctttcatccatcacaggactcgttcgtattgatatcagaag" \
+    "ctcgtgatgattagttgtcttctttaccaatactttgaggcctattctgcgaaatttttg" \
+    "ttgccctgcgaacttcacataccaaggaacacctcgcaacatgccttcatatccatcgtt" \
+    "cattgtaattcttacacaatgaatcctaagtaattacatccctgcgtaaaagatggtagg" \
+    "ggcactgaggatatattaccaagcatttagttatgagtaatcagcaatgtttcttgtatt" \
+    "aagttctctaaaatagttacatcgtaatgttatctcgggttccgcgaataaacgagatag" \
+    "attcattatatatggccctaagcaaaaacctcctcgtattctgttggtaattagaatcac" \
+    "acaatacgggttgagatattaattatttgtagtacgaagagatataaaaagatgaacaat" \
+    "tactcaagtcaagatgtatacgggatttataataaaaatcgggtagagatctgctttgca" \
+    "attcagacgtgccactaaatcgtaatatgtcgcgttacatcagaaagggtaactattatt" \
+    "aattaataaagggcttaatcactacatattagatcttatccgatagtcttatctattcgt" \
+    "tgtatttttaagcggttctaattcagtcattatatcagtgctccgagttctttattattg" \
+    "ttttaaggatgacaaaatgcctcttgttataacgctgggagaagcagactaagagtcgga" \
+    "gcagttggtagaatgaggctgcaaaagacggtctcgacgaatggacagactttactaaac" \
+    "caatgaaagacagaagtagagcaaagtctgaagtggtatcagcttaattatgacaaccct" \
+    "taatacttccctttcgccgaatactggcgtggaaaggttttaaaagtcgaagtagttaga" \
+    "ggcatctctcgctcataaataggtagactactcgcaatccaatgtgactatgtaatactg" \
+    "ggaacatcagtccgcgatgcagcgtgtttatcaaccgtccccactcgcctggggagacat" \
+    "gagaccacccccgtggggattattagtccgcagtaatcgactcttgacaatccttttcga" \
+    "ttatgtcatagcaatttacgacagttcagcgaagtgactactcggcgaaatggtattact" \
+    "aaagcattcgaacccacatgaatgtgattcttggcaatttctaatccactaaagcttttc" \
+    "cgttgaatctggttgtagatatttatataagttcactaattaagatcacggtagtatatt" \
+    "gatagtgatgtctttgcaagaggttggccgaggaatttacggattctctattgatacaat" \
+    "ttgtctggcttataactcttaaggctgaaccaggcgtttttagacgacttgatcagctgt" \
+    "tagaatggtttggactccctctttcatgtcagtaacatttcagccgttattgttacgata" \
+    "tgcttgaacaatattgatctaccacacacccatagtatattttataggtcatgctgttac" \
+    "ctacgagcatggtattccacttcccattcaatgagtattcaacatcactagcctcagaga" \
+    "tgatgacccacctctaataacgtcacgttgcggccatgtgaaacctgaacttgagtagac" \
+    "gatatcaagcgctttaaattgcatataacatttgagggtaaagctaagcggatgctttat" \
+    "ataatcaatactcaataataagatttgattgcattttagagttatgacacgacatagttc" \
+    "actaacgagttactattcccagatctagactgaagtactgatcgagacgatccttacgtc" \
+    "gatgatcgttagttatcgacttaggtcgggtctctagcggtattggtacttaaccggaca" \
+    "ctatactaataacccatgatcaaagcataacagaatacagacgataatttcgccaacata" \
+    "tatgtacagaccccaagcatgagaagctcattgaaagctatcattgaagtcccgctcaca" \
+    "atgtgtcttttccagacggtttaactggttcccgggagtcctggagtttcgacttacata" \
+    "aatggaaacaatgtattttgctaatttatctatagcgtcatttggaccaatacagaatat" \
+    "tatgttgcctagtaatccactataacccgcaagtgctgatagaaaatttttagacgattt" \
+    "ataaatgccccaagtatccctcccgtgaatcctccgttatactaattagtattcgttcat" \
+    "acgtataccgcgcatatatgaacatttggcgataaggcgcgtgaattgttacgtgacaga" \
+    "gatagcagtttcttgtgatatggttaacagacgtacatgaagggaaactttatatctata" \
+    "gtgatgcttccgtagaaataccgccactggtctgccaatgatgaagtatgtagctttagg" \
+    "tttgtactatgaggctttcgtttgtttgcagagtataacagttgcgagtgaaaaaccgac" \
+    "gaatttatactaatacgctttcactattggctacaaaatagggaagagtttcaatcatga" \
+    "gagggagtatatggatgctttgtagctaaaggtagaacgtatgtatatgctgccgttcat" \
+    "tcttgaaagatacataagcgataagttacgacaattataagcaacatccctaccttcgta" \
+    "acgatttcactgttactgcgcttgaaatacactatggggctattggcggagagaagcaga" \
+    "tcgcgccgagcatatacgagacctataatgttgatgatagagaaggcgtctgaattgata" \
+    "catcgaagtacactttctttcgtagtatctctcgtcctctttctatctccggacacaaga" \
+    "attaagttatatatatagagtcttaccaatcatgttgaatcctgattctcagagttcttt" \
+    "ggcgggccttgtgatgactgagaaacaatgcaatattgctccaaatttcctaagcaaatt" \
+    "ctcggttatgttatgttatcagcaaagcgttacgttatgttatttaaatctggaatgacg" \
+    "gagcgaagttcttatgtcggtgtgggaataattcttttgaagacagcactccttaaataa" \
+    "tatcgctccgtgtttgtatttatcgaatgggtctgtaaccttgcacaagcaaatcggtgg" \
+    "tgtatatatcggataacaattaatacgatgttcatagtgacagtatactgatcgagtcct" \
+    "ctaaagtcaattacctcacttaacaatctcattgatgttgtgtcattcccggtatcgccc" \
+    "gtagtatgtgctctgattgaccgagtgtgaaccaaggaacatctactaatgcctttgtta" \
+    "ggtaagatctctctgaattccttcgtgccaacttaaaacattatcaaaatttcttctact" \
+    "tggattaactacttttacgagcatggcaaattcccctgtggaagacggttcattattatc" \
+    "ggaaaccttatagaaattgcgtgttgactgaaattagatttttattgtaagagttgcatc" \
+    "tttgcgattcctctggtctagcttccaatgaacagtcctcccttctattcgacatcgggt" \
+    "ccttcgtacatgtctttgcgatgtaataattaggttcggagtgtggccttaatgggtgca" \
+    "actaggaatacaacgcaaatttgctgacatgatagcaaatcggtatgccggcaccaaaac" \
+    "gtgctccttgcttagcttgtgaatgagactcagtagttaaataaatccatatctgcaatc" \
+    "gattccacaggtattgtccactatctttgaactactctaagagatacaagcttagctgag" \
+    "accgaggtgtatatgactacgctgatatctgtaaggtaccaatgcaggcaaagtatgcga" \
+    "gaagctaataccggctgtttccagctttataagattaaaatttggctgtcctggcggcct" \
+    "cagaattgttctatcgtaatcagttggttcattaattagctaagtacgaggtacaactta" \
+    "tctgtcccagaacagctccacaagtttttttacagccgaaacccctgtgtgaatcttaat" \
+    "atccaagcgcgttatctgattagagtttacaactcagtattttatcagtacgttttgttt" \
+    "ccaacattacccggtatgacaaaatgacgccacgtgtcgaataatggtctgaccaatgta" \
+    "ggaagtgaaaagataaatat"
+
+
+#define FASTA_ONE_INPUT \
+    ">ONE Homo sapiens alu\n" \
+    FASTA_ONE_SEQUENCE \
+    "\n"
+
+#define FASTA_TWO_INPUT \
+    ">TWO IUB ambiguity codes\n" \
+    FASTA_TWO_SEQUENCE \
+    "\n"
+
+#define FASTA_THREE_INPUT \
+    ">THREE Homo sapiens frequency\n" \
+    FASTA_THREE_SEQUENCE 
+
+#endif
+

--- a/test/wasmBenchmarker/ctests/kNucleotide.c
+++ b/test/wasmBenchmarker/ctests/kNucleotide.c
@@ -17,10 +17,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "include/fastaInput.h"
 
 #define LOOP 2
 
-extern const char *input_3;
+const char *input_3 = FASTA_THREE_SEQUENCE;
 
 typedef struct {
     char key[50];
@@ -245,89 +246,4 @@ bool runtime() {
     return checks == LOOP;
 }
 
-const char *input_3 =
-        /* ">THREE Homo sapiens frequency" */
-        "aacacttcaccaggtatcgtgaaggctcaagattacccagagaacctttgcaatataaga"
-        "atatgtatgcagcattaccctaagtaattatattctttttctgactcaaagtgacaagcc"
-        "ctagtgtatattaaatcggtatatttgggaaattcctcaaactatcctaatcaggtagcc"
-        "atgaaagtgatcaaaaaagttcgtacttataccatacatgaattctggccaagtaaaaaa"
-        "tagattgcgcaaaattcgtaccttaagtctctcgccaagatattaggatcctattactca"
-        "tatcgtgtttttctttattgccgccatccccggagtatctcacccatccttctcttaaag"
-        "gcctaatattacctatgcaaataaacatatattgttgaaaattgagaacctgatcgtgat"
-        "tcttatgtgtaccatatgtatagtaatcacgcgactatatagtgctttagtatcgcccgt"
-        "gggtgagtgaatattctgggctagcgtgagatagtttcttgtcctaatatttttcagatc"
-        "gaatagcttctatttttgtgtttattgacatatgtcgaaactccttactcagtgaaagtc"
-        "atgaccagatccacgaacaatcttcggaatcagtctcgttttacggcggaatcttgagtc"
-        "taacttatatcccgtcgcttactttctaacaccccttatgtatttttaaaattacgttta"
-        "ttcgaacgtacttggcggaagcgttattttttgaagtaagttacattgggcagactcttg"
-        "acattttcgatacgactttctttcatccatcacaggactcgttcgtattgatatcagaag"
-        "ctcgtgatgattagttgtcttctttaccaatactttgaggcctattctgcgaaatttttg"
-        "ttgccctgcgaacttcacataccaaggaacacctcgcaacatgccttcatatccatcgtt"
-        "cattgtaattcttacacaatgaatcctaagtaattacatccctgcgtaaaagatggtagg"
-        "ggcactgaggatatattaccaagcatttagttatgagtaatcagcaatgtttcttgtatt"
-        "aagttctctaaaatagttacatcgtaatgttatctcgggttccgcgaataaacgagatag"
-        "attcattatatatggccctaagcaaaaacctcctcgtattctgttggtaattagaatcac"
-        "acaatacgggttgagatattaattatttgtagtacgaagagatataaaaagatgaacaat"
-        "tactcaagtcaagatgtatacgggatttataataaaaatcgggtagagatctgctttgca"
-        "attcagacgtgccactaaatcgtaatatgtcgcgttacatcagaaagggtaactattatt"
-        "aattaataaagggcttaatcactacatattagatcttatccgatagtcttatctattcgt"
-        "tgtatttttaagcggttctaattcagtcattatatcagtgctccgagttctttattattg"
-        "ttttaaggatgacaaaatgcctcttgttataacgctgggagaagcagactaagagtcgga"
-        "gcagttggtagaatgaggctgcaaaagacggtctcgacgaatggacagactttactaaac"
-        "caatgaaagacagaagtagagcaaagtctgaagtggtatcagcttaattatgacaaccct"
-        "taatacttccctttcgccgaatactggcgtggaaaggttttaaaagtcgaagtagttaga"
-        "ggcatctctcgctcataaataggtagactactcgcaatccaatgtgactatgtaatactg"
-        "ggaacatcagtccgcgatgcagcgtgtttatcaaccgtccccactcgcctggggagacat"
-        "gagaccacccccgtggggattattagtccgcagtaatcgactcttgacaatccttttcga"
-        "ttatgtcatagcaatttacgacagttcagcgaagtgactactcggcgaaatggtattact"
-        "aaagcattcgaacccacatgaatgtgattcttggcaatttctaatccactaaagcttttc"
-        "cgttgaatctggttgtagatatttatataagttcactaattaagatcacggtagtatatt"
-        "gatagtgatgtctttgcaagaggttggccgaggaatttacggattctctattgatacaat"
-        "ttgtctggcttataactcttaaggctgaaccaggcgtttttagacgacttgatcagctgt"
-        "tagaatggtttggactccctctttcatgtcagtaacatttcagccgttattgttacgata"
-        "tgcttgaacaatattgatctaccacacacccatagtatattttataggtcatgctgttac"
-        "ctacgagcatggtattccacttcccattcaatgagtattcaacatcactagcctcagaga"
-        "tgatgacccacctctaataacgtcacgttgcggccatgtgaaacctgaacttgagtagac"
-        "gatatcaagcgctttaaattgcatataacatttgagggtaaagctaagcggatgctttat"
-        "ataatcaatactcaataataagatttgattgcattttagagttatgacacgacatagttc"
-        "actaacgagttactattcccagatctagactgaagtactgatcgagacgatccttacgtc"
-        "gatgatcgttagttatcgacttaggtcgggtctctagcggtattggtacttaaccggaca"
-        "ctatactaataacccatgatcaaagcataacagaatacagacgataatttcgccaacata"
-        "tatgtacagaccccaagcatgagaagctcattgaaagctatcattgaagtcccgctcaca"
-        "atgtgtcttttccagacggtttaactggttcccgggagtcctggagtttcgacttacata"
-        "aatggaaacaatgtattttgctaatttatctatagcgtcatttggaccaatacagaatat"
-        "tatgttgcctagtaatccactataacccgcaagtgctgatagaaaatttttagacgattt"
-        "ataaatgccccaagtatccctcccgtgaatcctccgttatactaattagtattcgttcat"
-        "acgtataccgcgcatatatgaacatttggcgataaggcgcgtgaattgttacgtgacaga"
-        "gatagcagtttcttgtgatatggttaacagacgtacatgaagggaaactttatatctata"
-        "gtgatgcttccgtagaaataccgccactggtctgccaatgatgaagtatgtagctttagg"
-        "tttgtactatgaggctttcgtttgtttgcagagtataacagttgcgagtgaaaaaccgac"
-        "gaatttatactaatacgctttcactattggctacaaaatagggaagagtttcaatcatga"
-        "gagggagtatatggatgctttgtagctaaaggtagaacgtatgtatatgctgccgttcat"
-        "tcttgaaagatacataagcgataagttacgacaattataagcaacatccctaccttcgta"
-        "acgatttcactgttactgcgcttgaaatacactatggggctattggcggagagaagcaga"
-        "tcgcgccgagcatatacgagacctataatgttgatgatagagaaggcgtctgaattgata"
-        "catcgaagtacactttctttcgtagtatctctcgtcctctttctatctccggacacaaga"
-        "attaagttatatatatagagtcttaccaatcatgttgaatcctgattctcagagttcttt"
-        "ggcgggccttgtgatgactgagaaacaatgcaatattgctccaaatttcctaagcaaatt"
-        "ctcggttatgttatgttatcagcaaagcgttacgttatgttatttaaatctggaatgacg"
-        "gagcgaagttcttatgtcggtgtgggaataattcttttgaagacagcactccttaaataa"
-        "tatcgctccgtgtttgtatttatcgaatgggtctgtaaccttgcacaagcaaatcggtgg"
-        "tgtatatatcggataacaattaatacgatgttcatagtgacagtatactgatcgagtcct"
-        "ctaaagtcaattacctcacttaacaatctcattgatgttgtgtcattcccggtatcgccc"
-        "gtagtatgtgctctgattgaccgagtgtgaaccaaggaacatctactaatgcctttgtta"
-        "ggtaagatctctctgaattccttcgtgccaacttaaaacattatcaaaatttcttctact"
-        "tggattaactacttttacgagcatggcaaattcccctgtggaagacggttcattattatc"
-        "ggaaaccttatagaaattgcgtgttgactgaaattagatttttattgtaagagttgcatc"
-        "tttgcgattcctctggtctagcttccaatgaacagtcctcccttctattcgacatcgggt"
-        "ccttcgtacatgtctttgcgatgtaataattaggttcggagtgtggccttaatgggtgca"
-        "actaggaatacaacgcaaatttgctgacatgatagcaaatcggtatgccggcaccaaaac"
-        "gtgctccttgcttagcttgtgaatgagactcagtagttaaataaatccatatctgcaatc"
-        "gattccacaggtattgtccactatctttgaactactctaagagatacaagcttagctgag"
-        "accgaggtgtatatgactacgctgatatctgtaaggtaccaatgcaggcaaagtatgcga"
-        "gaagctaataccggctgtttccagctttataagattaaaatttggctgtcctggcggcct"
-        "cagaattgttctatcgtaatcagttggttcattaattagctaagtacgaggtacaactta"
-        "tctgtcccagaacagctccacaagtttttttacagccgaaacccctgtgtgaatcttaat"
-        "atccaagcgcgttatctgattagagtttacaactcagtattttatcagtacgttttgttt"
-        "ccaacattacccggtatgacaaaatgacgccacgtgtcgaataatggtctgaccaatgta"
-        "ggaagtgaaaagataaatat";
+

--- a/test/wasmBenchmarker/ctests/reverse-complement.c
+++ b/test/wasmBenchmarker/ctests/reverse-complement.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026-present Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "include/fastaInput.h"
+
+#define EXPECTED_OUTPUT_SIZE 10245
+
+const char* input =
+    FASTA_ONE_INPUT
+    FASTA_TWO_INPUT
+    FASTA_THREE_INPUT;
+
+const char *pairs = "ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN";
+char tbl[256];
+char output[EXPECTED_OUTPUT_SIZE + 1];
+
+
+const uint64_t EXPECTED_OUTPUT_HASH = UINT64_C(0x8cae2ea7900458e4);
+
+char* change(const char* from, const char* to, char* output_position) {
+    while (*from != '\n') {
+        *output_position++ = *from++;
+    }
+
+    *output_position++ = *from++;
+
+    if (to > from && to[-1] == '\n') {
+        to--;
+    }
+
+    size_t len = 0;
+
+    while (to > from) {
+        to--;
+
+        *output_position++ = tbl[(unsigned char)* to];
+        len++;
+
+        if (len == 60) {
+            *output_position++ = '\n';
+            len = 0;
+        }
+    }
+    
+    if (len != 0) {
+        *output_position++ = '\n';
+    }
+
+    return output_position;
+}
+
+uint64_t hashOutput(const char *data, size_t length) {
+    uint64_t hash = UINT64_C(14695981039346656037);
+
+    for (size_t i = 0; i < length; i++) {
+        hash ^= (unsigned char)data[i];
+        hash *= UINT64_C(1099511628211);
+    }
+
+    return hash;
+}
+
+bool check() {
+    size_t length = strlen(output);
+
+    return length == EXPECTED_OUTPUT_SIZE && hashOutput(output, length) == EXPECTED_OUTPUT_HASH;
+}
+
+bool runtime() {
+
+    for (const char* s = pairs; *s != '\0'; s += 2) {
+        tbl[toupper((unsigned int) s[0])] = s[1];
+        tbl[tolower((unsigned int) s[0])] = s[1];
+    }
+
+    const char* from = input;
+    const char* end = input + strlen(input);
+    char* output_position = output;
+
+    while (from < end ) {
+        const char* to = strstr(from + 1, "\n>");
+
+        if (to == NULL) {
+            output_position = change(from, end, output_position);
+            break;
+        }
+
+        output_position = change(from, to + 1, output_position);
+        from = to + 1;
+    }
+    
+    *output_position = '\0';
+
+    return check();
+}
+
+int main() {
+    printf("%u\n", (unsigned int) runtime());
+    return 0;
+}
+


### PR DESCRIPTION
Add reverse-complement benchmark

### testing
```bash
cmake --build out/release/x64 -j

./test/wasmBenchmarker/benchmark.py --engines ./out/release/x64/walrus --run reverse-complement --iterations 1

./tools/run-tests.py wasi --engine ./out/release/x64/walrus
```