### PR TITLE
Fix out-of-bound allocation range check in GC Array

### DIFF
--- a/src/runtime/GCArray.cpp
+++ b/src/runtime/GCArray.cpp
@@ -52,7 +52,7 @@ GCArray* GCArray::arrayNew(uint32_t length, const ArrayType* type, uint8_t* valu
 
     uint32_t startOffset = getAlignedStartOffset(size);
 
-    if (UNLIKELY(length >= (std::numeric_limits<uint32_t>::max() - startOffset) >> log2Size)) {
+    if (UNLIKELY(length >= (std::numeric_limits<uint32_t>::max() - (sizeof(void*) - 1) - startOffset) >> log2Size)) {
         // Array is larger than 4GB.
         return nullptr;
     }
@@ -103,7 +103,7 @@ GCArray* GCArray::arrayNewDefault(uint32_t length, const ArrayType* type)
 
     uint32_t startOffset = getAlignedStartOffset(size);
 
-    if (UNLIKELY(length >= (std::numeric_limits<uint32_t>::max() - startOffset) >> log2Size)) {
+    if (UNLIKELY(length >= (std::numeric_limits<uint32_t>::max() - (sizeof(void*) - 1) - startOffset) >> log2Size)) {
         // Array is larger than 4GB.
         return nullptr;
     }
@@ -137,7 +137,7 @@ GCArray* GCArray::arrayNewFixed(uint32_t length, const ArrayType* type, ByteCode
     uint32_t startOffset = getAlignedStartOffset(size);
 
     // Currently this case is not possible.
-    if (UNLIKELY(length >= (std::numeric_limits<uint32_t>::max() - startOffset) >> log2Size)) {
+    if (UNLIKELY(length >= (std::numeric_limits<uint32_t>::max() - (sizeof(void*) - 1) - startOffset) >> log2Size)) {
         // Array is larger than 4GB.
         return nullptr;
     }
@@ -212,7 +212,7 @@ GCArray* GCArray::arrayNewData(uint32_t offset, uint32_t size, const ArrayType* 
 #ifdef ENABLE_GC
     uint32_t startOffset = getAlignedStartOffset(1 << log2Size);
 
-    if (UNLIKELY(size >= (std::numeric_limits<uint32_t>::max() - startOffset) >> log2Size)) {
+    if (UNLIKELY(size >= (std::numeric_limits<uint32_t>::max() - (sizeof(void*) - 1) - startOffset) >> log2Size)) {
         // Array is larger than 4GB.
         return nullptr;
     }
@@ -247,7 +247,7 @@ GCArray* GCArray::arrayNewElem(uint32_t offset, uint32_t size, const ArrayType* 
 #ifdef ENABLE_GC
     uint32_t startOffset = getAlignedStartOffset(sizeof(void*));
 
-    if (UNLIKELY(size >= (std::numeric_limits<uint32_t>::max() - startOffset) / sizeof(void*))) {
+    if (UNLIKELY(size >= (std::numeric_limits<uint32_t>::max() - (sizeof(void*) - 1) - startOffset) / sizeof(void*))) {
         // Array is larger than 4GB.
         return nullptr;
     }

--- a/test/web-assembly3/jit/array_new_large_length.wast
+++ b/test/web-assembly3/jit/array_new_large_length.wast
@@ -1,0 +1,22 @@
+;; Allocation size overflow on array.new / array.new_default
+;;
+
+(module
+  (type $i8 (array (mut i8)))
+  (type $i32 (array (mut i32)))
+  (type $i64 (array (mut i64)))
+  (func (export "new") (param i32)
+    (drop (array.new $i8 (i32.const 65) (local.get 0))))
+  (func (export "new_default_i8") (param i32)
+    (drop (array.new_default $i8 (local.get 0))))
+  (func (export "new_default_i32") (param i32)
+    (drop (array.new_default $i32 (local.get 0))))
+  (func (export "new_default_i64") (param i32)
+    (drop (array.new_default $i64 (local.get 0))))
+)
+
+(assert_trap (invoke "new" (i32.const 4294967262)) "memory allocation failed")
+(assert_trap (invoke "new" (i32.const 4294967295)) "memory allocation failed")
+(assert_trap (invoke "new_default_i8" (i32.const 4294967262)) "memory allocation failed")
+(assert_trap (invoke "new_default_i32" (i32.const 1073741823)) "memory allocation failed")
+(assert_trap (invoke "new_default_i64" (i32.const 536870911)) "memory allocation failed")


### PR DESCRIPTION
I fixed GC Array allocation range check is failing that not checking about align padding in the 32bit limit.
This can be problematic when attacker uses 9 bits lesser number when doing a initialize a array.