### PR TITLE
Fixes #398: Apple Clang Optimization Breaking Bytecode Mapping 

### DIFF
--- a/build/target.cmake
+++ b/build/target.cmake
@@ -90,6 +90,7 @@ ELSEIF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") # Clang and AppleClang
         -Wno-expansion-to-defined -Wno-return-type -Wno-overloaded-virtual -Wno-unused-private-field -Wno-deprecated-copy
         -Wno-atomic-alignment -Wno-ambiguous-reversed-operator -Wno-deprecated-enum-enum-conversion
         -Wno-deprecated-enum-float-conversion -Wno-braced-scalar-init -Wno-unused-parameter -Wno-deprecated-literal-operator
+        -Wno-unused-label
     )
     IF (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 10)
         # this feature supported after clang version 11

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -1813,12 +1813,12 @@ public:
 class UnaryReversedOperation : public ByteCodeOffset2 {
 public:
     UnaryReversedOperation(Opcode code, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
-        : ByteCodeOffset2(code, dstOffset, srcOffset)
+        : ByteCodeOffset2(code, srcOffset, dstOffset)
     {
     }
 
-    ByteCodeStackOffset srcOffset() const { return stackOffset2(); }
-    ByteCodeStackOffset dstOffset() const { return stackOffset1(); }
+    ByteCodeStackOffset srcOffset() const { return stackOffset1(); }
+    ByteCodeStackOffset dstOffset() const { return stackOffset2(); }
 
 #if !defined(NDEBUG)
     void dump(size_t pos)
@@ -1931,8 +1931,8 @@ class MoveFloat : public ByteCode {
 public:
     MoveFloat(Opcode code, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset)
         : ByteCode(code)
-        , m_dstOffset(dstOffset)
         , m_srcOffset(srcOffset)
+        , m_dstOffset(dstOffset)
     {
     }
 
@@ -1940,10 +1940,8 @@ public:
     ByteCodeStackOffset dstOffset() const { return m_dstOffset; }
 
 protected:
-    // The field list is intentionally reserved, to avoid
-    // merging the integer and float code paths in the interpreter.
-    ByteCodeStackOffset m_dstOffset;
     ByteCodeStackOffset m_srcOffset;
+    ByteCodeStackOffset m_dstOffset;
 };
 
 #if !defined(NDEBUG)
@@ -2853,12 +2851,12 @@ DEFINE_MEMORY_LOAD(MemoryLoadM64, ByteCodeOffset2Value64, uint64_t);
     class className : public parentClassName {                                                                 \
     public:                                                                                                    \
         className(Opcode code, valueType offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset) \
-            : parentClassName(code, dstOffset, srcOffset, offset)                                              \
+            : parentClassName(code, srcOffset, dstOffset, offset)                                              \
         {                                                                                                      \
         }                                                                                                      \
         valueType offset() const { return uintValue(); }                                                       \
-        ByteCodeStackOffset srcOffset() const { return stackOffset2(); }                                       \
-        ByteCodeStackOffset dstOffset() const { return stackOffset1(); }                                       \
+        ByteCodeStackOffset srcOffset() const { return stackOffset1(); }                                       \
+        ByteCodeStackOffset dstOffset() const { return stackOffset2(); }                                       \
         IF_DEBUG_ENABLED(                                                                                      \
             void dump(size_t pos){});                                                                          \
     };
@@ -2888,12 +2886,12 @@ DEFINE_MEMORY_LOAD_MEM_IDX(MemoryLoadMemIdxM64, ByteCodeOffset2Value64MemIdx, ui
     class className : public parentClassName {                                                                                                     \
     public:                                                                                                                                        \
         className(uint32_t index, uint32_t alignment, Opcode code, valueType offset, ByteCodeStackOffset srcOffset, ByteCodeStackOffset dstOffset) \
-            : parentClassName(index, alignment, code, dstOffset, srcOffset, offset)                                                                \
+            : parentClassName(index, alignment, code, srcOffset, dstOffset, offset)                                                                \
         {                                                                                                                                          \
         }                                                                                                                                          \
         valueType offset() const { return uintValue(); }                                                                                           \
-        ByteCodeStackOffset srcOffset() const { return stackOffset2(); }                                                                           \
-        ByteCodeStackOffset dstOffset() const { return stackOffset1(); }                                                                           \
+        ByteCodeStackOffset srcOffset() const { return stackOffset1(); }                                                                           \
+        ByteCodeStackOffset dstOffset() const { return stackOffset2(); }                                                                           \
         IF_DEBUG_ENABLED(                                                                                                                          \
             void dump(size_t pos){});                                                                                                              \
     };
@@ -3196,12 +3194,12 @@ DEFINE_MEMORY_STORE(MemoryStore32M64, ByteCodeOffset2Value64, uint64_t);
     class className : public parentClassName {                                                         \
     public:                                                                                            \
         className(Opcode opcode, valueType offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1) \
-            : parentClassName(opcode, src1, src0, offset)                                              \
+            : parentClassName(opcode, src0, src1, offset)                                              \
         {                                                                                              \
         }                                                                                              \
         valueType offset() const { return uintValue(); }                                               \
-        ByteCodeStackOffset dstOffset() const { return stackOffset2(); }                               \
-        ByteCodeStackOffset valueOffset() const { return stackOffset1(); }                             \
+        ByteCodeStackOffset dstOffset() const { return stackOffset1(); }                               \
+        ByteCodeStackOffset valueOffset() const { return stackOffset2(); }                             \
         IF_DEBUG_ENABLED(                                                                              \
             void dump(size_t pos){});                                                                  \
     };
@@ -3231,12 +3229,12 @@ DEFINE_MEMORY_STORE_MEM_IDX(MemoryStoreMemIdx32M64, ByteCodeOffset2Value64MemIdx
     class className : public parentClassName {                                                                                                \
     public:                                                                                                                                   \
         className(uint32_t memIndex, uint32_t alignment, Opcode opcode, valueType offset, ByteCodeStackOffset src0, ByteCodeStackOffset src1) \
-            : parentClassName(memIndex, alignment, opcode, src1, src0, offset)                                                                \
+            : parentClassName(memIndex, alignment, opcode, src0, src1, offset)                                                                \
         {                                                                                                                                     \
         }                                                                                                                                     \
         valueType offset() const { return uintValue(); }                                                                                      \
-        ByteCodeStackOffset dstOffset() const { return stackOffset2(); }                                                                      \
-        ByteCodeStackOffset valueOffset() const { return stackOffset1(); }                                                                    \
+        ByteCodeStackOffset dstOffset() const { return stackOffset1(); }                                                                      \
+        ByteCodeStackOffset valueOffset() const { return stackOffset2(); }                                                                    \
         IF_DEBUG_ENABLED(                                                                                                                     \
             void dump(size_t pos){});                                                                                                         \
     };

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -474,16 +474,11 @@ inline static void simdSplatOperation(ExecutionState& state, UnaryOperation* cod
 #if defined(WALRUS_ENABLE_COMPUTED_GOTO)
 static void initAddressToOpcodeTable()
 {
-#define REGISTER_TABLE(name, ...)                                                                     \
-    {                                                                                                  \
-        void* addr = g_byteCodeTable.m_addressTable[ByteCode::name##Opcode];                          \
-        auto it = g_byteCodeTable.m_addressToOpcodeTable.find(addr);                                   \
-        RELEASE_ASSERT(it == g_byteCodeTable.m_addressToOpcodeTable.end()                              \
-                       || it->second == ByteCode::name##Opcode);                                       \
-        g_byteCodeTable.m_addressToOpcodeTable[addr] = ByteCode::name##Opcode;                         \
-    }
+#define REGISTER_TABLE(name, ...) \
+    g_byteCodeTable.m_addressToOpcodeTable[g_byteCodeTable.m_addressTable[ByteCode::name##Opcode]] = ByteCode::name##Opcode;
     FOR_EACH_BYTECODE(REGISTER_TABLE)
 #undef REGISTER_TABLE
+    RELEASE_ASSERT(g_byteCodeTable.m_addressToOpcodeTable.size() == ByteCode::OpcodeKindEnd);
 }
 #endif
 

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -474,8 +474,14 @@ inline static void simdSplatOperation(ExecutionState& state, UnaryOperation* cod
 #if defined(WALRUS_ENABLE_COMPUTED_GOTO)
 static void initAddressToOpcodeTable()
 {
-#define REGISTER_TABLE(name, ...) \
-    g_byteCodeTable.m_addressToOpcodeTable[g_byteCodeTable.m_addressTable[ByteCode::name##Opcode]] = ByteCode::name##Opcode;
+#define REGISTER_TABLE(name, ...)                                                                     \
+    {                                                                                                  \
+        void* addr = g_byteCodeTable.m_addressTable[ByteCode::name##Opcode];                          \
+        auto it = g_byteCodeTable.m_addressToOpcodeTable.find(addr);                                   \
+        RELEASE_ASSERT(it == g_byteCodeTable.m_addressToOpcodeTable.end()                              \
+                       || it->second == ByteCode::name##Opcode);                                       \
+        g_byteCodeTable.m_addressToOpcodeTable[addr] = ByteCode::name##Opcode;                         \
+    }
     FOR_EACH_BYTECODE(REGISTER_TABLE)
 #undef REGISTER_TABLE
 }
@@ -1424,7 +1430,10 @@ ByteCodeStackOffset* Interpreter::interpret(ExecutionState& state,
     }
 #endif
 
-#define DEFINE_OPCODE(codeName) codeName##OpcodeLbl
+#define DEFINE_OPCODE(codeName)                                     \
+    codeName##OpcodeLbl:                                            \
+    __asm__ volatile("" ::"i"(ByteCode::Opcode::codeName##Opcode)); \
+    codeName##OpcodeBodyLbl
 #define DEFINE_DEFAULT
 #define NEXT_INSTRUCTION() goto NextInstruction;
 


### PR DESCRIPTION
## Problem
| https://github.com/Samsung/walrus/issues/398

When built on macOS (Apple Clang), the opcode labels of the computed goto interpreter are merged into a single address by tail merging. `ByteCode::opcode()` performs a reverse address → opcode lookup through `m_addressToOpcodeTable`, so once merging occurs, different opcodes end up sharing the same address, which corrupts this table and makes it return the wrong opcode.

## Fix
- Insert an `__asm__ volatile` barrier after each opcode label so that the labels are not merged even when their bodies are identical. (Since an extra label is introduced, `-Wno-unused-label` is added as well.)
- Remove the existing workaround that intentionally reversed the field order in `MoveFloat` and others for the same purpose, restoring src/dst to their original order.
- Assert `m_addressToOpcodeTable.size() == OpcodeKindEnd` at initialization time so that any recurrence of the merging is detected immediately.

### Benchmark Results
aarch64 macOS, `test/wasmBenchmarker`, average of 10 runs for each of 31 benchmarks (unit: seconds)

- `tools/run-tests.py`

|            | Before | After | Ratio |
|-------------|--------|-------|-------|
| Interpreter | 4.536  | 4.406 | 0.971 |
| JIT         | 0.363  | 0.364 | 1.005 |
