### PR TITLE
Implement TryTable support

### DIFF
--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -19,6 +19,7 @@
 
 #include "runtime/ExecutionState.h"
 #include "runtime/Function.h"
+#include "runtime/GCException.h"
 #include "runtime/Instance.h"
 #include "runtime/JITExec.h"
 #include "runtime/Module.h"
@@ -152,8 +153,12 @@ private:
                                 if (item.m_tagIndex == std::numeric_limits<uint32_t>::max() || function->instance()->tag(item.m_tagIndex) == tag) {
                                     programCounter = item.m_catchStartPosition + reinterpret_cast<size_t>(moduleFunction->byteCode());
                                     uint8_t* sp = frame.bp() + item.m_stackSizeToBe;
+                                    size_t paramStackSize = tag->functionType()->paramStackSize();
                                     if (item.m_tagIndex != std::numeric_limits<uint32_t>::max() && tag->functionType()->paramStackSize()) {
-                                        memcpy(sp, e->userExceptionData().data(), tag->functionType()->paramStackSize());
+                                        memcpy(sp, e->userExceptionData().data(), paramStackSize);
+                                    }
+                                    if (item.m_pushExnRef) {
+                                        *reinterpret_cast<GCException**>(sp + paramStackSize) = GCException::exceptionNew(e);
                                     }
                                     isCatchSucessful = true;
                                     break;

--- a/src/jit/Backend.cpp
+++ b/src/jit/Backend.cpp
@@ -143,16 +143,18 @@ public:
     };
 
     struct CatchBlock {
-        CatchBlock(sljit_uw handlerAddr, size_t stackSizeToBe, uint32_t tagIndex)
+        CatchBlock(sljit_uw handlerAddr, size_t stackSizeToBe, uint32_t tagIndex, bool pushExnRef)
             : handlerAddr(handlerAddr)
             , stackSizeToBe(stackSizeToBe)
             , tagIndex(tagIndex)
+            , pushExnRef(pushExnRef)
         {
         }
 
         sljit_uw handlerAddr;
         size_t stackSizeToBe;
         uint32_t tagIndex;
+        bool pushExnRef;
     };
 
     InstanceConstData(std::vector<TrapBlock>& trapBlocks, std::vector<Walrus::TryBlock>& tryBlocks);

--- a/src/jit/ByteCodeParser.cpp
+++ b/src/jit/ByteCodeParser.cpp
@@ -87,7 +87,7 @@ static void buildCatchInfo(JITCompiler* compiler, ModuleFunction* function, std:
             catchLabel->addInfo(Label::kHasCatchInfo);
         }
 
-        tryBlocks[idx].catchBlocks.push_back(TryBlock::CatchBlock(catchLabel, it.m_stackSizeToBe, it.m_tagIndex));
+        tryBlocks[idx].catchBlocks.push_back(TryBlock::CatchBlock(catchLabel, it.m_stackSizeToBe, it.m_tagIndex, it.m_pushExnRef));
     }
 }
 

--- a/src/jit/Compiler.h
+++ b/src/jit/Compiler.h
@@ -446,9 +446,10 @@ private:
 
 struct TryBlock {
     struct CatchBlock {
-        CatchBlock(Label* handler, size_t stackSizeToBe, uint32_t tagIndex)
+        CatchBlock(Label* handler, size_t stackSizeToBe, uint32_t tagIndex, bool pushExnRef)
             : stackSizeToBe(stackSizeToBe)
             , tagIndex(tagIndex)
+            , pushExnRef(pushExnRef)
         {
             u.handler = handler;
         }
@@ -459,6 +460,7 @@ struct TryBlock {
         } u;
         size_t stackSizeToBe;
         uint32_t tagIndex;
+        bool pushExnRef;
     };
 
     TryBlock(Label* start, size_t size)

--- a/src/jit/TryCatchInl.h
+++ b/src/jit/TryCatchInl.h
@@ -63,7 +63,7 @@ InstanceConstData::InstanceConstData(std::vector<TrapBlock>& trapBlocks, std::ve
         m_tryBlocks.push_back(TryBlock(catchStart, catchCount, it.parent, sljit_get_label_addr(it.returnToLabel)));
 
         for (auto catchIt : it.catchBlocks) {
-            m_catchBlocks.push_back(CatchBlock(sljit_get_label_addr(catchIt.u.handlerLabel), catchIt.stackSizeToBe, catchIt.tagIndex));
+            m_catchBlocks.push_back(CatchBlock(sljit_get_label_addr(catchIt.u.handlerLabel), catchIt.stackSizeToBe, catchIt.tagIndex, catchIt.pushExnRef));
         }
 
         catchStart += catchCount;
@@ -124,7 +124,7 @@ void InstanceConstData::append(std::vector<TrapBlock>& trapBlocks, std::vector<W
         m_tryBlocks.push_back(TryBlock(catchStart, catchCount, parent, sljit_get_label_addr(it.returnToLabel)));
 
         for (auto catchIt : it.catchBlocks) {
-            m_catchBlocks.push_back(CatchBlock(sljit_get_label_addr(catchIt.u.handlerLabel), catchIt.stackSizeToBe, catchIt.tagIndex));
+            m_catchBlocks.push_back(CatchBlock(sljit_get_label_addr(catchIt.u.handlerLabel), catchIt.stackSizeToBe, catchIt.tagIndex, catchIt.pushExnRef));
         }
 
         catchStart += catchCount;
@@ -174,16 +174,26 @@ static sljit_sw findCatch(sljit_sw current, uint8_t* bp, ExecutionContext* conte
         while (i < end) {
             if (catchBlocks[i].tagIndex == std::numeric_limits<uint32_t>::max()) {
                 context->error = ExecutionContext::NoError;
-                context->clearException();
+                if (catchBlocks[i].pushExnRef) {
+                    std::unique_ptr<Exception> e(context->capturedException);
+                    *reinterpret_cast<GCException**>(bp) = GCException::exceptionNew(e);
+                } else {
+                    context->clearException();
+                }
                 return catchBlocks[i].handlerAddr;
             }
 
             if (instance->tag(catchBlocks[i].tagIndex) == tag) {
                 context->error = ExecutionContext::NoError;
-                memcpy(bp + catchBlocks[i].stackSizeToBe,
-                       context->capturedException->userExceptionData().data(),
-                       tag->functionType()->paramStackSize());
-                context->clearException();
+                uint8_t* sp = bp + catchBlocks[i].stackSizeToBe;
+                size_t paramStackSize = tag->functionType()->paramStackSize();
+                memcpy(sp, context->capturedException->userExceptionData().data(), paramStackSize);
+                if (catchBlocks[i].pushExnRef) {
+                    std::unique_ptr<Exception> e(context->capturedException);
+                    *reinterpret_cast<GCException**>(sp + paramStackSize) = GCException::exceptionNew(e);
+                } else {
+                    context->clearException();
+                }
                 return catchBlocks[i].handlerAddr;
             }
 

--- a/src/parser/WASMParser.cpp
+++ b/src/parser/WASMParser.cpp
@@ -335,6 +335,7 @@ private:
             Loop,
             Block,
             TryCatch,
+            TryTable,
         };
 
         static_assert(sizeof(Walrus::JumpIfTrue) == sizeof(Walrus::JumpIfFalse), "");
@@ -642,8 +643,10 @@ private:
         size_t m_tryEnd;
         size_t m_catchStart;
         uint32_t m_tagIndex;
+        bool m_pushExnRef;
     };
     std::vector<CatchInfo> m_catchInfo;
+    std::vector<CatchClauseVector> m_tryTableCatchVector;
     struct LocalInfo {
         Walrus::Value::Type m_valueType;
         size_t m_position;
@@ -2226,7 +2229,7 @@ public:
             }
         }
         if (blockInfo.m_blockType != BlockInfo::Loop) {
-            ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch);
+            ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch || blockInfo.m_blockType == BlockInfo::TryTable);
             blockInfo.m_jumpToEndBrInfo.push_back({ BlockInfo::JumpToEndBrInfo::IsJump, m_currentByteCode.size() });
         }
         pushByteCode(Walrus::Jump(offset), WASMOpcode::BrOpcode);
@@ -2258,7 +2261,7 @@ public:
 
             auto offset = (int32_t)blockInfo.m_position - (int32_t)m_currentByteCode.size();
             if (blockInfo.m_blockType != BlockInfo::Loop) {
-                ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch);
+                ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch || blockInfo.m_blockType == BlockInfo::TryTable);
                 blockInfo.m_jumpToEndBrInfo.push_back({ BlockInfo::JumpToEndBrInfo::IsJump, m_currentByteCode.size() });
             }
             pushByteCode(Walrus::Jump(offset), WASMOpcode::BrIfOpcode);
@@ -2280,7 +2283,7 @@ public:
 
             auto offset = (int32_t)blockInfo.m_position - (int32_t)m_currentByteCode.size();
             if (blockInfo.m_blockType != BlockInfo::Loop) {
-                ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch);
+                ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch || blockInfo.m_blockType == BlockInfo::TryTable);
                 blockInfo.m_jumpToEndBrInfo.push_back({ BlockInfo::JumpToEndBrInfo::IsJump, m_currentByteCode.size() });
             }
             pushByteCode(Walrus::Jump(offset), WASMOpcode::BrIfOpcode);
@@ -2290,7 +2293,7 @@ public:
 
         auto offset = (int32_t)blockInfo.m_position - (int32_t)m_currentByteCode.size();
         if (blockInfo.m_blockType != BlockInfo::Loop) {
-            ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch);
+            ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch || blockInfo.m_blockType == BlockInfo::TryTable);
             blockInfo.m_jumpToEndBrInfo.push_back({ BlockInfo::JumpToEndBrInfo::IsJumpIf, m_currentByteCode.size() });
         }
 
@@ -2367,7 +2370,7 @@ public:
         offset = (int32_t)(blockInfo.m_position - brTableCode);
 
         if (blockInfo.m_blockType != BlockInfo::Loop) {
-            ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch);
+            ASSERT(blockInfo.m_blockType == BlockInfo::Block || blockInfo.m_blockType == BlockInfo::IfElse || blockInfo.m_blockType == BlockInfo::TryCatch || blockInfo.m_blockType == BlockInfo::TryTable);
             offset = jumpOffset;
             blockInfo.m_jumpToEndBrInfo.push_back({ BlockInfo::JumpToEndBrInfo::IsBrTable, brTableCode + jumpOffset });
         }
@@ -2435,7 +2438,7 @@ public:
             ASSERT(m_currentByteCode.size() % sizeof(void*) == 0);
             Walrus::Throw* code = peekByteCode<Walrus::Throw>(pos);
             for (size_t i = 0; i < param.size(); i++) {
-                ASSERT(peekVMStackValueType() == param[functionType->param().size() - i - 1]);
+                ASSERT(toDebugType(peekVMStackValueType()) == toDebugType(param[functionType->param().size() - i - 1]));
                 code->dataOffsets()[param.size() - i - 1] = popVMStack();
             }
         }
@@ -2450,9 +2453,9 @@ public:
         m_currentFunction->m_hasTryCatch = true;
     }
 
-    void processCatchExpr(Index tagIndex)
+    void processCatchExpr(Index tagIndex, bool pushExnRef)
     {
-        ASSERT(m_blockInfo.back().m_blockType == BlockInfo::TryCatch);
+        ASSERT(m_blockInfo.back().m_blockType == BlockInfo::TryCatch || m_blockInfo.back().m_blockType == BlockInfo::TryTable);
 
         m_preprocessData.seenBranch();
         auto& blockInfo = m_blockInfo.back();
@@ -2472,7 +2475,7 @@ public:
 
         blockInfo.clearByteCodeGenerationStopped();
 
-        m_catchInfo.push_back({ m_blockInfo.size(), m_blockInfo.back().m_position, tryEnd, m_currentByteCode.size(), tagIndex });
+        m_catchInfo.push_back({ m_blockInfo.size(), m_blockInfo.back().m_position, tryEnd, m_currentByteCode.size(), tagIndex, pushExnRef });
 
         if (tagIndex != std::numeric_limits<Index>::max()) {
             auto& param = m_result.m_tagTypes[tagIndex]->functionType()->param().types();
@@ -2480,16 +2483,27 @@ public:
                 pushVMStack(param[i]);
             }
         }
+        if (pushExnRef) {
+            pushVMStack(Walrus::Value::ExnRef);
+        }
     }
 
     virtual void OnCatchExpr(Index tagIndex) override
     {
-        processCatchExpr(tagIndex);
+        processCatchExpr(tagIndex, false);
     }
 
     virtual void OnCatchAllExpr() override
     {
-        processCatchExpr(std::numeric_limits<Index>::max());
+        processCatchExpr(std::numeric_limits<Index>::max(), false);
+    }
+
+    virtual void OnTryTableExpr(Type sigType, const CatchClauseVector& catches) override
+    {
+        BlockInfo b(BlockInfo::TryTable, sigType, *this);
+        m_blockInfo.push_back(b);
+        m_currentFunction->m_hasTryCatch = true;
+        m_tryTableCatchVector.push_back(catches);
     }
 
     virtual void OnMemoryInitExpr(Index segmentIndex, Index memIdx) override
@@ -3470,6 +3484,22 @@ public:
         // because it is possible to jump to the location after i32.eqz
         m_lastI32EqzPos = s_noI32Eqz;
         if (m_blockInfo.size()) {
+            if (m_blockInfo.back().m_blockType == BlockInfo::TryTable && resumeGenerateByteCodeAfterNBlockEnd() == 0) {
+                ASSERT(shouldContinueToGenerateByteCode());
+                for (auto iter : m_tryTableCatchVector.back()) {
+                    Index tagIndex = (iter.kind == CatchKind::Catch || iter.kind == CatchKind::CatchRef) ? iter.tag : std::numeric_limits<Index>::max();
+                    bool pushExnRef = (iter.kind == CatchKind::CatchRef || iter.kind == CatchKind::CatchAllRef);
+
+                    setResumeGenerateByteCodeAfterNBlockEnd(0);
+                    setShouldContinueToGenerateByteCode(true);
+                    processCatchExpr(tagIndex, pushExnRef);
+                    OnBrExpr(iter.depth + 1);
+                }
+                m_tryTableCatchVector.pop_back();
+                setResumeGenerateByteCodeAfterNBlockEnd(0);
+                setShouldContinueToGenerateByteCode(true);
+            }
+
             auto dropSize = dropStackValuesBeforeBrIfNeeds(0);
             auto blockInfo = m_blockInfo.back();
             m_blockInfo.pop_back();
@@ -3483,7 +3513,7 @@ public:
             }
 #endif
 
-            if (blockInfo.m_blockType == BlockInfo::TryCatch) {
+            if (blockInfo.m_blockType == BlockInfo::TryCatch || blockInfo.m_blockType == BlockInfo::TryTable) {
                 auto iter = m_catchInfo.begin();
                 while (iter != m_catchInfo.end()) {
                     if (iter->m_tryCatchBlockDepth - 1 != m_blockInfo.size()) {
@@ -3494,7 +3524,7 @@ public:
                     for (size_t i = 0; i < blockInfo.m_vmStack.size(); i++) {
                         stackSizeToBe += m_vmStack[i].stackAllocatedSize();
                     }
-                    m_currentFunction->m_catchInfo.push_back({ iter->m_tryStart, iter->m_tryEnd, iter->m_catchStart, stackSizeToBe, iter->m_tagIndex });
+                    m_currentFunction->m_catchInfo.push_back({ iter->m_tryStart, iter->m_tryEnd, iter->m_catchStart, stackSizeToBe, iter->m_tagIndex, iter->m_pushExnRef });
                     iter = m_catchInfo.erase(iter);
                 }
             }

--- a/src/runtime/Module.h
+++ b/src/runtime/Module.h
@@ -210,6 +210,7 @@ public:
         size_t m_catchStartPosition;
         size_t m_stackSizeToBe;
         uint32_t m_tagIndex;
+        bool m_pushExnRef;
     };
 
     ModuleFunction(FunctionType* functionType);

--- a/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
+++ b/third_party/wabt/include/wabt/walrus/binary-reader-walrus.h
@@ -151,6 +151,7 @@ public:
     virtual void OnTryExpr(Type sigType) = 0;
     virtual void OnCatchExpr(Index tagIndex) = 0;
     virtual void OnCatchAllExpr() = 0;
+    virtual void OnTryTableExpr(Type sigType, const CatchClauseVector &catches) = 0;
     virtual void OnMemoryGrowExpr(Index memIdx) = 0;
     virtual void OnMemoryInitExpr(Index segmentIndex, Index memIdx) = 0;
     virtual void OnMemoryCopyExpr(Index srcMemIndex, Index dstMemIndex) = 0;

--- a/third_party/wabt/src/walrus/binary-reader-walrus.cc
+++ b/third_party/wabt/src/walrus/binary-reader-walrus.cc
@@ -655,7 +655,7 @@ public:
         return Result::Ok;
     }
     void SubBlockCheck() {
-        if (WABT_UNLIKELY(m_externalDelegate->resumeGenerateByteCodeAfterNBlockEnd() == 1)) {
+        if (m_externalDelegate->resumeGenerateByteCodeAfterNBlockEnd() == 1) {
             m_externalDelegate->setResumeGenerateByteCodeAfterNBlockEnd(0);
             m_externalDelegate->setShouldContinueToGenerateByteCode(true);
         }
@@ -1587,9 +1587,24 @@ public:
         m_externalDelegate->OnThrowRefExpr();
         return Result::Ok;
     }
-    Result OnTryTableExpr(Type sig_type, const CatchClauseVector &catches) override
+    Result OnTryTableExpr(Type sig_type, const CatchClauseVector& catches) override
     {
-        abort();
+        uint32_t exn_stack_height;
+        CHECK_RESULT(m_validator.BeginTryTable(GetLocation(), sig_type));
+        CHECK_RESULT(m_validator.GetCatchCount(m_labelStack.size() - 1, &exn_stack_height));
+        EXECUTE_VALIDATOR(PushLabel(LabelKind::Try));
+
+        for (const auto& catchData : catches) {
+            TableCatch tableCatch;
+            tableCatch.kind = catchData.kind;
+            tableCatch.tag = Var(catchData.tag, GetLocation());
+            tableCatch.target = Var(catchData.depth, GetLocation());
+            CHECK_RESULT(m_validator.OnTryTableCatch(GetLocation(), tableCatch));
+        }
+        CHECK_RESULT(m_validator.EndTryTable(GetLocation(), sig_type));
+
+        SHOULD_GENERATE_BYTECODE;
+        m_externalDelegate->OnTryTableExpr(sig_type, catches);
         return Result::Ok;
     }
 


### PR DESCRIPTION
This patch implements try_tables, which are replaced by try-catch block.

The only known issue, is that if returnCall is not possible, and replaced by a normal call, try blocks apply. This is not related to try_tables, but try-catch in general. At some point we need to figure out how to support returnCall for all functions in both interpreter and jit.

I plan to add the working WebAssembly 3.0 test cases