### PR TITLE
Fix isTypeFunc assertion failure

### DIFF
--- a/test/wasi/assertion_isTypeFunc.wast
+++ b/test/wasi/assertion_isTypeFunc.wast
@@ -1,0 +1,20 @@
+(component
+  (type $not-func s8)
+
+  (core module $m
+    (func (export "f"))
+  )
+
+  (core instance $i
+    (instantiate $m)
+  )
+
+  (alias core export $i "f"
+    (core func $f)
+  )
+
+  (func
+    (type $not-func)
+    (canon lift (core func $f))
+  )
+)

--- a/third_party/wabt/src/shared-validator.cc
+++ b/third_party/wabt/src/shared-validator.cc
@@ -2632,6 +2632,10 @@ Result SharedComponentValidator::OnCanonLift(
   TypeBase* type_base = nullptr;
   uint32_t info = 0;
   Result result = CheckIndex(ComponentSort::Type, type_index, &type_base);
+
+  if (result == Result::Ok && !type_base->IsTypeFunc())
+    return Result::Error;
+  
   result |= CheckIndex(ComponentSort::CoreFunc, core_func_index, &core_func);
   result |= CheckCanonOptions(option_count, options, &info);
   if (result == Result::Ok) {


### PR DESCRIPTION
## Description

Fuzzing revealed that Canonical Lift could reference a non-function type through `type_index`, causing the `isTypeFunc()` assertion to fail.

This change validates that `type_index` references a function type before processing Canonical Lift.