### PR TITLE
Fix isValueType assertion failure

### DIFF
--- a/third_party/wabt/include/wabt/shared-validator.h
+++ b/third_party/wabt/include/wabt/shared-validator.h
@@ -630,7 +630,8 @@ class SharedComponentValidator {
              type_def == TypeDef::Own ||
              type_def == TypeDef::Borrow ||
              type_def == TypeDef::Stream ||
-             type_def == TypeDef::Future;
+             type_def == TypeDef::Future ||
+             type_def == TypeDef::ListFixed;
     }
 
     ValueType* AsValueType() {


### PR DESCRIPTION
## Description

Fuzzing revealed that `IsValueType` was missing a check for `ListFixed`, causing the `isValueType()` assertion to fail.

This change adds the missing `ListFixed` check to `IsValueType`.