### PR TITLE
Reduce peak memory of the JIT dependency analysis

### DIFF
--- a/src/jit/Analysis.cpp
+++ b/src/jit/Analysis.cpp
@@ -20,8 +20,6 @@
 #include "jit/Compiler.h"
 #include "runtime/GCArray.h"
 
-#include <cstdlib>
-#include <cstring>
 #include <set>
 
 namespace Walrus {
@@ -60,27 +58,70 @@ struct DependencyGenContext {
         ~DependencyList()
         {
             if (isSpilled()) {
-                free(block());
+                delete spilled();
             }
         }
 
         size_t size() const
         {
             if (isSpilled()) {
-                return static_cast<size_t>(m_inline[1]);
+                return spilled()->size();
             }
             return m_inline[0] == 0 ? 0 : (m_inline[1] == 0 ? 1 : 2);
         }
 
-        const VariableRef* begin() const { return isSpilled() ? data() : m_inline; }
-        const VariableRef* end() const { return begin() + size(); }
+        class const_iterator {
+        public:
+            const_iterator(const VariableRef* current)
+                : m_isSpilled(false)
+                , m_current(current)
+            {
+            }
 
-        VariableRef at(size_t index) const { return begin()[index]; }
+            const_iterator(std::set<VariableRef>::const_iterator current)
+                : m_isSpilled(true)
+                , m_current(nullptr)
+                , m_spilledCurrent(current)
+            {
+            }
+
+            VariableRef operator*() const { return m_isSpilled ? *m_spilledCurrent : *m_current; }
+
+            const_iterator& operator++()
+            {
+                if (m_isSpilled) {
+                    ++m_spilledCurrent;
+                } else {
+                    ++m_current;
+                }
+                return *this;
+            }
+
+            bool operator!=(const const_iterator& other) const
+            {
+                return m_isSpilled ? m_spilledCurrent != other.m_spilledCurrent : m_current != other.m_current;
+            }
+
+        private:
+            bool m_isSpilled;
+            const VariableRef* m_current;
+            std::set<VariableRef>::const_iterator m_spilledCurrent;
+        };
+
+        const_iterator begin() const
+        {
+            return isSpilled() ? const_iterator(spilled()->begin()) : const_iterator(m_inline);
+        }
+
+        const_iterator end() const
+        {
+            return isSpilled() ? const_iterator(spilled()->end()) : const_iterator(m_inline + size());
+        }
 
         void clear()
         {
             if (isSpilled()) {
-                free(block());
+                delete spilled();
             }
             m_inline[0] = 0;
             m_inline[1] = 0;
@@ -91,12 +132,14 @@ struct DependencyGenContext {
 
     private:
         // Label refs are pointers (low bits 0) and variable refs end in 1,
-        // so 2 is free to mark a spilled block. A ref is never 0.
+        // so 2 is free to mark a spilled set. A ref is never 0.
         static const VariableRef kSpilledTag = 2;
 
         bool isSpilled() const { return (m_inline[0] & 0x3) == kSpilledTag; }
-        void* block() const { return reinterpret_cast<void*>(m_inline[0] & ~static_cast<VariableRef>(0x3)); }
-        VariableRef* data() const { return reinterpret_cast<VariableRef*>(static_cast<size_t*>(block()) + 1); }
+        std::set<VariableRef>* spilled() const
+        {
+            return reinterpret_cast<std::set<VariableRef>*>(m_inline[0] & ~static_cast<VariableRef>(0x3));
+        }
 
         VariableRef m_inline[2];
     };
@@ -134,46 +177,41 @@ bool DependencyGenContext::DependencyList::insert(VariableRef ref)
 {
     ASSERT(ref != 0 && (ref & 0x3) != kSpilledTag);
 
-    size_t count = size();
-    const VariableRef* items = begin();
-    size_t position = 0;
-
-    while (position < count && items[position] < ref) {
-        position++;
+    if (isSpilled()) {
+        return spilled()->insert(ref).second;
     }
 
-    if (position < count && items[position] == ref) {
-        return false;
-    }
-
-    if (!isSpilled() && count < 2) {
-        if (position == 0 && count == 1) {
-            m_inline[1] = m_inline[0];
-        }
-        m_inline[position] = ref;
+    if (m_inline[0] == 0) {
+        m_inline[0] = ref;
         return true;
     }
 
-    size_t capacity = isSpilled() ? *static_cast<size_t*>(block()) : 0;
-
-    if (!isSpilled() || count == capacity) {
-        size_t newCapacity = capacity == 0 ? 4 : capacity * 2;
-        size_t* newBlock = static_cast<size_t*>(malloc(sizeof(size_t) + newCapacity * sizeof(VariableRef)));
-        *newBlock = newCapacity;
-        memcpy(newBlock + 1, items, count * sizeof(VariableRef));
-
-        if (isSpilled()) {
-            free(block());
-        }
-
-        m_inline[0] = reinterpret_cast<VariableRef>(newBlock) | kSpilledTag;
-        m_inline[1] = count;
+    if (m_inline[0] == ref) {
+        return false;
     }
 
-    VariableRef* target = data();
-    memmove(target + position + 1, target + position, (count - position) * sizeof(VariableRef));
-    target[position] = ref;
-    m_inline[1] = count + 1;
+    if (m_inline[1] == 0) {
+        if (ref < m_inline[0]) {
+            m_inline[1] = m_inline[0];
+            m_inline[0] = ref;
+        } else {
+            m_inline[1] = ref;
+        }
+        return true;
+    }
+
+    if (m_inline[1] == ref) {
+        return false;
+    }
+
+    std::set<VariableRef>* set = new std::set<VariableRef>();
+
+    set->insert(m_inline[0]);
+    set->insert(m_inline[1]);
+    set->insert(ref);
+
+    m_inline[0] = reinterpret_cast<VariableRef>(set) | kSpilledTag;
+    m_inline[1] = 0;
     return true;
 }
 
@@ -706,9 +744,7 @@ void JITCompiler::buildVariables(uint32_t requiredStackSize)
 
                 unprocessedLabels.pop_back();
 
-                for (size_t j = 0; j < list.size(); ++j) {
-                    VariableRef it = list.at(j);
-
+                for (auto it : list) {
                     if (dependencies.insert(it)) {
                         if (VARIABLE_TYPE(it) == DependencyGenContext::Label) {
                             unprocessedLabels.push_back(VARIABLE_GET_LABEL(it));

--- a/src/jit/Analysis.cpp
+++ b/src/jit/Analysis.cpp
@@ -20,6 +20,8 @@
 #include "jit/Compiler.h"
 #include "runtime/GCArray.h"
 
+#include <cstdlib>
+#include <cstring>
 #include <set>
 
 namespace Walrus {
@@ -37,7 +39,67 @@ struct DependencyGenContext {
 
     static const VariableRef kNoRef = ~(VariableRef)0;
 
-    typedef std::set<VariableRef> DependencyList;
+    class DependencyList {
+    public:
+        DependencyList()
+            : m_inline{ 0, 0 }
+        {
+        }
+
+        // DependencyList is not available for copy, since it may double freed.
+        DependencyList(const DependencyList&) = delete;
+        DependencyList& operator=(const DependencyList&) = delete;
+
+        DependencyList(DependencyList&& other) noexcept
+            : m_inline{ other.m_inline[0], other.m_inline[1] }
+        {
+            other.m_inline[0] = 0;
+            other.m_inline[1] = 0;
+        }
+
+        ~DependencyList()
+        {
+            if (isSpilled()) {
+                free(block());
+            }
+        }
+
+        size_t size() const
+        {
+            if (isSpilled()) {
+                return static_cast<size_t>(m_inline[1]);
+            }
+            return m_inline[0] == 0 ? 0 : (m_inline[1] == 0 ? 1 : 2);
+        }
+
+        const VariableRef* begin() const { return isSpilled() ? data() : m_inline; }
+        const VariableRef* end() const { return begin() + size(); }
+
+        VariableRef at(size_t index) const { return begin()[index]; }
+
+        void clear()
+        {
+            if (isSpilled()) {
+                free(block());
+            }
+            m_inline[0] = 0;
+            m_inline[1] = 0;
+        }
+
+        // Returns true when ref was not present yet.
+        bool insert(VariableRef ref);
+
+    private:
+        // Label refs are pointers (low bits 0) and variable refs end in 1,
+        // so 2 is free to mark a spilled block. A ref is never 0.
+        static const VariableRef kSpilledTag = 2;
+
+        bool isSpilled() const { return (m_inline[0] & 0x3) == kSpilledTag; }
+        void* block() const { return reinterpret_cast<void*>(m_inline[0] & ~static_cast<VariableRef>(0x3)); }
+        VariableRef* data() const { return reinterpret_cast<VariableRef*>(static_cast<size_t*>(block()) + 1); }
+
+        VariableRef m_inline[2];
+    };
 
     DependencyGenContext(size_t dependencySize, size_t requiredStackSize)
     {
@@ -67,6 +129,53 @@ struct DependencyGenContext {
     std::vector<VariableRef> currentDependencies;
     std::vector<uint8_t> currentOptions;
 };
+
+bool DependencyGenContext::DependencyList::insert(VariableRef ref)
+{
+    ASSERT(ref != 0 && (ref & 0x3) != kSpilledTag);
+
+    size_t count = size();
+    const VariableRef* items = begin();
+    size_t position = 0;
+
+    while (position < count && items[position] < ref) {
+        position++;
+    }
+
+    if (position < count && items[position] == ref) {
+        return false;
+    }
+
+    if (!isSpilled() && count < 2) {
+        if (position == 0 && count == 1) {
+            m_inline[1] = m_inline[0];
+        }
+        m_inline[position] = ref;
+        return true;
+    }
+
+    size_t capacity = isSpilled() ? *static_cast<size_t*>(block()) : 0;
+
+    if (!isSpilled() || count == capacity) {
+        size_t newCapacity = capacity == 0 ? 4 : capacity * 2;
+        size_t* newBlock = static_cast<size_t*>(malloc(sizeof(size_t) + newCapacity * sizeof(VariableRef)));
+        *newBlock = newCapacity;
+        memcpy(newBlock + 1, items, count * sizeof(VariableRef));
+
+        if (isSpilled()) {
+            free(block());
+        }
+
+        m_inline[0] = reinterpret_cast<VariableRef>(newBlock) | kSpilledTag;
+        m_inline[1] = count;
+    }
+
+    VariableRef* target = data();
+    memmove(target + position + 1, target + position, (count - position) * sizeof(VariableRef));
+    target[position] = ref;
+    m_inline[1] = count + 1;
+    return true;
+}
 
 void DependencyGenContext::update(size_t dependencyStart, size_t id)
 {
@@ -163,7 +272,7 @@ void DependencyGenContext::assignReference(VariableRef ref, size_t offset, uint3
     currentOptions[offset] = 0;
 }
 
-static bool checkSameConst(VariableList* variableList, std::set<VariableRef>& dependencies)
+static bool checkSameConst(VariableList* variableList, DependencyGenContext::DependencyList& dependencies)
 {
     VariableRef constRef = 0;
     Instruction* constInstr = nullptr;
@@ -583,7 +692,7 @@ void JITCompiler::buildVariables(uint32_t requiredStackSize)
             }
 
             std::vector<Label*> unprocessedLabels;
-            std::set<VariableRef>& dependencies = dependencyCtx.dependencies[i];
+            DependencyGenContext::DependencyList& dependencies = dependencyCtx.dependencies[i];
 
             for (auto it : dependencies) {
                 if (VARIABLE_TYPE(it) == DependencyGenContext::Label) {
@@ -593,12 +702,14 @@ void JITCompiler::buildVariables(uint32_t requiredStackSize)
 
             while (!unprocessedLabels.empty()) {
                 Label* label = unprocessedLabels.back();
-                std::set<VariableRef>& list = dependencyCtx.dependencies[i - dependencyStart + label->m_dependencyStart];
+                DependencyGenContext::DependencyList& list = dependencyCtx.dependencies[i - dependencyStart + label->m_dependencyStart];
 
                 unprocessedLabels.pop_back();
 
-                for (auto it : list) {
-                    if (dependencies.insert(it).second) {
+                for (size_t j = 0; j < list.size(); ++j) {
+                    VariableRef it = list.at(j);
+
+                    if (dependencies.insert(it)) {
                         if (VARIABLE_TYPE(it) == DependencyGenContext::Label) {
                             unprocessedLabels.push_back(VARIABLE_GET_LABEL(it));
                         }

--- a/src/jit/ByteCodeParser.cpp
+++ b/src/jit/ByteCodeParser.cpp
@@ -24,6 +24,10 @@
 
 #include <map>
 
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
+
 #if defined(COMPILER_MSVC)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
@@ -3855,6 +3859,12 @@ void Module::jitCompile(ModuleFunction** functions, size_t functionsLength, uint
     }
 
     compiler.generateCode();
+
+#if defined(__GLIBC__)
+    // The analysis above frees everything it allocated, but the freed chunks are
+    // small and scattered through the arena. malloc_trim() handle that problem.
+    malloc_trim(0);
+#endif
 }
 
 } // namespace Walrus


### PR DESCRIPTION
Cuts the peak memory that `JITCompiler::buildVariables()` needs while it resolves
which value each stack slot carries at a control-flow merge, and returns what is
left over to the operating system when compilation finishes.

Two commits, independent of each other:

- **Store small JIT dependency sets inline instead of `std::set`** — the real fix.
- **Return the JIT analysis scratch memory with `malloc_trim`** — releases what the
  analysis already freed.

## Why the analysis dominates peak memory

`DependencyGenContext` holds one dependency set per (label, stack slot) cell. The
matrix is dense: every label gets `requiredStackSize` cells whether or not the
slot is live there, so both dimensions grow with function size and the cell count
grows quadratically. `bzip2.wasm` produces 413,652 cells, and with `std::set` each
one cost 48 bytes while empty plus a separately allocated 40-byte node per element.

(*bzip2.wasm is external benchmark - from human writer)

The sets are tiny. Counted over every cell of that module:

| max elements | cells | share |
|---:|---:|---:|
| 0 | 120 | 0.0% |
| 1 | 152,031 | 36.8% |
| 2 | 228,507 | 55.2% |
| 3 | 20,628 | 5.0% |
| 4 or more | 12,366 | 3.0% |

So `DependencyList` now keeps two refs inline in the object and spills to a
malloc'd block only past that. A cell is 16 bytes instead of 48, and 92% of them
never allocate at all. The low two bits of the first word separate the two states:
dependency refs are either label pointers (low bits 0) or variable refs (low bits
1), and 0 marks an empty slot, so tag 2 is free to mark a spilled block. Elements
stay sorted and deduplicated, which preserves the `std::set` iteration order that
`mergeVariables` depends on.

## Measurements

`valgrind --tool=massif --time-unit=B` over `test/wasmBenchmarker/ctests/wasm`,
run as `walrus --jit <module>`. Both binaries come from the same tree; "before"
only has `Analysis.cpp` reverted to its current upstream state. Numbers are
`useful-heap` at the peak snapshot. The "analysis" columns attribute the peak
tree to `Analysis.cpp`.

| benchmark | peak before | peak after | analysis before | analysis after |
|---|---:|---:|---:|---:|
| binary-trees | 1.10 MB | 0.49 MB | 0.79 MB (72%) | 0.18 MB (38%) |
| fasta | 1.09 MB | 0.52 MB | 0.79 MB (72%) | 0.14 MB (26%) |
| huffman | 1.10 MB | 0.50 MB | 0.78 MB (71%) | 0.18 MB (37%) |
| kNucleotide | 1.07 MB | 0.47 MB | 0.78 MB (73%) | 0.18 MB (39%) |
| rsa | 1.04 MB | 0.43 MB | 0.78 MB (75%) | 0.18 MB (42%) |
| gaussian | 1.03 MB | 0.44 MB | 0.75 MB (73%) | 0.18 MB (40%) |
| nbody | 1.01 MB | 0.45 MB | 0.73 MB (72%) | 0.17 MB (38%) |
| simdMatrixMultiply | 1.01 MB | 0.44 MB | 0.73 MB (72%) | 0.17 MB (39%) |

The top of the peak tree changes shape. Before, the largest single contributor is
red-black tree node allocation:

```
->45.5%  insert (stl_set.h:514) -> _M_insert_unique -> _M_get_node
    ->37.6% (495,680B) DependencyGenContext::update (Analysis.cpp:85)
```

After, that chain is gone and only the cell array itself is left:

```
->22.0%  _M_allocate (stl_vector.h:381)
    ->22.0% (108,288B) DependencyGenContext::DependencyGenContext (Analysis.cpp)
```

These modules are small (7-20 KB of wasm), so the absolute numbers are small. The
effect scales with the square of function size. Compiling every function of
`bzip2.wasm` peaks at 34.51 MB before and 7.42 MB after, split as:

| | before | after |
|---|---:|---:|
| cell array (`resize`) | 12.74 MB | 4.25 MB |
| elements (`insert`) | 19.37 MB | 0.78 MB |
| module total | 34.51 MB | 7.42 MB |

Across ten larger benchmarks, peak RSS over the interpreter drops from +29.35 MB
worst case to +5.58 MB. 483,954 node allocations become roughly 30,000 block
allocations, which also takes JIT compile time on that set from 5.14 s to 4.83 s.

## The one behavioural subtlety

The transitive-closure loop in `buildVariables()` can pull from the very cell it
inserts into, when a label refers to itself. A `std::set` never moves its nodes,
so iterating while inserting was safe; this container may move its storage. The
loop now indexes rather than holding an iterator. (Please check lines 709 to 717 at Analysis.cpp)

## malloc_trim

The analysis frees everything it allocates -- massif puts the heap at 0.41 MB in
its final snapshot -- but resident memory does not go back down, because the
allocations are many small chunks spread through the glibc main arena.
`MALLOC_MMAP_THRESHOLD_` and `MALLOC_TRIM_THRESHOLD_` do not help, since those
only govern large single allocations.

Splitting `/proc/<pid>/smaps` by mapping shows `malloc_trim(0)` touches only
`[heap]` and leaves the generated machine code alone. On a JIT-compiled sqlite the
heap mapping goes from 27.3 MB to 6.6 MB while the executable mapping stays at
3.4 MB.

`jitCompile()` runs once per module while the module is parsed, so this is one
call per module load. Over the 32 wasmBenchmarker programs it costs no measurable
time: 14.71 s and 14.71 s for the first two of four alternating passes, and within
0.012 s on the rest.

## Verification

- Builds clean on this base, no new warnings.
- `tools/run-tests.py` passes 130/130 across `basic-tests`, `jit`, `wasi`,
  `wasm-test-core`, `wasm-test-extended`, `wasm-test-web-assembly3`.
- All 32 `wasmBenchmarker` programs produce byte-identical output before and after.
  (`redBlack.wasm` fails with `undefined element` on both, unrelated to this change.)
- An assert-enabled debug build compiles every benchmark module without tripping
  an assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

